### PR TITLE
BUG: Fix Empty Query in Instance Segmentor

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1160,14 +1160,14 @@ def test_model_to():
     import torch.nn as nn
     import torchvision.models as torch_models
 
-    # test on GPU
+    # Test on GPU
     # no GPU on Travis so this will crash
     if not torch.cuda.is_available():
         model = torch_models.resnet18()
         with pytest.raises(RuntimeError):
             _ = misc.model_to(on_gpu=True, model=model)
 
-    # test on CPU
+    # Test on CPU
     model = torch_models.resnet18()
     model = misc.model_to(on_gpu=False, model=model)
     assert isinstance(model, nn.Module)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1238,6 +1238,7 @@ def test_detect_pixman():
     """Test detection of the pixman version.
 
     Simply check it passes without exception.
+
     """
     _, _ = utils.env_detection.pixman_version()
 
@@ -1246,5 +1247,6 @@ def test_detect_travis():
     """Test detection of the travis environment.
 
     Simply check it passes without exception.
+
     """
     _ = utils.env_detection.running_on_travis()

--- a/tiatoolbox/data/pretrained_model.yaml
+++ b/tiatoolbox/data/pretrained_model.yaml
@@ -696,7 +696,7 @@ hovernet_original-kumar:
                 - {"units": "mpp", "resolution": 0.25}
                 - {"units": "mpp", "resolution": 0.25}
             margin: 128
-            tile_shape: [1024, 1024]
+            tile_shape: [2048, 2048]
             patch_input_shape: [270, 270]
             patch_output_shape: [80, 80]
             stride_shape: [80, 80]
@@ -720,7 +720,7 @@ hovernetplus-oed:
                 - {"units": "mpp", "resolution": 0.50}
                 - {"units": "mpp", "resolution": 0.50}    
             margin: 128
-            tile_shape: [1024, 1024]
+            tile_shape: [2048, 2048]
             patch_input_shape: [256, 256]
             patch_output_shape: [164, 164]
             stride_shape: [164, 164]

--- a/tiatoolbox/models/engine/nucleus_instance_segmentor.py
+++ b/tiatoolbox/models/engine/nucleus_instance_segmentor.py
@@ -655,6 +655,10 @@ class NucleusInstanceSegmentor(SemanticSegmentor):
                     index_by_id[id(geo)] for geo in spatial_indexer.query(sel_box)
                 ]
 
+                # there is nothing in the tile
+                if len(sel_indices) == 0:
+                    continue
+
                 tile_patch_inputs = patch_inputs[sel_indices]
                 tile_patch_outputs = patch_outputs[sel_indices]
                 self._to_shared_space(wsi_idx, tile_patch_inputs, tile_patch_outputs)

--- a/tiatoolbox/models/engine/nucleus_instance_segmentor.py
+++ b/tiatoolbox/models/engine/nucleus_instance_segmentor.py
@@ -656,7 +656,9 @@ class NucleusInstanceSegmentor(SemanticSegmentor):
                 ]
 
                 # there is nothing in the tile
-                if len(sel_indices) == 0:
+                # Ignore coverage as the condition is difficult
+                # to reproduce on travis.
+                if len(sel_indices) == 0:  # pragma: no cover
                     continue
 
                 tile_patch_inputs = patch_inputs[sel_indices]


### PR DESCRIPTION
- Empty querry will make the program crash (this is depending on wsi/tile). This check should fix it.
- Banding issue (missing prediction) due to wrong removal handling, It is not yet clear why it happens as the larger images (12k x 12k atm) does not seem to be affected. Setting larger tile fixes it so this is an emergency fix. A follow up investigation is necessary.