### PR TITLE
BUG: Remove ujson From Annotation Store

### DIFF
--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -40,6 +40,7 @@ Properties
 """
 import contextlib
 import copy
+import json
 import pickle
 import sqlite3
 import sys
@@ -72,11 +73,6 @@ from shapely import speedups, wkb, wkt
 from shapely.geometry import LineString, Point, Polygon
 from shapely.geometry import mapping as geometry2feature
 from shapely.geometry import shape as feature2geometry
-
-try:
-    import ujson as json  # pyright: reportMissingModuleSource=false
-except ImportError:
-    import json
 
 from tiatoolbox.annotation.dsl import (
     PY_GLOBALS,


### PR DESCRIPTION
Some slight differences in `ujson.dumps` and `json.dumps` arguments means that ujson cannot be used as a drop-in replacement for json.

This was causing an issue as this module was using ujson with options which are in standard library json dumps (separators kwarg) but not ujson. In future ujson, orjson or some other optimised json library could be used in place of built-in json for performance improvements but would mean adding another dependency.