### PR TITLE
BUG: Fix `filter_coordinates` read wrong resolutions

### DIFF
--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -51,7 +51,7 @@ def read_points_patches(
 
     patches.n = 1870
     with pytest.raises(StopIteration):
-        # skipcq: PTC-W0063
+        # skipcq
         next(patches)
 
     with pytest.raises(IndexError):
@@ -63,7 +63,7 @@ def read_points_patches(
     return data
 
 
-def testpatch_extractor(source_image):
+def test_patch_extractor(source_image):
     """Test base class patch extractor."""
     input_img = misc.imread(pathlib.Path(source_image))
     patches = patchextraction.PatchExtractor(input_img=input_img, patch_size=(20, 20))
@@ -96,7 +96,7 @@ def test_get_patch_extractor(source_image, patch_extr_csv):
         patchextraction.get_patch_extractor("unknown")
 
 
-def test_pointspatch_extractor_image_format(
+def test_points_patch_extractor_image_format(
     sample_svs, sample_jp2, source_image, patch_extr_csv
 ):
     """Test PointsPatchExtractor returns the right object."""
@@ -140,7 +140,7 @@ def test_pointspatch_extractor_image_format(
         )
 
 
-def test_pointspatch_extractor(
+def test_points_patch_extractor(
     patch_extr_vf_image,
     patch_extr_npy_read,
     patch_extr_csv,
@@ -180,7 +180,7 @@ def test_pointspatch_extractor(
     assert np.all(data == saved_data)
 
 
-def test_pointspatch_extractor_svs(
+def test_points_patch_extractor_svs(
     sample_svs, patch_extr_svs_csv, patch_extr_svs_npy_read
 ):
     """Test PointsPatchExtractor for svs image."""
@@ -199,7 +199,9 @@ def test_pointspatch_extractor_svs(
     assert np.all(data == saved_data)
 
 
-def test_pointspatch_extractor_jp2(sample_jp2, patch_extr_jp2_csv, patch_extr_jp2_read):
+def test_points_patch_extractor_jp2(
+    sample_jp2, patch_extr_jp2_csv, patch_extr_jp2_read
+):
     """Test PointsPatchExtractor for jp2 image."""
     locations_list = pathlib.Path(patch_extr_jp2_csv)
     saved_data = np.load(str(pathlib.Path(patch_extr_jp2_read)))
@@ -446,7 +448,7 @@ def test_get_coordinates():
         )
 
 
-def test_mask_basedpatch_extractor_ndpi(sample_ndpi):
+def test_mask_based_patch_extractor_ndpi(sample_ndpi):
     """Test SlidingWindowPatchExtractor with mask for ndpi image."""
     res = 0
     patch_size = stride = (400, 400)

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -244,6 +244,7 @@ class PatchExtractor(ABC):
                 resolution=reader.info.mpp if resolution is None else resolution,
                 units="mpp" if units is None else units,
                 interpolation="nearest",
+                coord_space="resolution",
             )
             return np.sum(roi > 0) > 0
 


### PR DESCRIPTION
Current predictors or any functions rely on `get_coordinates` will have the patch coordinates extracted at requested resolution not at baseline of input wsi. However, `filter_coordinates` does not indicate that and thus the `mask_reader` (after being binded to read wrt to the source image metadata) will read at wrong resolution, thus filtering out wrong coordinates.