### PR TITLE
BUG: Add User Warning For Missing SQLite Functions

### DIFF
--- a/tests/test_annotation_stores.py
+++ b/tests/test_annotation_stores.py
@@ -172,6 +172,18 @@ def test_sqlite_store_compile_options_exception(monkeypatch):
         SQLiteStore()
 
 
+def test_sqlite_store_compile_options_missing_math(monkeypatch, caplog):
+    """Test that a warning is shown if the sqlite math module is missing."""
+    monkeypatch.setattr(
+        SQLiteStore,
+        "compile_options",
+        lambda x: ["ENABLE_JSON1", "ENABLE_RTREE"],
+        raising=True,
+    )
+    SQLiteStore()
+    assert "SQLite math functions are not enabled" in caplog.text
+
+
 def test_sqlite_store_multiple_connection(tmp_path):
     store = SQLiteStore(tmp_path / "annotations.db")
     store2 = SQLiteStore(tmp_path / "annotations.db")

--- a/tiatoolbox/annotation/dsl.py
+++ b/tiatoolbox/annotation/dsl.py
@@ -53,7 +53,7 @@ input string.
 
 Supported operators and functions:
     - Property access: `props["key"]`
-    - Math operations (`+`, `-`, `*`, `/`, `**`, `%`): `props["key"] + 1`
+    - Math operations (`+`, `-`, `*`, `/`, `//`, `**`, `%`): `props["key"] + 1`
     - Boolean operations (`and`, `or`, `not`): `props["key"] and props["key"] == 1`
     - Key checking: `"key" in props`
     - List indexing: `props["key"][0]`

--- a/tiatoolbox/annotation/dsl.py
+++ b/tiatoolbox/annotation/dsl.py
@@ -68,6 +68,10 @@ Unsupported operations:
     - Imports: `import re`
     - List length: `len(props["key"])` (support planned)
 
+Some mathematical functions will not function if the compile option
+`ENABLE_MATH_FUNCTIONS` is not set. These are:
+    - `//` (floor division)
+
 """
 import json
 import operator

--- a/tiatoolbox/annotation/dsl.py
+++ b/tiatoolbox/annotation/dsl.py
@@ -44,7 +44,7 @@ An additional benefit is that the same input string can be
 used across different backends. For example, the previous
 simple example predicate string can be evaluated as both a valid
 python expression and can be converted to an equivalent valid SQL
-expression simply by running `eval with a different set of globals
+expression simply by running `eval` with a different set of globals
 from this module.
 
 It is important to note that untrusted user input should not be

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -77,6 +77,7 @@ from shapely.geometry import LineString, Point, Polygon
 from shapely.geometry import mapping as geometry2feature
 from shapely.geometry import shape as feature2geometry
 
+from tiatoolbox import logger
 from tiatoolbox.annotation.dsl import (
     PY_GLOBALS,
     SQL_GLOBALS,
@@ -1002,6 +1003,14 @@ class SQLiteStore(AnnotationStore):
             ["ENABLE_JSON1" in compile_options, "ENABLE_RTREE" in compile_options]
         ):
             raise Exception("RTREE and JSON1 sqlite3 compile options are required.")
+
+        # Check that math functions are enabled
+        if "ENABLE_MATH_FUNCTIONS" not in compile_options:
+            logger.warning(
+                "SQLite math functions are not enabled."
+                " This may cause problems with some queries."
+                " For example, floor division (//) will not work."
+            )
 
         # Set up database connection and cursor
         path = Path(connection)

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -77,6 +77,7 @@ from shapely.geometry import LineString, Point, Polygon
 from shapely.geometry import mapping as geometry2feature
 from shapely.geometry import shape as feature2geometry
 
+import tiatoolbox
 from tiatoolbox import logger
 from tiatoolbox.annotation.dsl import (
     PY_GLOBALS,
@@ -1010,6 +1011,9 @@ class SQLiteStore(AnnotationStore):
                 "SQLite math functions are not enabled."
                 " This may cause problems with some queries."
                 " For example, floor division (//) will not work."
+                " For a full list see https://tia-toolbox.readthedocs.io/"
+                "en/v%s/_autosummary/tiatoolbox.annotation.dsl.html",
+                tiatoolbox.__version__,
             )
 
         # Set up database connection and cursor


### PR DESCRIPTION
It is possible that SQLite (e.g. versions <3.35) may not have math functions enabled (e.g. floor). This could break some queries e.g. those made using a DSL string including a floor division (//).

Added information to docs. See https://tia-toolbox.readthedocs.io/en/bug-sqlite-floor/_autosummary/tiatoolbox.annotation.dsl.html.