### PR TITLE
[skip travis] DEV: Increase Cognitive Complexity Limit In setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ max-line-length = 88
 extend-ignore = E203 # For black compatibility
 spellcheck-targets = comments
 dictionaries = en_US,python,technical
-max-cognitive-complexity = 11
+max-cognitive-complexity = 14
 max-expression-complexity = 7
 
 [aliases]


### PR DESCRIPTION
A suggestion to in crease the cognitive complexity limit. The current threshold can be triggered by simple things such as a few ifs in a row, especially as python doesn't use switch statements. We also have two other complexity checks in place.