### PR TITLE
DOC: Separate out readthedocs requirements 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -30,3 +30,7 @@ python:
   version: "3.8"
   install:
       - requirements: requirements_dev.txt
+        extra_requirements:
+            - nbsphinx
+            - sphinx_gallery
+            - sphinx_toolbox

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -30,8 +30,4 @@ python:
   version: "3.8"
   install:
       - requirements: requirements.txt
-      - method: pip
-  extra_requirements:
-      - nbsphinx
-      - sphinx_gallery
-      - sphinx_toolbox
+      - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -29,8 +29,9 @@ build:
 python:
   version: "3.8"
   install:
-      - requirements: requirements_dev.txt
-        extra_requirements:
-            - nbsphinx
-            - sphinx_gallery
-            - sphinx_toolbox
+      - requirements: requirements.txt
+      - method: pip
+  extra_requirements:
+      - nbsphinx
+      - sphinx_gallery
+      - sphinx_toolbox

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+nbsphinx
+sphinx_gallery
+sphinx_toolbox

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,6 @@ glymur
 imagecodecs
 jupyterlab
 matplotlib
-nbsphinx
 numpy
 opencv-python==4.5.4.60
 openslide-python==1.1.2
@@ -28,8 +27,6 @@ scikit-image==0.18.3
 scikit-learn>=0.23.2
 shapely
 sphinx==4.1.2
-sphinx_gallery
-sphinx_toolbox
 tifffile
 torch==1.9.1
 torchvision==0.10.1


### PR DESCRIPTION
- Separate out readthedocs requirements to avoid python 3.7 requirements errors.