### PR TITLE
REL: Release 1.0.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,9 +44,9 @@ authors:
   given-names: "Shan E Ahmed"
   orcid: "https://orcid.org/0000-0002-1097-1738"
 title: "TIAToolbox: An End-to-End Toolbox for Advanced Tissue Image Analytics"
-version: 1.0.0
-doi: 10.5281/zenodo.5802443
-date-released: 2021-12-23
+version: 1.0.1
+doi: 10.5281/zenodo.5802442
+date-released: 2022-01-31
 url: "https://github.com/TissueImageAnalytics/tiatoolbox"
 preferred-citation:
   type: article

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,24 @@
 History
 =======
 
+1.0.1 (2022-01-31)
+------------------
+### Major Updates and Feature Improvements
+- Updates dependencies for conda recipe #262
+
+### Changes to API
+- None
+
+### Bug Fixes and Other Changes
+- Adds User Warning For Missing SQLite Functions
+- Fixes Pixman version check errors
+- Fixes empty query in instance segmentor
+
+### Development related changes
+- Fixes flake8 linting issues and typos
+- Conditional pytest.skipif to skip GPU tests on travis while running them locally or elsewhere
+
+
 1.0.0 (2021-12-23)
 ------------------
 ### Major Updates and Feature Improvements

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ imagecodecs>2021.10.0
 jupyterlab
 matplotlib
 numpy
-opencv-python<=4.5.4
+opencv-python>=4.5.4
 openslide-python==1.1.2
 pandas
 pillow

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/TissueImageAnalytics/tiatoolbox",
-    version="1.0.0",
+    version="1.0.1",
     zip_safe=False,
 )

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -27,7 +27,7 @@ import yaml
 
 __author__ = """TIA Lab"""
 __email__ = "tialab@dcs.warwick.ac.uk"
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 # This will set the tiatoolbox external data
 # default to be the user home folder, should work on both Window and Unix/Linux


### PR DESCRIPTION
- Bump version: 1.0.0 → 1.0.1

### Major Updates and Feature Improvements
- Updates dependencies for conda recipe #262

### Changes to API
- None

### Bug Fixes and Other Changes
- Adds User Warning For Missing SQLite Functions
- Fixes Pixman version check errors
- Fixes empty query in instance segmentor

### Development related changes
- Fixes flake8 linting issues and typos
- Conditional pytest.skipif to skip GPU tests on travis while running them locally or elsewhere