### PR TITLE
NEW: Add HoVer-Net CoNSeP and MoNuSAC models

### DIFF
--- a/tests/models/test_hovernet.py
+++ b/tests/models/test_hovernet.py
@@ -55,7 +55,35 @@ def test_functionality(remote_sample, tmp_path):
     output = model.postproc(output)
     assert len(output[1]) > 0, "Must have some nuclei."
 
-    # * test original mode (architecture used in HoVerNet paper)
+    # * test fast mode (architecture used for MoNuSAC data)
+    patch = reader.read_bounds(
+        [0, 0, 256, 256], resolution=0.25, units="mpp", coord_space="resolution"
+    )
+    batch = torch.from_numpy(patch)[None]
+    model = HoVerNet(num_types=5, mode="fast")
+    fetch_pretrained_weights("hovernet_fast-monusac", f"{tmp_path}/weigths.pth")
+    pretrained = torch.load(f"{tmp_path}/weigths.pth")
+    model.load_state_dict(pretrained)
+    output = model.infer_batch(model, batch, on_gpu=False)
+    output = [v[0] for v in output]
+    output = model.postproc(output)
+    assert len(output[1]) > 0, "Must have some nuclei."
+
+    # * test original mode on CoNSeP dataset (architecture used in HoVerNet paper)
+    patch = reader.read_bounds(
+        [0, 0, 270, 270], resolution=0.25, units="mpp", coord_space="resolution"
+    )
+    batch = torch.from_numpy(patch)[None]
+    model = HoVerNet(num_types=5, mode="original")
+    fetch_pretrained_weights("hovernet_original-consep", f"{tmp_path}/weigths.pth")
+    pretrained = torch.load(f"{tmp_path}/weigths.pth")
+    model.load_state_dict(pretrained)
+    output = model.infer_batch(model, batch, on_gpu=False)
+    output = [v[0] for v in output]
+    output = model.postproc(output)
+    assert len(output[1]) > 0, "Must have some nuclei."
+
+    # * test original mode on Kumar dataset (architecture used in HoVerNet paper)
     patch = reader.read_bounds(
         [0, 0, 270, 270], resolution=0.25, units="mpp", coord_space="resolution"
     )

--- a/tiatoolbox/data/pretrained_model.yaml
+++ b/tiatoolbox/data/pretrained_model.yaml
@@ -634,6 +634,52 @@ hovernet_fast-pannuke:
             stride_shape: [164, 164]
             save_resolution: {'units': 'mpp', 'resolution': 0.25}
 
+hovernet_fast-monusac:
+    url: https://tiatoolbox.dcs.warwick.ac.uk/models/seg/hovernet_fast-monusac.pth
+    architecture:
+        class: hovernet.HoVerNet
+        kwargs:
+            num_types: 5
+            mode: "fast"
+    ioconfig:
+        class: semantic_segmentor.IOSegmentorConfig
+        kwargs:
+            input_resolutions: 
+                - {"units": "mpp", "resolution": 0.25}
+            output_resolutions:
+                - {"units": "mpp", "resolution": 0.25}
+                - {"units": "mpp", "resolution": 0.25}
+                - {"units": "mpp", "resolution": 0.25}
+            margin: 128
+            tile_shape: [1024, 1024]
+            patch_input_shape: [256, 256]
+            patch_output_shape: [164, 164]
+            stride_shape: [164, 164]
+            save_resolution: {'units': 'mpp', 'resolution': 0.25}
+
+hovernet_original-consep:
+    url: https://tiatoolbox.dcs.warwick.ac.uk/models/seg/hovernet_original-consep.pth
+    architecture:
+        class: hovernet.HoVerNet
+        kwargs:
+            num_types: 5
+            mode: "original"
+    ioconfig:
+        class: semantic_segmentor.IOSegmentorConfig
+        kwargs:
+            input_resolutions: 
+                - {"units": "mpp", "resolution": 0.25}
+            output_resolutions:
+                - {"units": "mpp", "resolution": 0.25}
+                - {"units": "mpp", "resolution": 0.25}
+                - {"units": "mpp", "resolution": 0.25}
+            margin: 128
+            tile_shape: [1024, 1024]
+            patch_input_shape: [270, 270]
+            patch_output_shape: [80, 80]
+            stride_shape: [80, 80]
+            save_resolution: {'units': 'mpp', 'resolution': 0.25}
+
 hovernet_original-kumar:
     url: https://tiatoolbox.dcs.warwick.ac.uk/models/seg/hovernet_original-kumar.pth
     architecture:
@@ -649,7 +695,7 @@ hovernet_original-kumar:
             output_resolutions:
                 - {"units": "mpp", "resolution": 0.25}
                 - {"units": "mpp", "resolution": 0.25}
-            margin: 235
+            margin: 128
             tile_shape: [1024, 1024]
             patch_input_shape: [270, 270]
             patch_output_shape: [80, 80]

--- a/tiatoolbox/models/architecture/hovernet.py
+++ b/tiatoolbox/models/architecture/hovernet.py
@@ -287,14 +287,14 @@ class HoVerNet(ModelABC):
           Once define, a branch dedicated for typing is created.
           By default, no typing (`num_types=None`) is used.
         mode (str): To use architecture defined in as in original paper
-          (`original`) or the one used in Pannuke paper (`fast`).
+          (`original`) or the one used in PanNuke paper (`fast`).
 
     References:
         Graham, Simon, et al. "Hover-net: Simultaneous segmentation and
         classification of nuclei in multi-tissue histology images."
         Medical Image Analysis 58 (2019): 101563.
 
-        Gamper, Jevgenij, et al. "Pannuke dataset extension, insights and baselines."
+        Gamper, Jevgenij, et al. "PanNuke dataset extension, insights and baselines."
         arXiv preprint arXiv:2003.10778 (2020).
 
     """


### PR DESCRIPTION
Add HoVer-Net model weights trained on both the CoNSeP and MoNuSAC datasets.

- path to weights updated in `pretrained_model.yml`
- added tests