### PR TITLE
MAINT: Setting Up Conditional Tests Using "pytest skipif"

### DIFF
--- a/tests/models/test_abc.py
+++ b/tests/models/test_abc.py
@@ -25,9 +25,13 @@ import pytest
 from tiatoolbox import rcParam
 from tiatoolbox.models.abc import ModelABC
 from tiatoolbox.models.architecture import get_pretrained_model
+from tiatoolbox.utils import env_detection as toolbox_env
 
 
-@pytest.mark.skip(reason="Local test, not applicable for travis.")
+@pytest.mark.skipif(
+    toolbox_env.running_on_travis() or not toolbox_env.has_gpu(),
+    reason="Local test on machine with GPU.",
+)
 def test_get_pretrained_model():
     """Test for downloading and creating pretrained models."""
     pretrained_info = rcParam["pretrained_model_info"]

--- a/tests/models/test_dataset.py
+++ b/tests/models/test_dataset.py
@@ -27,6 +27,7 @@ import pytest
 
 from tiatoolbox import rcParam
 from tiatoolbox.models.dataset import DatasetInfoABC, KatherPatchDataset, PatchDataset
+from tiatoolbox.utils import env_detection as toolbox_env
 from tiatoolbox.utils.misc import download_data, unzip_data
 
 
@@ -77,7 +78,9 @@ def test_dataset_abc():
         Proto()  # skipcq
 
 
-@pytest.mark.skip(reason="Local test, not applicable for travis.")
+@pytest.mark.skipif(
+    toolbox_env.running_on_travis(), reason="Local test on local machine."
+)
 def test_kather_dataset_default(tmp_path):
     """Test for kather patch dataset with default parameters."""
 

--- a/tests/models/test_multi_task_segmentor.py
+++ b/tests/models/test_multi_task_segmentor.py
@@ -25,13 +25,14 @@ import shutil
 
 import numpy as np
 import pytest
-import torch
 
 from tiatoolbox.models import SemanticSegmentor
+from tiatoolbox.utils import env_detection as toolbox_env
 
-BATCH_SIZE = 1
-ON_TRAVIS = True
-ON_GPU = not ON_TRAVIS and torch.cuda.is_available()
+ON_GPU = ON_GPU = toolbox_env.has_gpu()
+# The value is based on 2 TitanXP each with 12GB
+BATCH_SIZE = 1 if not ON_GPU else 16
+NUM_POSTPROC_WORKERS = 2 if not toolbox_env.running_on_travis() else 8
 
 # ----------------------------------------------------
 
@@ -41,20 +42,23 @@ def _rm_dir(path):
     shutil.rmtree(path, ignore_errors=True)
 
 
-@pytest.mark.skip(reason="Local manual test, not applicable for travis.")
+@pytest.mark.skipif(
+    toolbox_env.running_on_travis() or not toolbox_env.has_gpu(),
+    reason="Local test on machine with GPU.",
+)
 def test_functionality_local(remote_sample, tmp_path):
     """Local functionality test for multi task segmentor. Currently only
     testing HoVer-Net+ with semantic segmentor.
     """
     root_save_dir = pathlib.Path(tmp_path)
-    mini_wsi_svs = pathlib.Path(remote_sample("CMU-1-Small-Region.svs"))
+    mini_wsi_svs = pathlib.Path(remote_sample("svs-1-small"))
 
     save_dir = f"{root_save_dir}/semantic/"
     _rm_dir(save_dir)
     semantic_segmentor = SemanticSegmentor(
         pretrained_model="hovernetplus-oed",
         batch_size=BATCH_SIZE,
-        num_postproc_workers=2,
+        num_postproc_workers=NUM_POSTPROC_WORKERS,
     )
     output = semantic_segmentor.predict(
         [mini_wsi_svs],

--- a/tests/models/test_nucleus_instance_segmentor.py
+++ b/tests/models/test_nucleus_instance_segmentor.py
@@ -47,7 +47,7 @@ from tiatoolbox.utils.metrics import f1_detection
 from tiatoolbox.utils.misc import imwrite
 from tiatoolbox.wsicore.wsireader import WSIReader
 
-ON_GPU = ON_GPU = toolbox_env.has_gpu()
+ON_GPU = toolbox_env.has_gpu()
 # The value is based on 2 TitanXP each with 12GB
 BATCH_SIZE = 1 if not ON_GPU else 16
 

--- a/tests/models/test_nucleus_instance_segmentor.py
+++ b/tests/models/test_nucleus_instance_segmentor.py
@@ -29,7 +29,6 @@ import shutil
 import joblib
 import numpy as np
 import pytest
-import torch
 import yaml
 from click.testing import CliRunner
 

--- a/tests/models/test_nucleus_instance_segmentor.py
+++ b/tests/models/test_nucleus_instance_segmentor.py
@@ -43,13 +43,14 @@ from tiatoolbox.models.architecture import fetch_pretrained_weights
 from tiatoolbox.models.engine.nucleus_instance_segmentor import (
     _process_tile_predictions,
 )
+from tiatoolbox.utils import env_detection as toolbox_env
 from tiatoolbox.utils.metrics import f1_detection
 from tiatoolbox.utils.misc import imwrite
 from tiatoolbox.wsicore.wsireader import WSIReader
 
-BATCH_SIZE = 1
-ON_TRAVIS = True
-ON_GPU = not ON_TRAVIS and torch.cuda.is_available()
+ON_GPU = ON_GPU = toolbox_env.has_gpu()
+# The value is based on 2 TitanXP each with 12GB
+BATCH_SIZE = 1 if not ON_GPU else 16
 
 # ----------------------------------------------------
 
@@ -449,7 +450,10 @@ def test_functionality_merge_tile_predictions_travis(remote_sample, tmp_path):
     _rm_dir(tmp_path)
 
 
-@pytest.mark.skip(reason="Local manual test, not applicable for travis.")
+@pytest.mark.skipif(
+    toolbox_env.running_on_travis() or not toolbox_env.has_gpu(),
+    reason="Local test on machine with GPU.",
+)
 def test_functionality_local(remote_sample, tmp_path):
     """Local functionality test for nuclei instance segmentor."""
     root_save_dir = pathlib.Path(tmp_path)

--- a/tests/models/test_nucleus_instance_segmentor.py
+++ b/tests/models/test_nucleus_instance_segmentor.py
@@ -450,7 +450,7 @@ def test_functionality_merge_tile_predictions_travis(remote_sample, tmp_path):
 
 
 @pytest.mark.skipif(
-    toolbox_env.running_on_travis() or not toolbox_env.has_gpu(),
+    toolbox_env.running_on_travis() or not ON_GPU,
     reason="Local test on machine with GPU.",
 )
 def test_functionality_local(remote_sample, tmp_path):

--- a/tests/models/test_patch_predictor.py
+++ b/tests/models/test_patch_predictor.py
@@ -30,6 +30,7 @@ import pytest
 import torch
 from click.testing import CliRunner
 
+import tiatoolbox
 from tiatoolbox import cli, rcParam
 from tiatoolbox.models.architecture.vanilla import CNNModel
 from tiatoolbox.models.dataset import (
@@ -39,14 +40,14 @@ from tiatoolbox.models.dataset import (
     predefined_preproc_func,
 )
 from tiatoolbox.models.engine.patch_predictor import (
-    PatchPredictor,
     IOPatchPredictorConfig,
+    PatchPredictor,
 )
+from tiatoolbox.utils import env_detection as toolbox_env
 from tiatoolbox.utils.misc import download_data, imread, imwrite
 from tiatoolbox.wsicore.wsireader import get_wsireader
 
-ON_TRAVIS = True
-ON_GPU = not ON_TRAVIS and torch.cuda.is_available()
+ON_GPU = toolbox_env.has_gpu()
 
 
 def _rm_dir(path):
@@ -868,7 +869,7 @@ def test_wsi_predictor_merge_predictions(sample_wsi_dict):
         **kwargs,
     )
 
-    # mockup to change the preproc func and
+    # mock up to change the preproc func and
     # force to use the default in merge function
     # still should have the same results
     kwargs["merge_predictions"] = False
@@ -968,7 +969,7 @@ def test_patch_predictor_kather100k_output(sample_patch1, sample_patch2):
             on_gpu=ON_GPU,
         )
         # only test 1 on travis to limit runtime
-        if ON_TRAVIS:
+        if toolbox_env.running_on_travis():
             break
 
 
@@ -1003,7 +1004,7 @@ def test_patch_predictor_pcam_output(sample_patch3, sample_patch4):
             on_gpu=ON_GPU,
         )
         # only test 1 on travis to limit runtime
-        if ON_TRAVIS:
+        if toolbox_env.running_on_travis():
             break
 
 

--- a/tests/models/test_patch_predictor.py
+++ b/tests/models/test_patch_predictor.py
@@ -30,7 +30,6 @@ import pytest
 import torch
 from click.testing import CliRunner
 
-import tiatoolbox
 from tiatoolbox import cli, rcParam
 from tiatoolbox.models.architecture.vanilla import CNNModel
 from tiatoolbox.models.dataset import (

--- a/tests/models/test_semantic_segmentation.py
+++ b/tests/models/test_semantic_segmentation.py
@@ -677,7 +677,7 @@ def test_functional_pretrained(remote_sample, tmp_path):
 
 
 @pytest.mark.skipif(
-    toolbox_env.running_on_travis() or not toolbox_env.has_gpu(),
+    toolbox_env.running_on_travis() or not ON_GPU,
     reason="Local test on machine with GPU.",
 )
 def test_behavior_tissue_mask_local(remote_sample, tmp_path):
@@ -718,7 +718,7 @@ def test_behavior_tissue_mask_local(remote_sample, tmp_path):
 
 
 @pytest.mark.skipif(
-    toolbox_env.running_on_travis() or not toolbox_env.has_gpu(),
+    toolbox_env.running_on_travis() or not ON_GPU,
     reason="Local test on machine with GPU.",
 )
 def test_behavior_bcss_local(remote_sample, tmp_path):

--- a/tests/models/test_semantic_segmentation.py
+++ b/tests/models/test_semantic_segmentation.py
@@ -20,12 +20,13 @@
 """Tests for Semantic Segmentor."""
 
 import copy
+
+# ! The garbage collector
+import gc
 import os
 import pathlib
 import shutil
 
-# ! The garbage collector
-import gc
 import numpy as np
 import pytest
 import torch
@@ -44,11 +45,15 @@ from tiatoolbox.models.engine.semantic_segmentor import (
     SemanticSegmentor,
     WSIStreamDataset,
 )
+from tiatoolbox.utils import env_detection as toolbox_env
 from tiatoolbox.utils.misc import imread, imwrite
 from tiatoolbox.wsicore.wsireader import get_wsireader
 
-ON_TRAVIS = True
-ON_GPU = not ON_TRAVIS and torch.cuda.is_available()
+ON_GPU = toolbox_env.has_gpu()
+# The value is based on 2 TitanXP each with 12GB
+BATCH_SIZE = 1 if not ON_GPU else 16
+NUM_POSTPROC_WORKERS = 2 if not toolbox_env.running_on_travis() else 8
+
 # ----------------------------------------------------
 
 
@@ -275,7 +280,7 @@ def test_crash_segmentor(remote_sample):
     mini_wsi_msk = pathlib.Path(remote_sample("wsi2_4k_4k_msk"))
 
     model = _CNNTo1()
-    semantic_segmentor = SemanticSegmentor(batch_size=1, model=model)
+    semantic_segmentor = SemanticSegmentor(batch_size=BATCH_SIZE, model=model)
     # fake injection to trigger Segmentor to create parallel
     # post processing workers because baseline Semantic Segmentor does not support
     # post processing out of the box. It only contains condition to create it
@@ -351,7 +356,7 @@ def test_functional_segmentor_merging(tmp_path):
     save_dir = pathlib.Path(tmp_path)
 
     model = _CNNTo1()
-    semantic_segmentor = SemanticSegmentor(batch_size=1, model=model)
+    semantic_segmentor = SemanticSegmentor(batch_size=BATCH_SIZE, model=model)
 
     _rm_dir(save_dir)
     os.mkdir(save_dir)
@@ -479,7 +484,7 @@ def test_functional_segmentor(remote_sample, tmp_path):
     # preemptive clean up
     _rm_dir("output")  # default output dir test
     model = _CNNTo1()
-    semantic_segmentor = SemanticSegmentor(batch_size=1, model=model)
+    semantic_segmentor = SemanticSegmentor(batch_size=BATCH_SIZE, model=model)
     # fake injection to trigger Segmentor to create parallel
     # post processing workers because baseline Semantic Segmentor does not support
     # post processing out of the box. It only contains condition to create it
@@ -587,7 +592,7 @@ def test_functional_segmentor(remote_sample, tmp_path):
 
     # check normal run with auto get mask
     semantic_segmentor = SemanticSegmentor(
-        batch_size=1, model=model, auto_generate_mask=True
+        batch_size=BATCH_SIZE, model=model, auto_generate_mask=True
     )
     output_list = semantic_segmentor.predict(
         [mini_wsi_svs],
@@ -642,7 +647,7 @@ def test_functional_pretrained(remote_sample, tmp_path):
     imwrite(mini_wsi_jpg, thumb)
 
     semantic_segmentor = SemanticSegmentor(
-        batch_size=1, pretrained_model="fcn-tissue_mask"
+        batch_size=BATCH_SIZE, pretrained_model="fcn-tissue_mask"
     )
 
     _rm_dir(save_dir)
@@ -671,7 +676,10 @@ def test_functional_pretrained(remote_sample, tmp_path):
     _rm_dir(tmp_path)
 
 
-@pytest.mark.skip(reason="Local manual test, not applicable for travis.")
+@pytest.mark.skipif(
+    toolbox_env.running_on_travis() or not toolbox_env.has_gpu(),
+    reason="Local test on machine with GPU.",
+)
 def test_behavior_tissue_mask_local(remote_sample, tmp_path):
     """Contain test for behavior of the segmentor and pretrained models."""
     save_dir = pathlib.Path(tmp_path)
@@ -679,13 +687,13 @@ def test_behavior_tissue_mask_local(remote_sample, tmp_path):
     mini_wsi_jpg = pathlib.Path(remote_sample("wsi2_4k_4k_jpg"))
 
     semantic_segmentor = SemanticSegmentor(
-        batch_size=4, pretrained_model="fcn-tissue_mask"
+        batch_size=BATCH_SIZE, pretrained_model="fcn-tissue_mask"
     )
     _rm_dir(save_dir)
     semantic_segmentor.predict(
         [wsi_with_artifacts],
         mode="wsi",
-        on_gpu=ON_GPU,
+        on_gpu=True,
         crash_on_exception=True,
         save_dir=f"{save_dir}/raw/",
     )
@@ -701,7 +709,7 @@ def test_behavior_tissue_mask_local(remote_sample, tmp_path):
     semantic_segmentor.predict(
         [mini_wsi_jpg],
         mode="tile",
-        on_gpu=ON_GPU,
+        on_gpu=True,
         crash_on_exception=True,
         save_dir=f"{save_dir}/raw/",
     )
@@ -709,7 +717,10 @@ def test_behavior_tissue_mask_local(remote_sample, tmp_path):
     _rm_dir(save_dir)
 
 
-@pytest.mark.skip(reason="Local manual test, not applicable for travis.")
+@pytest.mark.skipif(
+    toolbox_env.running_on_travis() or not toolbox_env.has_gpu(),
+    reason="Local test on machine with GPU.",
+)
 def test_behavior_bcss_local(remote_sample, tmp_path):
     """Contain test for behavior of the segmentor and pretrained models."""
     save_dir = pathlib.Path(tmp_path)
@@ -717,7 +728,9 @@ def test_behavior_bcss_local(remote_sample, tmp_path):
     _rm_dir(save_dir)
     wsi_breast = pathlib.Path(remote_sample("wsi4_4k_4k_svs"))
     semantic_segmentor = SemanticSegmentor(
-        num_loader_workers=4, batch_size=16, pretrained_model="fcn_resnet50_unet-bcss"
+        num_loader_workers=4,
+        batch_size=BATCH_SIZE,
+        pretrained_model="fcn_resnet50_unet-bcss",
     )
     semantic_segmentor.predict(
         [wsi_breast],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1162,7 +1162,7 @@ def test_model_to():
 
     # test on GPU
     # no GPU on Travis so this will crash
-    if not torch.cuda.is_available():
+    if not utils.env_detection.has_gpu():
         model = torch_models.resnet18()
         with pytest.raises(RuntimeError):
             _ = misc.model_to(on_gpu=True, model=model)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,6 @@ import cv2
 import numpy as np
 import pandas as pd
 import pytest
-import torch.cuda
 from PIL import Image
 
 from tiatoolbox import rcParam, utils

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1238,6 +1238,7 @@ def test_detect_pixman():
     """Test detection of the pixman version.
 
     Simply check it passes without exception.
+
     """
     _, _ = utils.env_detection.pixman_version()
 
@@ -1246,6 +1247,7 @@ def test_detect_travis():
     """Test detection of the travis environment.
 
     Simply check it passes without exception.
+
     """
     _ = utils.env_detection.running_on_travis()
 
@@ -1254,5 +1256,6 @@ def test_detect_gpu():
     """Test detection of GPU in the current runtime environment.
 
     Simply check it passes without exception.
+
     """
     _ = utils.env_detection.has_gpu()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1248,3 +1248,11 @@ def test_detect_travis():
     Simply check it passes without exception.
     """
     _ = utils.env_detection.running_on_travis()
+
+
+def test_detect_gpu():
+    """Test detection of GPU in the current runtime environment.
+
+    Simply check it passes without exception.
+    """
+    _ = utils.env_detection.has_gpu()

--- a/tiatoolbox/utils/env_detection.py
+++ b/tiatoolbox/utils/env_detection.py
@@ -42,7 +42,23 @@ import threading
 from numbers import Number
 from typing import Tuple
 
+import torch
+
 from tiatoolbox import logger
+
+
+def has_gpu() -> bool:
+    """Detect if the runtime has GPU.
+
+    This function calls torch function underneath. To mask an environment
+    to have no GPU, you can set "CUDA_VISIBLE_DEVICES" environment variable
+    to empty before running the python script.
+
+    Returns:
+        bool: True if the current runtime environment has GPU, False otherwise.
+
+    """
+    return torch.cuda.is_available()
 
 
 def is_interactive() -> bool:

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -13,6 +13,7 @@ dataframe
 dataset
 Dataset
 Delaunay
+DNS
 downsample
 downsampled
 dpkg


### PR DESCRIPTION
There are several tests that have been marked to be skipped when running pytest because there were no way to check if they are run on Travis. Now we have the facility for detecting runtime flag in place, we can automatically flag which test to run on which conditions. This PR deals with tests that are related to Deep Learning Models (require GPU and Travis runtime check).