### PR TITLE
BUG: Fix patch predictor io config delegation

### DIFF
--- a/tests/models/test_patch_predictor.py
+++ b/tests/models/test_patch_predictor.py
@@ -521,7 +521,7 @@ def test_io_config_delegation(remote_sample, tmp_path):
         "resolution": 1.75,
         "units": "mpp",
     }
-    for key in kwargs.keys():
+    for key, _ in enumerate(kwargs.items()):
         _kwargs = copy.deepcopy(kwargs)
         _kwargs.pop(key)
         with pytest.raises(ValueError, match=r".*Must provide.*`ioconfig`.*"):
@@ -731,8 +731,6 @@ def test_wsi_predictor_api(sample_wsi_dict, tmp_path):
         merge_predictions=True,  # to test the api coverage
         units="mpp",
     )
-
-    import copy
 
     _kwargs = copy.deepcopy(kwargs)
     _kwargs["merge_predictions"] = False

--- a/tests/models/test_patch_predictor.py
+++ b/tests/models/test_patch_predictor.py
@@ -598,7 +598,11 @@ def test_io_config_delegation(remote_sample, tmp_path):
 
     predictor = CNNPatchPredictor(pretrained_model="resnet18-kather100k")
     predictor.predict(
-        [mini_wsi_svs], mode="wsi", merge_predictions=True, save_dir=f"{tmp_path}/dump"
+        [mini_wsi_svs],
+        mode="wsi",
+        merge_predictions=True,
+        save_dir=f"{tmp_path}/dump",
+        on_gpu=ON_GPU,
     )
     _rm_dir(f"{tmp_path}/dump")
 

--- a/tests/models/test_patch_predictor.py
+++ b/tests/models/test_patch_predictor.py
@@ -45,7 +45,7 @@ from tiatoolbox.models.engine.patch_predictor import (
 from tiatoolbox.utils.misc import download_data, imread, imwrite
 from tiatoolbox.wsicore.wsireader import get_wsireader
 
-ON_TRAVIS = False
+ON_TRAVIS = True
 ON_GPU = not ON_TRAVIS and torch.cuda.is_available()
 
 

--- a/tests/models/test_patch_predictor.py
+++ b/tests/models/test_patch_predictor.py
@@ -526,7 +526,11 @@ def test_io_config_delegation(remote_sample, tmp_path):
         _kwargs.pop(key)
         with pytest.raises(ValueError, match=r".*Must provide.*`ioconfig`.*"):
             predictor.predict(
-                [mini_wsi_svs], mode="wsi", save_dir=f"{tmp_path}/dump", **_kwargs
+                [mini_wsi_svs],
+                mode="wsi",
+                save_dir=f"{tmp_path}/dump",
+                on_gpu=ON_GPU,
+                **_kwargs,
             )
         _rm_dir(f"{tmp_path}/dump")
 
@@ -537,11 +541,17 @@ def test_io_config_delegation(remote_sample, tmp_path):
         input_resolutions=[{"resolution": 1.35, "units": "mpp"}],
     )
     predictor.predict(
-        [mini_wsi_svs], ioconfig=ioconfig, mode="wsi", save_dir=f"{tmp_path}/dump"
+        [mini_wsi_svs],
+        ioconfig=ioconfig,
+        mode="wsi",
+        save_dir=f"{tmp_path}/dump",
+        on_gpu=ON_GPU,
     )
     _rm_dir(f"{tmp_path}/dump")
 
-    predictor.predict([mini_wsi_svs], mode="wsi", save_dir=f"{tmp_path}/dump", **kwargs)
+    predictor.predict(
+        [mini_wsi_svs], mode="wsi", save_dir=f"{tmp_path}/dump", on_gpu=ON_GPU, **kwargs
+    )
     _rm_dir(f"{tmp_path}/dump")
 
     # test overwriting pretrained ioconfig
@@ -550,6 +560,7 @@ def test_io_config_delegation(remote_sample, tmp_path):
         [mini_wsi_svs],
         patch_input_shape=[300, 300],
         mode="wsi",
+        on_gpu=ON_GPU,
         save_dir=f"{tmp_path}/dump",
     )
     assert predictor._ioconfig.patch_input_shape == [300, 300]
@@ -559,6 +570,7 @@ def test_io_config_delegation(remote_sample, tmp_path):
         [mini_wsi_svs],
         stride_shape=[300, 300],
         mode="wsi",
+        on_gpu=ON_GPU,
         save_dir=f"{tmp_path}/dump",
     )
     assert predictor._ioconfig.stride_shape == [300, 300]
@@ -568,6 +580,7 @@ def test_io_config_delegation(remote_sample, tmp_path):
         [mini_wsi_svs],
         resolution=1.99,
         mode="wsi",
+        on_gpu=ON_GPU,
         save_dir=f"{tmp_path}/dump",
     )
     assert predictor._ioconfig.input_resolutions[0]["resolution"] == 1.99
@@ -577,6 +590,7 @@ def test_io_config_delegation(remote_sample, tmp_path):
         [mini_wsi_svs],
         units="baseline",
         mode="wsi",
+        on_gpu=ON_GPU,
         save_dir=f"{tmp_path}/dump",
     )
     assert predictor._ioconfig.input_resolutions[0]["units"] == "baseline"

--- a/tests/models/test_patch_predictor.py
+++ b/tests/models/test_patch_predictor.py
@@ -596,6 +596,12 @@ def test_io_config_delegation(remote_sample, tmp_path):
     assert predictor._ioconfig.input_resolutions[0]["units"] == "baseline"
     _rm_dir(f"{tmp_path}/dump")
 
+    predictor = CNNPatchPredictor(pretrained_model="resnet18-kather100k")
+    predictor.predict(
+        [mini_wsi_svs], mode="wsi", merge_predictions=True, save_dir=f"{tmp_path}/dump"
+    )
+    _rm_dir(f"{tmp_path}/dump")
+
 
 def test_patch_predictor_api(sample_patch1, sample_patch2, tmp_path):
     """Helper function to get the model output using API 1."""

--- a/tests/models/test_patch_predictor.py
+++ b/tests/models/test_patch_predictor.py
@@ -521,7 +521,7 @@ def test_io_config_delegation(remote_sample, tmp_path):
         "resolution": 1.75,
         "units": "mpp",
     }
-    for key, _ in enumerate(kwargs.items()):
+    for key, _ in kwargs.items():
         _kwargs = copy.deepcopy(kwargs)
         _kwargs.pop(key)
         with pytest.raises(ValueError, match=r".*Must provide.*`ioconfig`.*"):

--- a/tests/models/test_patch_predictor.py
+++ b/tests/models/test_patch_predictor.py
@@ -19,6 +19,7 @@
 # ***** END GPL LICENSE BLOCK *****
 """Tests for Patch Predictor."""
 
+import copy
 import os
 import pathlib
 import shutil
@@ -31,20 +32,21 @@ from click.testing import CliRunner
 
 from tiatoolbox import cli, rcParam
 from tiatoolbox.models.architecture.vanilla import CNNModel
-from tiatoolbox.models.engine.patch_predictor import (
-    CNNPatchPredictor,
-    IOPatchPredictorConfig,
-)
 from tiatoolbox.models.dataset import (
     PatchDataset,
     PatchDatasetABC,
     WSIPatchDataset,
     predefined_preproc_func,
 )
+from tiatoolbox.models.engine.patch_predictor import (
+    CNNPatchPredictor,
+    IOPatchPredictorConfig,
+)
 from tiatoolbox.utils.misc import download_data, imread, imwrite
 from tiatoolbox.wsicore.wsireader import get_wsireader
 
-ON_GPU = False
+ON_TRAVIS = False
+ON_GPU = not ON_TRAVIS and torch.cuda.is_available()
 
 
 def _rm_dir(path):
@@ -275,8 +277,8 @@ def test_wsi_patch_dataset(sample_wsi_dict):
         WSIPatchDataset(
             img_path="aaaa",
             mode="wsi",
-            patch_size=[512, 512],
-            stride_size=[256, 256],
+            patch_input_shape=[512, 512],
+            stride_shape=[256, 256],
             auto_get_mask=False,
         )
 
@@ -286,8 +288,8 @@ def test_wsi_patch_dataset(sample_wsi_dict):
             img_path=mini_wsi_svs,
             mask_path="aaaa",
             mode="wsi",
-            patch_size=[512, 512],
-            stride_size=[256, 256],
+            patch_input_shape=[512, 512],
+            stride_shape=[256, 256],
             resolution=1.0,
             units="mpp",
             auto_get_mask=False,
@@ -301,21 +303,21 @@ def test_wsi_patch_dataset(sample_wsi_dict):
     with pytest.raises(ValueError):
         reuse_init()
     with pytest.raises(ValueError):
-        reuse_init_wsi(patch_size=[512, 512, 512])
+        reuse_init_wsi(patch_input_shape=[512, 512, 512])
     with pytest.raises(ValueError):
-        reuse_init_wsi(patch_size=[512, "a"])
+        reuse_init_wsi(patch_input_shape=[512, "a"])
     with pytest.raises(ValueError):
-        reuse_init_wsi(patch_size=512)
+        reuse_init_wsi(patch_input_shape=512)
     # invalid stride
     with pytest.raises(ValueError):
-        reuse_init_wsi(patch_size=[512, 512], stride_size=[512, "a"])
+        reuse_init_wsi(patch_input_shape=[512, 512], stride_shape=[512, "a"])
     with pytest.raises(ValueError):
-        reuse_init_wsi(patch_size=[512, 512], stride_size=[512, 512, 512])
+        reuse_init_wsi(patch_input_shape=[512, 512], stride_shape=[512, 512, 512])
     # negative
     with pytest.raises(ValueError):
-        reuse_init_wsi(patch_size=[512, -512], stride_size=[512, 512])
+        reuse_init_wsi(patch_input_shape=[512, -512], stride_shape=[512, 512])
     with pytest.raises(ValueError):
-        reuse_init_wsi(patch_size=[512, 512], stride_size=[512, -512])
+        reuse_init_wsi(patch_input_shape=[512, 512], stride_shape=[512, -512])
 
     # * for wsi
     # dummy test for analysing the output
@@ -323,8 +325,8 @@ def test_wsi_patch_dataset(sample_wsi_dict):
     patch_size = [512, 512]
     stride_size = [256, 256]
     ds = reuse_init_wsi(
-        patch_size=patch_size,
-        stride_size=stride_size,
+        patch_input_shape=patch_size,
+        stride_shape=stride_size,
         resolution=1.0,
         units="mpp",
         auto_get_mask=False,
@@ -348,8 +350,8 @@ def test_wsi_patch_dataset(sample_wsi_dict):
 
     # test creation with auto mask gen and input mask
     ds = reuse_init_wsi(
-        patch_size=patch_size,
-        stride_size=stride_size,
+        patch_input_shape=patch_size,
+        stride_shape=stride_size,
         resolution=1.0,
         units="mpp",
         auto_get_mask=True,
@@ -359,8 +361,8 @@ def test_wsi_patch_dataset(sample_wsi_dict):
         img_path=mini_wsi_svs,
         mask_path=mini_wsi_msk,
         mode="wsi",
-        patch_size=[512, 512],
-        stride_size=[256, 256],
+        patch_input_shape=[512, 512],
+        stride_shape=[256, 256],
         auto_get_mask=False,
         resolution=1.0,
         units="mpp",
@@ -373,8 +375,8 @@ def test_wsi_patch_dataset(sample_wsi_dict):
             img_path=mini_wsi_svs,
             mask_path="negative_mask.png",
             mode="wsi",
-            patch_size=[512, 512],
-            stride_size=[256, 256],
+            patch_input_shape=[512, 512],
+            stride_shape=[256, 256],
             auto_get_mask=False,
             resolution=1.0,
             units="mpp",
@@ -386,8 +388,8 @@ def test_wsi_patch_dataset(sample_wsi_dict):
     tile_ds = WSIPatchDataset(
         img_path=mini_wsi_jpg,
         mode="tile",
-        patch_size=patch_size,
-        stride_size=stride_size,
+        patch_input_shape=patch_size,
+        stride_shape=stride_size,
         auto_get_mask=False,
     )
     step_idx = 3  # manually calibrate
@@ -455,10 +457,9 @@ def test_io_patch_predictor_config():
     """Test for IOConfig."""
     # test for creating
     cfg = IOPatchPredictorConfig(
-        patch_size=[224, 224],
-        stride_size=[224, 224],
+        patch_input_shape=[224, 224],
+        stride_shape=[224, 224],
         input_resolutions=[{"resolution": 0.5, "units": "mpp"}],
-        output_resolutions=[{"resolution": 0.5, "units": "mpp"}],
         # test adding random kwarg and they should be accessible as kwargs
         crop_from_source=True,
     )
@@ -502,6 +503,84 @@ def test_predictor_crash():
         predictor.predict([1, 2, 3], labels=[1, 2], mode="patch")
     # remove previously generated data
     _rm_dir("output")
+
+
+def test_io_config_delegation(remote_sample, tmp_path):
+    """Tests for delegating args to io config."""
+    mini_wsi_svs = pathlib.Path(remote_sample("wsi2_4k_4k_svs"))
+
+    # test not providing config / full input info for not pretrained models
+    model = CNNModel("resnet50")
+    predictor = CNNPatchPredictor(model=model)
+    with pytest.raises(ValueError, match=r".*Must provide.*`ioconfig`.*"):
+        predictor.predict([mini_wsi_svs], mode="wsi", save_dir=f"{tmp_path}/dump")
+    _rm_dir(f"{tmp_path}/dump")
+
+    kwargs = {
+        "patch_input_shape": [512, 512],
+        "resolution": 1.75,
+        "units": "mpp",
+    }
+    for key in kwargs.keys():
+        _kwargs = copy.deepcopy(kwargs)
+        _kwargs.pop(key)
+        with pytest.raises(ValueError, match=r".*Must provide.*`ioconfig`.*"):
+            predictor.predict(
+                [mini_wsi_svs], mode="wsi", save_dir=f"{tmp_path}/dump", **_kwargs
+            )
+        _rm_dir(f"{tmp_path}/dump")
+
+    # test providing config / full input info for not pretrained models
+    ioconfig = IOPatchPredictorConfig(
+        patch_input_shape=[512, 512],
+        stride_shape=[256, 256],
+        input_resolutions=[{"resolution": 1.35, "units": "mpp"}],
+    )
+    predictor.predict(
+        [mini_wsi_svs], ioconfig=ioconfig, mode="wsi", save_dir=f"{tmp_path}/dump"
+    )
+    _rm_dir(f"{tmp_path}/dump")
+
+    predictor.predict([mini_wsi_svs], mode="wsi", save_dir=f"{tmp_path}/dump", **kwargs)
+    _rm_dir(f"{tmp_path}/dump")
+
+    # test overwriting pretrained ioconfig
+    predictor = CNNPatchPredictor(pretrained_model="resnet18-kather100k", batch_size=1)
+    predictor.predict(
+        [mini_wsi_svs],
+        patch_input_shape=[300, 300],
+        mode="wsi",
+        save_dir=f"{tmp_path}/dump",
+    )
+    assert predictor._ioconfig.patch_input_shape == [300, 300]
+    _rm_dir(f"{tmp_path}/dump")
+
+    predictor.predict(
+        [mini_wsi_svs],
+        stride_shape=[300, 300],
+        mode="wsi",
+        save_dir=f"{tmp_path}/dump",
+    )
+    assert predictor._ioconfig.stride_shape == [300, 300]
+    _rm_dir(f"{tmp_path}/dump")
+
+    predictor.predict(
+        [mini_wsi_svs],
+        resolution=1.99,
+        mode="wsi",
+        save_dir=f"{tmp_path}/dump",
+    )
+    assert predictor._ioconfig.input_resolutions[0]["resolution"] == 1.99
+    _rm_dir(f"{tmp_path}/dump")
+
+    predictor.predict(
+        [mini_wsi_svs],
+        units="baseline",
+        mode="wsi",
+        save_dir=f"{tmp_path}/dump",
+    )
+    assert predictor._ioconfig.input_resolutions[0]["units"] == "baseline"
+    _rm_dir(f"{tmp_path}/dump")
 
 
 def test_patch_predictor_api(sample_patch1, sample_patch2, tmp_path):
@@ -610,8 +689,8 @@ def test_wsi_predictor_api(sample_wsi_dict, tmp_path):
         return_probabilities=True,
         return_labels=True,
         on_gpu=ON_GPU,
-        patch_size=patch_size,
-        stride_size=patch_size,
+        patch_input_shape=patch_size,
+        stride_shape=patch_size,
         resolution=1.0,
         units="baseline",
     )
@@ -645,8 +724,8 @@ def test_wsi_predictor_api(sample_wsi_dict, tmp_path):
         return_probabilities=True,
         return_labels=True,
         on_gpu=ON_GPU,
-        patch_size=patch_size,
-        stride_size=patch_size,
+        patch_input_shape=patch_size,
+        stride_shape=patch_size,
         resolution=0.5,
         save_dir=save_dir,
         merge_predictions=True,  # to test the api coverage
@@ -739,8 +818,8 @@ def test_wsi_predictor_merge_predictions(sample_wsi_dict):
         return_probabilities=True,
         return_labels=True,
         on_gpu=ON_GPU,
-        patch_size=np.array([224, 224]),
-        stride_size=np.array([224, 224]),
+        patch_input_shape=np.array([224, 224]),
+        stride_shape=np.array([224, 224]),
         resolution=1.0,
         units="baseline",
         merge_predictions=True,
@@ -852,6 +931,9 @@ def test_patch_predictor_output(sample_patch1, sample_patch2):
             predictions_check=[6, 3],
             on_gpu=ON_GPU,
         )
+        # only test 1 on travis to limit runtime
+        if ON_TRAVIS:
+            break
 
 
 # -------------------------------------------------------------------------------------

--- a/tests/models/test_patch_predictor.py
+++ b/tests/models/test_patch_predictor.py
@@ -823,6 +823,20 @@ def test_wsi_predictor_merge_predictions(sample_wsi_dict):
     _merged = np.array([[2, 2, 0, 0], [2, 2, 0, 0], [0, 0, 1, 1], [0, 0, 1, 1]])
     assert np.sum(merged - _merged) == 0
 
+    # blind test for merging probabilities
+    merged = CNNPatchPredictor.merge_predictions(
+        np.zeros([4, 4]),
+        output,
+        resolution=1.0,
+        units="baseline",
+        return_raw=True,
+    )
+    _merged = np.array(
+        [[0.45, 0.45, 0, 0], [0.45, 0.45, 0, 0], [0, 0, 0.90, 0.90], [0, 0, 0.90, 0.90]]
+    )
+    assert merged.shape == (4, 4, 2)
+    assert np.mean(np.abs(merged[..., 0] - _merged)) < 1.0e-6
+
     # integration test
     predictor = CNNPatchPredictor(pretrained_model="resnet18-kather100k", batch_size=1)
 

--- a/tiatoolbox/data/pretrained_model.yaml
+++ b/tiatoolbox/data/pretrained_model.yaml
@@ -8,11 +8,9 @@ alexnet-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 resnet18-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/resnet18-kather100k.pth
@@ -24,11 +22,9 @@ resnet18-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 resnet34-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/resnet34-kather100k.pth
@@ -40,11 +36,9 @@ resnet34-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 resnet50-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/resnet50-kather100k.pth
@@ -56,11 +50,9 @@ resnet50-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 resnet101-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/resnet101-kather100k.pth
@@ -72,11 +64,9 @@ resnet101-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 resnext50_32x4d-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/resnext50_32x4d-kather100k.pth
@@ -88,11 +78,9 @@ resnext50_32x4d-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 resnext101_32x8d-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/resnext101_32x8d-kather100k.pth
@@ -104,11 +92,9 @@ resnext101_32x8d-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 wide_resnet50_2-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/wide_resnet50_2-kather100k.pth
@@ -120,11 +106,9 @@ wide_resnet50_2-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 wide_resnet101_2-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/wide_resnet101_2-kather100k.pth
@@ -136,11 +120,9 @@ wide_resnet101_2-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 densenet121-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/densenet121-kather100k.pth
@@ -152,11 +134,9 @@ densenet121-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 densenet161-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/densenet161-kather100k.pth
@@ -168,11 +148,9 @@ densenet161-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 densenet169-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/densenet169-kather100k.pth
@@ -184,11 +162,9 @@ densenet169-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 densenet201-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/densenet201-kather100k.pth
@@ -200,11 +176,9 @@ densenet201-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 mobilenet_v2-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/mobilenet_v2-kather100k.pth
@@ -216,11 +190,9 @@ mobilenet_v2-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 mobilenet_v3_large-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/mobilenet_v3_large-kather100k.pth
@@ -232,11 +204,9 @@ mobilenet_v3_large-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 mobilenet_v3_small-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/mobilenet_v3_small-kather100k.pth
@@ -248,11 +218,9 @@ mobilenet_v3_small-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 googlenet-kather100k:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/pc/googlenet-kather100k.pth
@@ -264,11 +232,9 @@ googlenet-kather100k:
     ioconfig:
         class: patch_predictor.IOPatchPredictorConfig
         kwargs:
-            patch_size: [224, 224]
-            stride_size: [224, 224]
+            patch_input_shape: [224, 224]
+            stride_shape: [224, 224]
             input_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-            output_resolutions: [{"resolution": 0.5, "units": "mpp"}]
-    # dataset: KatherPatchDataset
     dataset: kather100k
 
 fcn-tissue_mask:

--- a/tiatoolbox/models/dataset/classification.py
+++ b/tiatoolbox/models/dataset/classification.py
@@ -144,11 +144,8 @@ class WSIPatchDataset(abc.PatchDatasetABC):
           for reading pyramidal image or large tile in pyramidal way.
         inputs: List of coordinates to read from the `reader`,
           each coordinate is of the form [start_x, start_y, end_x, end_y].
-        patch_size: a tuple(int, int) or ndarray of shape (2,).
+        patch_input_shape: a tuple(int, int) or ndarray of shape (2,).
           Expected size to read from `reader` at requested `resolution`
-          and `units`. Expected to be (height, width).
-        lv0_patch_size: a tuple (int, int) or ndarray of shape (2,).
-          `patch_size` at level 0 in `reader` at requested `resolution`
           and `units`. Expected to be (height, width).
         resolution: check (:class:`.WSIReader`) for details.
         units: check (:class:`.WSIReader`) for details.
@@ -166,8 +163,8 @@ class WSIPatchDataset(abc.PatchDatasetABC):
         img_path,
         mode="wsi",
         mask_path=None,
-        patch_size=None,
-        stride_size=None,
+        patch_input_shape=None,
+        stride_shape=None,
         resolution=None,
         units=None,
         auto_get_mask=True,
@@ -179,11 +176,11 @@ class WSIPatchDataset(abc.PatchDatasetABC):
             img_path (:obj:`str` or :obj:`pathlib.Path`): valid to pyramidal
               whole-slide image or large tile to read.
             mask_path (:obj:`str` or :obj:`pathlib.Path`): valid mask image.
-            patch_size: a tuple (int, int) or ndarray of shape (2,).
+            patch_input_shape: a tuple (int, int) or ndarray of shape (2,).
               Expected shape to read from `reader` at requested `resolution` and
               `units`. Expected to be positive and of (height, width). Note, this
               is not at `resolution` coordinate space.
-            stride_size: a tuple (int, int) or ndarray of shape (2,).
+            stride_shape: a tuple (int, int) or ndarray of shape (2,).
               Expected stride shape to read at requested `resolution` and `units`.
               Expected to be positive and of (height, width). Note, this is not at
               level 0.
@@ -201,8 +198,8 @@ class WSIPatchDataset(abc.PatchDatasetABC):
             >>> ds = WSIPatchDataset(
             ...     img_path='/A/B/C/wsi.svs',
             ...     mode="wsi",
-            ...     patch_size=[512, 512],
-            ...     stride_size=[256, 256],
+            ...     patch_input_shape=[512, 512],
+            ...     stride_shape=[256, 256],
             ...     auto_get_mask=False,
             ...     preproc_func=preproc_func
             ... )
@@ -215,21 +212,21 @@ class WSIPatchDataset(abc.PatchDatasetABC):
             raise ValueError("`img_path` must be a valid file path.")
         if mode not in ["wsi", "tile"]:
             raise ValueError(f"`{mode}` is not supported.")
-        patch_size = np.array(patch_size)
-        stride_size = np.array(stride_size)
+        patch_input_shape = np.array(patch_input_shape)
+        stride_shape = np.array(stride_shape)
 
         if (
-            not np.issubdtype(patch_size.dtype, np.integer)
-            or np.size(patch_size) > 2
-            or np.any(patch_size < 0)
+            not np.issubdtype(patch_input_shape.dtype, np.integer)
+            or np.size(patch_input_shape) > 2
+            or np.any(patch_input_shape < 0)
         ):
-            raise ValueError(f"Invalid `patch_size` value {patch_size}.")
+            raise ValueError(f"Invalid `patch_input_shape` value {patch_input_shape}.")
         if (
-            not np.issubdtype(stride_size.dtype, np.integer)
-            or np.size(stride_size) > 2
-            or np.any(stride_size < 0)
+            not np.issubdtype(stride_shape.dtype, np.integer)
+            or np.size(stride_shape) > 2
+            or np.any(stride_shape < 0)
         ):
-            raise ValueError(f"Invalid `stride_size` value {stride_size}.")
+            raise ValueError(f"Invalid `stride_shape` value {stride_shape}.")
 
         img_path = pathlib.Path(img_path)
         if mode == "wsi":
@@ -272,8 +269,8 @@ class WSIPatchDataset(abc.PatchDatasetABC):
         # use all patches, as long as it overlaps source image
         self.inputs = PatchExtractor.get_coordinates(
             image_shape=wsi_shape,
-            patch_input_shape=patch_size[::-1],
-            stride_shape=stride_size[::-1],
+            patch_input_shape=patch_input_shape[::-1],
+            stride_shape=stride_shape[::-1],
             input_within_bound=False,
         )
 
@@ -306,7 +303,7 @@ class WSIPatchDataset(abc.PatchDatasetABC):
         if len(self.inputs) == 0:
             raise ValueError("No coordinate remain after tiling!")
 
-        self.patch_size = patch_size
+        self.patch_input_shape = patch_input_shape
         self.resolution = resolution
         self.units = units
 

--- a/tiatoolbox/models/engine/patch_predictor.py
+++ b/tiatoolbox/models/engine/patch_predictor.py
@@ -468,7 +468,7 @@ class CNNPatchPredictor:
                     "Must provide either `ioconfig` or "
                     "`patch_input_shape`, `resolution`, and `units`."
                 )
-            elif ioconfig is None and self.ioconfig:
+            if ioconfig is None and self.ioconfig:
                 ioconfig = copy.deepcopy(self.ioconfig)
                 # ! not sure if there is a nicer way to set this
                 if patch_input_shape is not None:
@@ -479,7 +479,7 @@ class CNNPatchPredictor:
                     ioconfig.input_resolutions[0]["resolution"] = resolution
                 if units is not None:
                     ioconfig.input_resolutions[0]["units"] = units
-            elif ioconfig is None and all([not v for v in make_config_flag]):
+            elif ioconfig is None and all(not v for v in make_config_flag):
                 ioconfig = IOPatchPredictorConfig(
                     input_resolutions=[{"resolution": resolution, "units": units}],
                     patch_input_shape=patch_input_shape,

--- a/tiatoolbox/models/engine/patch_predictor.py
+++ b/tiatoolbox/models/engine/patch_predictor.py
@@ -14,7 +14,7 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
-# The Original Code is Copyright (C) 2021, TIALab, University of Warwick
+# The Original Code is Copyright (C) 2021, TIA Centre, University of Warwick
 # All rights reserved.
 # ***** END GPL LICENSE BLOCK *****
 

--- a/tiatoolbox/models/engine/patch_predictor.py
+++ b/tiatoolbox/models/engine/patch_predictor.py
@@ -25,7 +25,7 @@ import os
 import pathlib
 import warnings
 from collections import OrderedDict
-from typing import Callable, Tuple
+from typing import Callable, Tuple, Union
 
 import numpy as np
 import torch
@@ -161,12 +161,12 @@ class CNNPatchPredictor:
 
     @staticmethod
     def merge_predictions(
-        img,
-        output,
-        resolution=None,
-        units=None,
+        img: Union[str, pathlib.Path, np.ndarray],
+        output: dict,
+        resolution: float = None,
+        units: str = None,
         postproc_func: Callable = None,
-        return_probmap=False,
+        return_raw: bool = False,
     ):
         """Merge patch-level predictions to form a 2-dimensional prediction map.
 
@@ -183,8 +183,9 @@ class CNNPatchPredictor:
             units (str): Units of resolution used when merging predictions. This
               must be the same `units` used when processing the data.
             postproc_func (callable): A function to post-process raw prediction
-              from model.
-
+              from model. By default, internal code uses the `np.argmax` function.
+            return_raw (bool): Return raw result without applying the `postproc_func`
+              on the assembled image.
         Returns:
             prediction_map (ndarray): Merged predictions as a 2D array.
 
@@ -257,7 +258,7 @@ class CNNPatchPredictor:
         # deal with overlapping regions
         if denominator is not None:
             output = output / (np.expand_dims(denominator, -1) + 1.0e-8)
-            if not return_probmap:
+            if not return_raw:
                 # convert raw probabilities to predictions
                 if postproc_func is not None:
                     output = postproc_func(output)

--- a/tiatoolbox/models/engine/patch_predictor.py
+++ b/tiatoolbox/models/engine/patch_predictor.py
@@ -575,8 +575,8 @@ class CNNPatchPredictor:
                     merged_prediction = self.merge_predictions(
                         img_path,
                         output_model,
-                        resolution=resolution,
-                        units=units,
+                        resolution=output_model["resolution"],
+                        units=output_model["units"],
                         postproc_func=self.model.postproc,
                     )
                     outputs.append(merged_prediction)


### PR DESCRIPTION
The current way patch predictor parses input arguments for reading is locked behind some very specific cases, and some time counter intuitive to figure out. Here, I ported over the definition and handling from semantic, which is more flexible, and simplified it for this specific niche case. The way input output configuration will be parsed going forward is as follow:
- `ioconfig` will supersed everything
- if `ioconfig` is not provided
  - If `model` is pretrained (defined in `pretrained_model.yaml` )
    - Use the yaml ioconfig
    - Any other input patch reading arguments will overwrite the yaml ioconfig (at the same keyword).
  - If `model` is not defined, all input patch reading arguments must be provided else exception will be thrown.
