### PR TITLE
DEV: Fix Flake8 Errors And Typos In `patchextraction.py`

### DIFF
--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -462,13 +462,13 @@ def test_filter_coordinates():
     flag_list = PatchExtractor.filter_coordinates_fast(
         mask_reader,
         bbox_list,
-        coord_resolution=1.0,
-        coord_units="mpp",
+        coordinate_resolution=1.0,
+        coordinate_units="mpp",
         mask_resolution=1,
     )
     assert np.sum(flag_list - np.array([1, 1, 0, 0, 0, 0])) == 0
     flag_list = PatchExtractor.filter_coordinates_fast(
-        mask_reader, bbox_list, coord_resolution=(1.0, 1.0), coord_units="mpp"
+        mask_reader, bbox_list, coordinate_resolution=(1.0, 1.0), coordinate_units="mpp"
     )
 
     # Test for bad mask input
@@ -478,8 +478,8 @@ def test_filter_coordinates():
         PatchExtractor.filter_coordinates_fast(
             mask,
             bbox_list,
-            coord_resolution=1.0,
-            coord_units="mpp",
+            coordinate_resolution=1.0,
+            coordinate_units="mpp",
         )
 
     # Test for bad bbox coordinate list in the input
@@ -487,8 +487,8 @@ def test_filter_coordinates():
         PatchExtractor.filter_coordinates_fast(
             mask_reader,
             bbox_list.tolist(),
-            coord_resolution=1,
-            coord_units="mpp",
+            coordinate_resolution=1,
+            coordinate_units="mpp",
         )
 
     # Test for incomplete coordinate list
@@ -496,8 +496,8 @@ def test_filter_coordinates():
         PatchExtractor.filter_coordinates_fast(
             mask_reader,
             bbox_list[:, :2],
-            coord_resolution=1,
-            coord_units="mpp",
+            coordinate_resolution=1,
+            coordinate_units="mpp",
         )
 
 

--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -585,8 +585,8 @@ def test_mask_based_patch_extractor_ndpi(sample_ndpi):
 
     # Test passing an empty mask
     wsi_mask = np.zeros(mask_dim, dtype=np.uint8)
-    with pytest.raises(ValueError, match=".*No candidate coordinates left.*"):
-        patches = patchextraction.get_patch_extractor(
+    with pytest.warns(UserWarning, match=".*No candidate coordinates left.*"):
+        _ = patchextraction.get_patch_extractor(
             input_img=input_img,
             input_mask=wsi_mask,
             method_name="slidingwindow",

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -561,11 +561,12 @@ def get_patch_extractor(method_name, **kwargs):
         ...  'point', img_patch_h=200, img_patch_w=200)
 
     """
-    if method_name.lower() == "point":
-        patch_extractor = PointsPatchExtractor(**kwargs)
-    elif method_name.lower() == "slidingwindow":
-        patch_extractor = SlidingWindowPatchExtractor(**kwargs)
-    else:
-        raise MethodNotSupported
+    if method_name.lower() not in ["point", "slidingwindow"]:
+        raise MethodNotSupported(
+            f"{method_name.lower()} method is not currently supported."
+        )
 
-    return patch_extractor
+    if method_name.lower() == "point":
+        return PointsPatchExtractor(**kwargs)
+    elif method_name.lower() == "slidingwindow":
+        return SlidingWindowPatchExtractor(**kwargs)

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -546,13 +546,6 @@ class PointsPatchExtractor(PatchExtractor):
             also be a :class:`numpy.ndarray` or :class:`pandas.DataFrame`.
             NOTE: value of location $(x,y)$ is expected to be based on the specified
             `resolution` and `units` (not the `'baseline'` resolution).
-        input_mask(str, pathlib.Path, :class:`numpy.ndarray`, or :obj:`WSIReader`):
-            input mask that is used for position filtering when extracting patches
-            i.e., patches will only be extracted based on the highlighted regions in
-            the `input_mask`. `input_mask` can be either path to the mask, a numpy
-            array, :class:`VirtualWSIReader`, or one of 'otsu' and 'morphological'
-            options. In case of 'otsu' or 'morphological', a tissue mask is generated
-            for the input_image using tiatoolbox :class:`TissueMasker` functionality.
         patch_size(int or tuple(int)): patch size tuple (width, height).
         resolution (int or float or tuple of float): resolution at
             which to read the image, default = 0. Either a single
@@ -585,7 +578,6 @@ class PointsPatchExtractor(PatchExtractor):
         self,
         input_img,
         locations_list,
-        input_mask=None,
         patch_size=(224, 224),
         resolution=0,
         units="level",
@@ -595,7 +587,6 @@ class PointsPatchExtractor(PatchExtractor):
     ):
         super().__init__(
             input_img=input_img,
-            input_mask=input_mask,
             patch_size=patch_size,
             resolution=resolution,
             units=units,

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -73,11 +73,11 @@ class PatchExtractor(ABC):
         resolution(tuple(int)): resolution at which to read the image.
         units (str): the units of resolution.
         n(int): current state of the iterator.
-        locations_df(pd.DataFrame): A table containing location and/or type of patces
+        locations_df(pd.DataFrame): A table containing location and/or type of patches
             in `(x_start, y_start, class)` format.
-        coord_list(:class:`numpy.ndarray`): An array containing coordinates of patches
-            in `(x_start, y_start, x_end, y_end)` format to be used for `slidingwindow`
-            patch extraction.
+        coordinate_list(:class:`numpy.ndarray`): An array containing coordinates of
+            patches in `(x_start, y_start, x_end, y_end)` format to be used for
+            `slidingwindow` patch extraction.
         pad_mode (str): Method for padding at edges of the WSI.
             See :func:`numpy.pad` for more information.
         pad_constant_values (int or tuple(int)): Values to use with
@@ -142,7 +142,7 @@ class PatchExtractor(ABC):
         return self[n]
 
     def __getitem__(self, item):
-        if isinstance(item, int):
+        if not isinstance(item, int):
             raise TypeError("Index should be an integer.")
 
         if item >= self.locations_df.shape[0]:
@@ -226,8 +226,8 @@ class PatchExtractor(ABC):
                 `resolution` and `units`. The shape of `coordinates_list` is (N, K)
                 where N is the number of coordinate sets and K is either 2 for centroids
                 or 4 for bounding boxes. When using the default `func=None`, K should be
-                4, as we expect the `coordinates_list` to be refer to bounding boxes in
-                `[start_x, start_y, end_x, end_y]` format.
+                4, as we expect the `coordinates_list` to be referred to bounding boxes
+                in `[start_x, start_y, end_x, end_y]` format.
             coordinate_resolution (float): the resolution value at which
                 coordinates_list are generated.
             coordinate_units (str): the resolution unit at which coordinates_list are
@@ -294,8 +294,8 @@ class PatchExtractor(ABC):
                 `resolution` and `units`. The shape of `coordinates_list` is (N, K)
                 where N is the number of coordinate sets and K is either 2 for centroids
                 or 4 for bounding boxes. When using the default `func=None`, K should be
-                4, as we expect the `coordinates_list` to be refer to bounding boxes in
-                `[start_x, start_y, end_x, end_y]` format.
+                4, as we expect the `coordinates_list` to be referred to bounding boxes
+                in `[start_x, start_y, end_x, end_y]` format.
             func: The coordinate validator function. A function that takes `reader` and
                 `coordinate` as arguments and return True or False as indication of
                 coordinate validity.
@@ -348,7 +348,7 @@ class PatchExtractor(ABC):
 
         Args:
             image_shape (a tuple (int, int) or :class:`numpy.ndarray` of shape (2,)):
-                This argument specifies the shape of mother image (the image we want to)
+                This argument specifies the shape of mother image (the image we want to
                 extract patches from) at requested `resolution` and `units` and it is
                 expected to be in (width, height) format.
             patch_input_shape (a tuple (int, int) or
@@ -363,7 +363,7 @@ class PatchExtractor(ABC):
                 (width, height) format. If this is not provided, `patch_output_shape`
                 will be the same as `patch_input_shape`.
             stride_shape (a tuple (int, int) or :class:`numpy.ndarray` of shape (2,)):
-                The stride that is used to calcualte the patch location during the patch
+                The stride that is used to calculate the patch location during the patch
                 extraction. If `patch_output_shape` is provided, next stride location
                 will base on the output rather than the input.
             input_within_bound (bool): Whether to include the patches where their

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -19,6 +19,7 @@
 # ***** END GPL LICENSE BLOCK *****
 
 """This file defines patch extraction methods for deep learning models."""
+import warnings
 from abc import ABC
 
 import numpy as np
@@ -194,7 +195,7 @@ class PatchExtractor(ABC):
             )
             self.coordinate_list = self.coordinate_list[selected_coord_idxs]
             if len(self.coordinate_list) == 0:
-                raise ValueError(
+                warnings.warn(
                     "No candidate coordinates left after "
                     "filtering by `input_mask` positions."
                 )

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -29,8 +29,7 @@ from tiatoolbox.wsicore import wsireader
 
 
 class PatchExtractor(ABC):
-    """
-    Class for extracting and merging patches in standard and whole-slide images.
+    """Class for extracting and merging patches in standard and whole-slide images.
 
     Args:
         input_img(str, pathlib.Path, :class:`numpy.ndarray`): input image for
@@ -235,8 +234,8 @@ class PatchExtractor(ABC):
                 generated.
             mask_resolution (float): resolution at which mask array is extracted. It is
                 supposed to be in the same units as `coord_resolution` i.e.,
-                `coord_units`. If not provided, a default value will be selected based on
-                `coord_units`.
+                `coord_units`. If not provided, a default value will be selected based
+                on `coord_units`.
 
         Returns:
             ndarray: list of flags to indicate which coordinate is valid.

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -568,5 +568,5 @@ def get_patch_extractor(method_name, **kwargs):
 
     if method_name.lower() == "point":
         return PointsPatchExtractor(**kwargs)
-    elif method_name.lower() == "slidingwindow":
-        return SlidingWindowPatchExtractor(**kwargs)
+
+    return SlidingWindowPatchExtractor(**kwargs)

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -460,6 +460,40 @@ class SlidingWindowPatchExtractor(PatchExtractor):
     """Extract patches using sliding fixed sized window for images and labels.
 
     Args:
+        input_img(str, pathlib.Path, :class:`numpy.ndarray`): input image for
+            patch extraction.
+        patch_size(int or tuple(int)): patch size tuple (width, height).
+        input_mask(str, pathlib.Path, :class:`numpy.ndarray`, or :obj:`WSIReader`):
+            input mask that is used for position filtering when extracting patches
+            i.e., patches will only be extracted based on the highlighted regions in
+            the input_mask. input_mask can be either path to the mask, a numpy
+            array, :class:`VirtualWSIReader`, or one of 'otsu' and 'morphological'
+            options. In case of 'otsu' or 'morphological', a tissue mask is generated
+            for the input_image using tiatoolbox :class:`TissueMasker` functionality.
+        resolution (int or float or tuple of float): resolution at
+            which to read the image, default = 0. Either a single
+            number or a sequence of two numbers for x and y are
+            valid. This value is in terms of the corresponding
+            units. For example: resolution=0.5 and units="mpp" will
+            read the slide at 0.5 microns per-pixel, and
+            resolution=3, units="level" will read at level at
+            pyramid level / resolution layer 3.
+        units (str): the units of resolution, default = "level".
+            Supported units are: microns per pixel (mpp), objective
+            power (power), pyramid / resolution level (level),
+            Only pyramid / resolution levels (level) embedded in
+            the whole slide image are supported.
+        pad_mode (str): Method for padding at edges of the WSI. Default
+            to 'constant'. See :func:`numpy.pad` for more information.
+        pad_constant_values (int or tuple(int)): Values to use with
+            constant padding. Defaults to 0. See :func:`numpy.pad` for
+            more.
+        within_bound (bool): whether to extract patches beyond the
+            input_image size limits. If False, extracted patches at margins
+            will be padded appropriately based on `pad_constant_values` and
+            `pad_mode`. If False, patches at the margin that their bounds
+            exceed the mother image dimensions would be neglected.
+            Default is False.
         stride(int or tuple(int)): stride in (x, y) direction for patch extraction,
             default = patch_size
 
@@ -505,11 +539,45 @@ class PointsPatchExtractor(PatchExtractor):
     """Extracting patches with specified points as a centre.
 
     Args:
+        input_img(str, pathlib.Path, :class:`numpy.ndarray`): input image for
+            patch extraction.
         locations_list(ndarray, pd.DataFrame, str, pathlib.Path): contains location
             and/or type of patch. This can be path to csv, npy or json files. Input can
             also be a :class:`numpy.ndarray` or :class:`pandas.DataFrame`.
             NOTE: value of location $(x,y)$ is expected to be based on the specified
             `resolution` and `units` (not the `'baseline'` resolution).
+        input_mask(str, pathlib.Path, :class:`numpy.ndarray`, or :obj:`WSIReader`):
+            input mask that is used for position filtering when extracting patches
+            i.e., patches will only be extracted based on the highlighted regions in
+            the input_mask. input_mask can be either path to the mask, a numpy
+            array, :class:`VirtualWSIReader`, or one of 'otsu' and 'morphological'
+            options. In case of 'otsu' or 'morphological', a tissue mask is generated
+            for the input_image using tiatoolbox :class:`TissueMasker` functionality.
+        patch_size(int or tuple(int)): patch size tuple (width, height).
+        resolution (int or float or tuple of float): resolution at
+            which to read the image, default = 0. Either a single
+            number or a sequence of two numbers for x and y are
+            valid. This value is in terms of the corresponding
+            units. For example: resolution=0.5 and units="mpp" will
+            read the slide at 0.5 microns per-pixel, and
+            resolution=3, units="level" will read at level at
+            pyramid level / resolution layer 3.
+        units (str): the units of resolution, default = "level".
+            Supported units are: microns per pixel (mpp), objective
+            power (power), pyramid / resolution level (level),
+            Only pyramid / resolution levels (level) embedded in
+            the whole slide image are supported.
+        pad_mode (str): Method for padding at edges of the WSI. Default
+            to 'constant'. See :func:`numpy.pad` for more information.
+        pad_constant_values (int or tuple(int)): Values to use with
+            constant padding. Defaults to 0. See :func:`numpy.pad` for
+            more.
+        within_bound (bool): whether to extract patches beyond the
+            input_image size limits. If False, extracted patches at margins
+            will be padded appropriately based on `pad_constant_values` and
+            `pad_mode`. If False, patches at the margin that their bounds
+            exceed the mother image dimensions would be neglected.
+            Default is False.
 
     """
 
@@ -517,6 +585,7 @@ class PointsPatchExtractor(PatchExtractor):
         self,
         input_img,
         locations_list,
+        input_mask=None,
         patch_size=(224, 224),
         resolution=0,
         units="level",
@@ -526,6 +595,7 @@ class PointsPatchExtractor(PatchExtractor):
     ):
         super().__init__(
             input_img=input_img,
+            input_mask=input_mask,
             patch_size=patch_size,
             resolution=resolution,
             units=units,

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -34,39 +34,39 @@ class PatchExtractor(ABC):
 
     Args:
         input_img(str, pathlib.Path, :class:`numpy.ndarray`): input image for
-          patch extraction.
+            patch extraction.
         patch_size(int or tuple(int)): patch size tuple (width, height).
         input_mask(str, pathlib.Path, :class:`numpy.ndarray`, or :obj:`WSIReader`):
-          input mask that is used for position filtering when extracting patches
-          i.e., patches will only be extracted based on the highlighted regions in
-          the input_mask. input_mask can be either path to the mask, a numpy
-          array, :class:`VirtualWSIReader`, or one of 'otsu' and 'morphological'
-          options. In case of 'otsu' or 'morphological', a tissue mask is generated
-          for the input_image using tiatoolbox :class:`TissueMasker` functionality.
+            input mask that is used for position filtering when extracting patches
+            i.e., patches will only be extracted based on the highlighted regions in
+            the input_mask. input_mask can be either path to the mask, a numpy
+            array, :class:`VirtualWSIReader`, or one of 'otsu' and 'morphological'
+            options. In case of 'otsu' or 'morphological', a tissue mask is generated
+            for the input_image using tiatoolbox :class:`TissueMasker` functionality.
         resolution (int or float or tuple of float): resolution at
-          which to read the image, default = 0. Either a single
-          number or a sequence of two numbers for x and y are
-          valid. This value is in terms of the corresponding
-          units. For example: resolution=0.5 and units="mpp" will
-          read the slide at 0.5 microns per-pixel, and
-          resolution=3, units="level" will read at level at
-          pyramid level / resolution layer 3.
+            which to read the image, default = 0. Either a single
+            number or a sequence of two numbers for x and y are
+            valid. This value is in terms of the corresponding
+            units. For example: resolution=0.5 and units="mpp" will
+            read the slide at 0.5 microns per-pixel, and
+            resolution=3, units="level" will read at level at
+            pyramid level / resolution layer 3.
         units (str): the units of resolution, default = "level".
-          Supported units are: microns per pixel (mpp), objective
-          power (power), pyramid / resolution level (level),
-          Only pyramid / resolution levels (level) embedded in
-          the whole slide image are supported.
+            Supported units are: microns per pixel (mpp), objective
+            power (power), pyramid / resolution level (level),
+            Only pyramid / resolution levels (level) embedded in
+            the whole slide image are supported.
         pad_mode (str): Method for padding at edges of the WSI. Default
-          to 'constant'. See :func:`numpy.pad` for more information.
+            to 'constant'. See :func:`numpy.pad` for more information.
         pad_constant_values (int or tuple(int)): Values to use with
-          constant padding. Defaults to 0. See :func:`numpy.pad` for
-          more.
+            constant padding. Defaults to 0. See :func:`numpy.pad` for
+            more.
         within_bound (bool): whether to extract patches beyond the
-          input_image size limits. If False, extracted patches at margins
-          will be padded appropriately based on `pad_constant_values` and
-          `pad_mode`. If False, patches at the margin that their bounds
-          exceed the mother image dimensions would be neglected.
-          Default is False.
+            input_image size limits. If False, extracted patches at margins
+            will be padded appropriately based on `pad_constant_values` and
+            `pad_mode`. If False, patches at the margin that their bounds
+            exceed the mother image dimensions would be neglected.
+            Default is False.
 
     Attributes:
         wsi(WSIReader): input image for patch extraction of type :obj:`WSIReader`.
@@ -75,17 +75,17 @@ class PatchExtractor(ABC):
         units (str): the units of resolution.
         n(int): current state of the iterator.
         locations_df(pd.DataFrame): A table containing location and/or type of patces
-          in `(x_start, y_start, class)` format.
+            in `(x_start, y_start, class)` format.
         coord_list(:class:`numpy.ndarray`): An array containing coordinates of patches
-          in `(x_start, y_start, x_end, y_end)` format to be used for `slidingwindow`
-          patch extraction.
+            in `(x_start, y_start, x_end, y_end)` format to be used for `slidingwindow`
+            patch extraction.
         pad_mode (str): Method for padding at edges of the WSI.
-          See :func:`numpy.pad` for more information.
+            See :func:`numpy.pad` for more information.
         pad_constant_values (int or tuple(int)): Values to use with
-          constant padding. Defaults to 0. See :func:`numpy.pad` for
-          more.
+            constant padding. Defaults to 0. See :func:`numpy.pad` for
+            more.
         stride (tuple(int)): stride in (x, y) direction for patch extraction. Not used
-         for :obj:`PointsPatchExtractor`
+            for :obj:`PointsPatchExtractor`
 
     """
 
@@ -109,7 +109,7 @@ class PatchExtractor(ABC):
         self.pad_mode = pad_mode
         self.pad_constant_values = pad_constant_values
         self.n = 0
-        self.wsi = wsireader.get_wsireader(input_img=input_img)
+        self.wsi = wsireader.WSIReader.open(input_img=input_img)
         self.locations_df = None
         self.coord_list = None
         self.stride = None
@@ -221,22 +221,22 @@ class PatchExtractor(ABC):
 
         Args:
             mask_reader (:class:`.VirtualReader`): a virtual pyramidal reader of the
-              mask related to the WSI from which we want to extract the patches.
+                mask related to the WSI from which we want to extract the patches.
             coordinates_list (ndarray and np.int32): Coordinates to be checked
-              via the `func`. They must be in the same resolution as requested
-              `resolution` and `units`. The shape of `coordinates_list` is (N, K)
-              where N is the number of coordinate sets and K is either 2 for centroids
-              or 4 for bounding boxes. When using the default `func=None`, K should be
-              4, as we expect the `coordinates_list` to be refer to bounding boxes in
-              `[start_x, start_y, end_x, end_y]` format.
+                via the `func`. They must be in the same resolution as requested
+                `resolution` and `units`. The shape of `coordinates_list` is (N, K)
+                where N is the number of coordinate sets and K is either 2 for centroids
+                or 4 for bounding boxes. When using the default `func=None`, K should be
+                4, as we expect the `coordinates_list` to be refer to bounding boxes in
+                `[start_x, start_y, end_x, end_y]` format.
             coord_resolution (float): the resolution value at which coordinates_list are
-              generated.
-            coord_resolution (str): the resolution unit at which coordinates_list are
-              generated.
-            mask_resolution (floar): resolution at which mask array is extracted. It is
-              supposed to be in the same units as `coord_resolution` i.e.,
-              `coord_units`. If not provided, a default value will be selected based on
-              `coord_units`.
+                generated.
+            coord_units (str): the resolution unit at which coordinates_list are
+                generated.
+            mask_resolution (float): resolution at which mask array is extracted. It is
+                supposed to be in the same units as `coord_resolution` i.e.,
+                `coord_units`. If not provided, a default value will be selected based on
+                `coord_units`.
 
         Returns:
             ndarray: list of flags to indicate which coordinate is valid.
@@ -284,26 +284,30 @@ class PatchExtractor(ABC):
     def filter_coordinates(
         mask_reader, coordinates_list, func=None, resolution=None, units=None
     ):
-        """
-        Indicates which coordinate is valid for mask-based patch extraction.
+        """Indicates which coordinate is valid for mask-based patch extraction.
         Locations are being validated by a custom or build-in `func`.
 
         Args:
             mask_reader (:class:`.VirtualReader`): a virtual pyramidal reader of the
-              mask related to the WSI from which we want to extract the patches.
+                mask related to the WSI from which we want to extract the patches.
             coordinates_list (ndarray and np.int32): Coordinates to be checked
-              via the `func`. They must be in the same resolution as requested
-              `resolution` and `units`. The shape of `coordinates_list` is (N, K)
-              where N is the number of coordinate sets and K is either 2 for centroids
-              or 4 for bounding boxes. When using the default `func=None`, K should be
-              4, as we expect the `coordinates_list` to be refer to bounding boxes in
-              `[start_x, start_y, end_x, end_y]` format.
+                via the `func`. They must be in the same resolution as requested
+                `resolution` and `units`. The shape of `coordinates_list` is (N, K)
+                where N is the number of coordinate sets and K is either 2 for centroids
+                or 4 for bounding boxes. When using the default `func=None`, K should be
+                4, as we expect the `coordinates_list` to be refer to bounding boxes in
+                `[start_x, start_y, end_x, end_y]` format.
             func: The coordinate validator function. A function that takes `reader` and
-              `coordinate` as arguments and return True or False as indication of
-              coordinate validity.
+                `coordinate` as arguments and return True or False as indication of
+                coordinate validity.
+            resolution (float): the resolution value at which coordinates_list are
+                generated.
+            units (str): the resolution unit at which coordinates_list are
+                generated.
 
         Returns:
             ndarray: list of flags to indicate which coordinate is valid.
+
         """
 
         def default_sel_func(reader: wsireader.VirtualWSIReader, coord: np.ndarray):
@@ -345,37 +349,37 @@ class PatchExtractor(ABC):
 
         Args:
             image_shape (a tuple (int, int) or :class:`numpy.ndarray` of shape (2,)):
-              This argument specifies the shape of mother image (the image we want to)
-              extract patches from) at requested `resolution` and `units` and it is
-              expected to be in (width, height) format.
+                This argument specifies the shape of mother image (the image we want to)
+                extract patches from) at requested `resolution` and `units` and it is
+                expected to be in (width, height) format.
             patch_input_shape (a tuple (int, int) or
-              :class:`numpy.ndarray` of shape (2,)): Specifies the input shape of
-              requested patches to be extracted from mother image at desired
-              `resolution` and `units`. This argument is also expected to be in
-              (width, height) format.
+                :class:`numpy.ndarray` of shape (2,)): Specifies the input shape of
+                requested patches to be extracted from mother image at desired
+                `resolution` and `units`. This argument is also expected to be in
+                (width, height) format.
             patch_output_shape (a tuple (int, int) or
-              :class:`numpy.ndarray` of shape (2,)): Specifies the output shape of
-              requested patches to be extracted from mother image at desired
-              `resolution` and `units`. This argument is also expected to be in
-              (width, height) format. If this is not provided, `patch_output_shape`
-              will be the same as `patch_input_shape`.
+                :class:`numpy.ndarray` of shape (2,)): Specifies the output shape of
+                requested patches to be extracted from mother image at desired
+                `resolution` and `units`. This argument is also expected to be in
+                (width, height) format. If this is not provided, `patch_output_shape`
+                will be the same as `patch_input_shape`.
             stride_shape (a tuple (int, int) or :class:`numpy.ndarray` of shape (2,)):
-              The stride that is used to calcualte the patch location during the patch
-              extraction. If `patch_output_shape` is provided, next stride location
-              will base on the output rather than the input.
+                The stride that is used to calcualte the patch location during the patch
+                extraction. If `patch_output_shape` is provided, next stride location
+                will base on the output rather than the input.
             input_within_bound (bool): Whether to include the patches where their
-              `input` location exceed the margins of mother image. If `True`, the
-              patches with input location exceeds the `image_shape` would be
-              neglected. Otherwise, those patches would be extracted with `Reader`
-              function and appropriate padding.
+                `input` location exceed the margins of mother image. If `True`, the
+                patches with input location exceeds the `image_shape` would be
+                neglected. Otherwise, those patches would be extracted with `Reader`
+                function and appropriate padding.
             output_within_bound (bool): Whether to include the patches where their
-              `output` location exceed the margins of mother image. If `True`, the
-              patches with output location exceeds the `image_shape` would be
-              neglected. Otherwise, those patches would be extracted with `Reader`
-              function and appropriate padding.
+                `output` location exceed the margins of mother image. If `True`, the
+                patches with output location exceeds the `image_shape` would be
+                neglected. Otherwise, those patches would be extracted with `Reader`
+                function and appropriate padding.
 
         Return:
-            coord_list: a list of corrdinates in `[start_x, start_y, end_x, end_y]`
+            coord_list: a list of coordinates in `[start_x, start_y, end_x, end_y]`
             format to be used for patch extraction.
 
         """
@@ -458,7 +462,7 @@ class SlidingWindowPatchExtractor(PatchExtractor):
 
     Args:
         stride(int or tuple(int)): stride in (x, y) direction for patch extraction,
-          default = patch_size
+            default = patch_size
 
     Attributes:
         stride(tuple(int)): stride in (x, y) direction for patch extraction.
@@ -503,10 +507,10 @@ class PointsPatchExtractor(PatchExtractor):
 
     Args:
         locations_list(ndarray, pd.DataFrame, str, pathlib.Path): contains location
-          and/or type of patch. This can be path to csv, npy or json files. Input can
-          also be a :class:`numpy.ndarray` or :class:`pandas.DataFrame`.
-          NOTE: value of location $(x,y)$ is expected to be based on the specified
-          `resolution` and `units` (not the `'baseline'` resolution).
+            and/or type of patch. This can be path to csv, npy or json files. Input can
+            also be a :class:`numpy.ndarray` or :class:`pandas.DataFrame`.
+            NOTE: value of location $(x,y)$ is expected to be based on the specified
+            `resolution` and `units` (not the `'baseline'` resolution).
 
     """
 
@@ -545,7 +549,7 @@ def get_patch_extractor(method_name, **kwargs):
 
     Args:
         method_name (str): name of patch extraction method, must be one of "point" or
-          "slidingwindow".
+            "slidingwindow".
         **kwargs: Keyword arguments passed to :obj:`PatchExtractor`.
 
     Returns:

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -142,7 +142,7 @@ class PatchExtractor(ABC):
         return self[n]
 
     def __getitem__(self, item):
-        if type(item) is not int:
+        if isinstance(item, int):
             raise TypeError("Index should be an integer.")
 
         if item >= self.locations_df.shape[0]:
@@ -228,8 +228,8 @@ class PatchExtractor(ABC):
                 or 4 for bounding boxes. When using the default `func=None`, K should be
                 4, as we expect the `coordinates_list` to be refer to bounding boxes in
                 `[start_x, start_y, end_x, end_y]` format.
-            coordinate_resolution (float): the resolution value at which coordinates_list are
-                generated.
+            coordinate_resolution (float): the resolution value at which
+                coordinates_list are generated.
             coordinate_units (str): the resolution unit at which coordinates_list are
                 generated.
             mask_resolution (float): resolution at which mask array is extracted. It is

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -328,8 +328,8 @@ class PatchExtractor(ABC):
             raise ValueError("`coordinates_list` should be ndarray of integer type.")
         if func is None and coordinates_list.shape[-1] != 4:
             raise ValueError(
-                "Default `func` does not support "
-                "`coordinates_list` of shape {}.".format(coordinates_list.shape)
+                f"Default `func` does not support "
+                f"`coordinates_list` of shape {coordinates_list.shape}."
             )
         func = default_sel_func if func is None else func
         flag_list = [func(mask_reader, coord) for coord in coordinates_list]

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -38,17 +38,17 @@ class PatchExtractor(ABC):
         input_mask(str, pathlib.Path, :class:`numpy.ndarray`, or :obj:`WSIReader`):
             input mask that is used for position filtering when extracting patches
             i.e., patches will only be extracted based on the highlighted regions in
-            the input_mask. input_mask can be either path to the mask, a numpy
+            the `input_mask`. `input_mask` can be either path to the mask, a numpy
             array, :class:`VirtualWSIReader`, or one of 'otsu' and 'morphological'
             options. In case of 'otsu' or 'morphological', a tissue mask is generated
             for the input_image using tiatoolbox :class:`TissueMasker` functionality.
         resolution (int or float or tuple of float): resolution at
             which to read the image, default = 0. Either a single
-            number or a sequence of two numbers for x and y are
+            number or a sequence of two numbers for `x` and `y` are
             valid. This value is in terms of the corresponding
-            units. For example: resolution=0.5 and units="mpp" will
+            units. For example: `resolution`=0.5 and `units`="mpp" will
             read the slide at 0.5 microns per-pixel, and
-            resolution=3, units="level" will read at level at
+            `resolution`=3, `units`="level" will read at level at
             pyramid level / resolution layer 3.
         units (str): the units of resolution, default = "level".
             Supported units are: microns per pixel (mpp), objective
@@ -56,7 +56,7 @@ class PatchExtractor(ABC):
             Only pyramid / resolution levels (level) embedded in
             the whole slide image are supported.
         pad_mode (str): Method for padding at edges of the WSI. Default
-            to 'constant'. See :func:`numpy.pad` for more information.
+            to `constant`. See :func:`numpy.pad` for more information.
         pad_constant_values (int or tuple(int)): Values to use with
             constant padding. Defaults to 0. See :func:`numpy.pad` for
             more.
@@ -83,7 +83,7 @@ class PatchExtractor(ABC):
         pad_constant_values (int or tuple(int)): Values to use with
             constant padding. Defaults to 0. See :func:`numpy.pad` for
             more.
-        stride (tuple(int)): stride in (x, y) direction for patch extraction. Not used
+        stride (tuple(int)): stride in `(x, y)` direction for patch extraction. Not used
             for :obj:`PointsPatchExtractor`
 
     """
@@ -196,7 +196,7 @@ class PatchExtractor(ABC):
             if len(self.coordinate_list) == 0:
                 raise ValueError(
                     "No candidate coordinates left after "
-                    "filtering by input_mask positions."
+                    "filtering by `input_mask` positions."
                 )
 
         data = self.coordinate_list[:, :2]  # only use the x_start and y_start
@@ -229,13 +229,13 @@ class PatchExtractor(ABC):
                 4, as we expect the `coordinates_list` to be referred to bounding boxes
                 in `[start_x, start_y, end_x, end_y]` format.
             coordinate_resolution (float): the resolution value at which
-                coordinates_list are generated.
+                `coordinates_list` are generated.
             coordinate_units (str): the resolution unit at which coordinates_list are
                 generated.
             mask_resolution (float): resolution at which mask array is extracted. It is
                 supposed to be in the same units as `coord_resolution` i.e.,
-                `coord_units`. If not provided, a default value will be selected based
-                on `coord_units`.
+                `coordinate_units`. If not provided, a default value will be selected
+                based on `coordinate_units`.
 
         Returns:
             ndarray: list of flags to indicate which coordinate is valid.
@@ -466,7 +466,7 @@ class SlidingWindowPatchExtractor(PatchExtractor):
         input_mask(str, pathlib.Path, :class:`numpy.ndarray`, or :obj:`WSIReader`):
             input mask that is used for position filtering when extracting patches
             i.e., patches will only be extracted based on the highlighted regions in
-            the input_mask. input_mask can be either path to the mask, a numpy
+            the `input_mask`. `input_mask` can be either path to the mask, a numpy
             array, :class:`VirtualWSIReader`, or one of 'otsu' and 'morphological'
             options. In case of 'otsu' or 'morphological', a tissue mask is generated
             for the input_image using tiatoolbox :class:`TissueMasker` functionality.
@@ -495,7 +495,7 @@ class SlidingWindowPatchExtractor(PatchExtractor):
             exceed the mother image dimensions would be neglected.
             Default is False.
         stride(int or tuple(int)): stride in (x, y) direction for patch extraction,
-            default = patch_size
+            default = `patch_size`
 
     Attributes:
         stride(tuple(int)): stride in (x, y) direction for patch extraction.
@@ -549,7 +549,7 @@ class PointsPatchExtractor(PatchExtractor):
         input_mask(str, pathlib.Path, :class:`numpy.ndarray`, or :obj:`WSIReader`):
             input mask that is used for position filtering when extracting patches
             i.e., patches will only be extracted based on the highlighted regions in
-            the input_mask. input_mask can be either path to the mask, a numpy
+            the `input_mask`. `input_mask` can be either path to the mask, a numpy
             array, :class:`VirtualWSIReader`, or one of 'otsu' and 'morphological'
             options. In case of 'otsu' or 'morphological', a tissue mask is generated
             for the input_image using tiatoolbox :class:`TissueMasker` functionality.
@@ -618,7 +618,7 @@ def get_patch_extractor(method_name, **kwargs):
 
     Args:
         method_name (str): name of patch extraction method, must be one of "point" or
-            "slidingwindow".
+            "slidingwindow". The method name is case-insensitive.
         **kwargs: Keyword arguments passed to :obj:`PatchExtractor`.
 
     Returns:


### PR DESCRIPTION
- Fix flake8 errors and typos in `patchextraction.py`
- Replace ValueError with a warning if empty list of points is passed.