### PR TITLE
ENH: Rename 'boundary' Column To 'geometry' & Rename Variables

### DIFF
--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -1082,7 +1082,7 @@ class SQLiteStore(AnnotationStore):
                 objtype TEXT,            -- Object type
                 cx INTEGER NOT NULL,     -- X of centroid/representative point
                 cy INTEGER NOT NULL,     -- Y of centroid/representative point
-                boundary BLOB,           -- Detailed boundary
+                geometry BLOB,           -- Detailed geometry
                 properties TEXT          -- JSON properties
             )
             """
@@ -1201,12 +1201,12 @@ class SQLiteStore(AnnotationStore):
         key = key or str(uuid.uuid4())
         geometry = annotation.geometry
         if geometry.geom_type == "Point":
-            boundary = None
+            serialised_geometry = None
         else:
-            boundary = self.serialise_geometry(geometry)
+            serialised_geometry = self.serialise_geometry(geometry)
         return {
             "key": key,
-            "boundary": boundary,
+            "geometry": serialised_geometry,
             "cx": int(geometry.centroid.x),
             "cy": int(geometry.centroid.y),
             "min_x": geometry.bounds[0],
@@ -1254,7 +1254,7 @@ class SQLiteStore(AnnotationStore):
             """
                 INSERT INTO annotations VALUES(
                     NULL, :key, :geom_type,
-                    :cx, :cy, :boundary, :properties
+                    :cx, :cy, :geometry, :properties
                 )
                 """,
             token,
@@ -1324,7 +1324,7 @@ class SQLiteStore(AnnotationStore):
           AND min_x <= :max_x
           AND max_y >= :min_y
           AND min_y <= :max_y
-          AND geometry_predicate(:geometry_predicate, :query_geometry, boundary, cx, cy)
+          AND geometry_predicate(:geometry_predicate, :query_geometry, geometry, cx, cy)
         """
         )
         query_parameters = {
@@ -1356,7 +1356,7 @@ class SQLiteStore(AnnotationStore):
             geometry=query_geometry,
             geometry_predicate=geometry_predicate,
             where=where,
-            select_callable="[key], boundary, properties",
+            select_callable="[key], geometry, properties",
         )
         if isinstance(where, Callable):
             return [
@@ -1374,7 +1374,7 @@ class SQLiteStore(AnnotationStore):
     ) -> List[Annotation]:
         query_geometry = geometry
         cur = self._query(
-            "boundary, properties, cx, cy",
+            "geometry, properties, cx, cy",
             geometry=query_geometry,
             geometry_predicate=geometry_predicate,
             where=where,
@@ -1408,7 +1408,7 @@ class SQLiteStore(AnnotationStore):
         cur = self.con.cursor()
         cur.execute(
             """
-            SELECT boundary, properties, cx, cy
+            SELECT geometry, properties, cx, cy
               FROM annotations
              WHERE [key] = :key
             """,
@@ -1417,9 +1417,9 @@ class SQLiteStore(AnnotationStore):
         row = cur.fetchone()
         if row is None:
             raise KeyError(key)
-        boundary, properties, cx, cy = row
-        properties = json.loads(properties or "{}")
-        geometry = self._unpack_geometry(boundary, cx, cy)
+        serialised_geometry, serialised_properties, cx, cy = row
+        properties = json.loads(serialised_properties or "{}")
+        geometry = self._unpack_geometry(serialised_geometry, cx, cy)
         return Annotation(geometry, properties)
 
     def keys(self) -> Iterable[int]:
@@ -1448,7 +1448,7 @@ class SQLiteStore(AnnotationStore):
         cur = self.con.cursor()
         cur.execute(
             """
-            SELECT [key], cx, cy, boundary, properties
+            SELECT [key], cx, cy, geometry, properties
               FROM annotations
             """
         )
@@ -1456,12 +1456,12 @@ class SQLiteStore(AnnotationStore):
             row = cur.fetchone()
             if row is None:
                 break
-            key, cx, cy, boundary, properties = row
-            if boundary is not None:
-                geometry = self._unpack_geometry(boundary, cx, cy)
+            key, cx, cy, serialised_geometry, serialised_properties = row
+            if serialised_geometry is not None:
+                geometry = self._unpack_geometry(serialised_geometry, cx, cy)
             else:
                 geometry = Point(cx, cy)
-            properties = json.loads(properties)
+            properties = json.loads(serialised_properties)
             yield key, Annotation(geometry, properties)
 
     def patch_many(
@@ -1527,7 +1527,7 @@ class SQLiteStore(AnnotationStore):
             **bounds,
             **xy,
             key=key,
-            boundary=self.serialise_geometry(geometry),
+            geometry=self.serialise_geometry(geometry),
         )
         cur.execute(
             """
@@ -1545,7 +1545,7 @@ class SQLiteStore(AnnotationStore):
         cur.execute(
             """
             UPDATE annotations
-               SET cx = :x, cy = :y, boundary = :boundary
+               SET cx = :x, cy = :y, geometry = :geometry
              WHERE [key] = :key
             """,
             query_parameters,


### PR DESCRIPTION
I would like to rename the 'boundary' column in the table used by SQLiteStore to 'geometry' and best to do this before it goes into a version published on pypi to avoid incompatibility between versions.