### PR TITLE
DEV: Dependency upgrades

### DIFF
--- a/requirements.dev.conda.yml
+++ b/requirements.dev.conda.yml
@@ -7,10 +7,12 @@ channels:
 dependencies:
   - albumentations
   - black>=21
+  - bump2version==1.0.1
   - Click>=7.0
+  - coverage==6.3.2
   - cython
   - defusedxml
-  - flake8
+  - flake8==4.0.1
   - flake8-bugbear
   - flask
   - glymur>=0.9.7
@@ -28,7 +30,7 @@ dependencies:
   - pixman!=0.38.0
   - pre-commit
   - pydicom # Used by wsidicom
-  - pytest-cov
+  - pytest-cov==3.0.0
   - pytest-runner>=5.2
   - pytest>=6.2.5
   - python=3.7
@@ -41,10 +43,13 @@ dependencies:
   - shapely
   - sphinx-gallery
   - tifffile>2021.10.0
+  - toml==0.10.2
   - torchvision>=0.10.1
   - tox
   - tqdm
+  - twine==3.8.0
   - umap-learn
+  - wheel==0.37.1
   - zarr
   - pip:
       - openslide-python>=1.1.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@ albumentations
 black>=21.4b0
 bump2version==1.0.1
 Click>=7.0
-coverage[toml]==6.3.2
+coverage==6.3.2
 flake8-bugbear
 flake8==4.0.1
 flask
@@ -31,6 +31,7 @@ sphinx>=4.1.2
 sphinx-gallery
 sphinx-toolbox
 tifffile>2021.10.0
+toml==0.10.2
 torch>=1.9.0
 torchvision>=0.10.1
 tox

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -37,7 +37,6 @@ tox
 tqdm
 twine==3.8.0
 umap-learn
-watchdog==0.9.0
 wheel==0.33.6
 wsidicom
 zarr

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 albumentations
 black>=21.4b0
-bump2version==0.5.11
+bump2version==1.0.1
 Click>=7.0
 coverage==5.1
 flake8-bugbear

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ bump2version==0.5.11
 Click>=7.0
 coverage==5.1
 flake8-bugbear
-flake8==3.7.8
+flake8==4.0.1
 flask
 glymur>=0.9.7
 imagecodecs>2021.10.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -35,7 +35,7 @@ torch>=1.9.0
 torchvision>=0.10.1
 tox
 tqdm
-twine==1.14.0
+twine==3.8.0
 umap-learn
 watchdog==0.9.0
 wheel==0.33.6

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@ albumentations
 black>=21.4b0
 bump2version==1.0.1
 Click>=7.0
-coverage==5.1
+coverage[toml]==6.3.2
 flake8-bugbear
 flake8==4.0.1
 flask

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -37,6 +37,6 @@ tox
 tqdm
 twine==3.8.0
 umap-learn
-wheel==0.33.6
+wheel==0.37.1
 wsidicom
 zarr

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,7 +18,7 @@ pillow
 pip>=20.0.2
 pre-commit
 pydicom # Used by wsidicom
-pytest-cov==2.9.0
+pytest-cov==3.0.0
 pytest-runner>=5.2
 pytest>=6.2.5
 pyyaml>=5.1

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ conda_channels=
 passenv =
     TRAVIS CI
 deps =
-    pytest-cov==2.9.0
+    pytest-cov==3.0.0
     pytest-runner==5.2
     pytest==6.2.5
     coverage[toml]==6.3.2

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,8 @@ deps =
     pytest-cov==3.0.0
     pytest-runner==5.2
     pytest==6.2.5
-    coverage[toml]==6.3.2
+    coverage==6.3.2
+    toml==0.10.2
     -r{toxinidir}/requirements.txt
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following line:

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     pytest-cov==2.9.0
     pytest-runner==5.2
     pytest==6.2.5
-    coverage==5.1
+    coverage[toml]==6.3.2
     -r{toxinidir}/requirements.txt
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following line:


### PR DESCRIPTION
- [DEP: Bump flake8 from 3.7.8 to 4.0.1](https://github.com/TissueImageAnalytics/tiatoolbox/commit/4ba0c3ba4eda3f7a729707e9c53ea29372c6eb0d)
- [DEP: Bump twine from 1.14.0 to 3.8.0](https://github.com/TissueImageAnalytics/tiatoolbox/commit/1e63d9a857ec1eda03839fad5b812668d1dac248)
- [DEP: Bump bump2version from 0.5.11 to 1.0.1](https://github.com/TissueImageAnalytics/tiatoolbox/commit/d33fefba3269fbb96f0bef5d828bec2a2cf638ef)
- [DEP: Remove watchdog from dependency list](https://github.com/TissueImageAnalytics/tiatoolbox/commit/0ac321690b6730267a2e5619ce36675280d8eaba)
- [DEP: Bump coverage from 5.1 to 6.3.2](https://github.com/TissueImageAnalytics/tiatoolbox/commit/8c2d97fae5d201c315a6ef3e19c38d8372ad2da6)
- [DEP: Bump wheel from 0.33.6 to 0.37.1](https://github.com/TissueImageAnalytics/tiatoolbox/commit/0e2251b71004ff7125773adb5b75b18cf5ef3129)
- [DEP: Bump pytest-cov from 2.9.0 to 3.0.0](https://github.com/TissueImageAnalytics/tiatoolbox/commit/bf3d630be035df15265255134436d946a0168bcd)
- Update `requirements.dev.conda.yml` accordingly.