### PR TITLE
DEV: Fix Makefile Docs Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ instance/
 docs/_build/
 docs/_notebooks/
 docs/_autosummary/
+docs/modules.rst
+docs/tiatoolbox.rst
+docs/tiatoolbox.*.rst
 
 # PyBuilder
 target/

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,12 @@ clean-test: ## remove test and coverage artifacts
 
 clean-docs: ## remove documentation artifacts
 	rm -fr docs/_build/
+	rm -rf docs/_autosummary/
+	rm -rf docs/_notebooks/
 	rm -fr docs/html/
 	rm -f docs/tiatoolbox.rst
 	rm -f docs/modules.rst
-	rm -rf docs/_autosummary/
+
 
 lint: ## check style with flake8
 	flake8 tiatoolbox tests

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ clean-docs: ## remove documentation artifacts
 	rm -fr docs/html/
 	rm -f docs/tiatoolbox.rst
 	rm -f docs/modules.rst
+	rm -f docs/tiatoolbox.*.rst
 
 
 lint: ## check style with flake8

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ BROWSER := python -c "$$BROWSER_PYSCRIPT"
 help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
-clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+clean: clean-build clean-pyc clean-test clean-docs ## remove all build, test, coverage and Python artifacts
 
 clean-build: ## remove build artifacts
 	rm -fr build/

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,13 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
 
+clean-docs: ## remove documentation artifacts
+	rm -fr docs/_build/
+	rm -fr docs/html/
+	rm -f docs/tiatoolbox.rst
+	rm -f docs/modules.rst
+	rm -rf docs/_autosummary/
+
 lint: ## check style with flake8
 	flake8 tiatoolbox tests
 
@@ -60,10 +67,7 @@ coverage: ## check code coverage quickly with the default Python
 	pytest  --cov=tiatoolbox --cov-report=term --cov-report=html --cov-report=xml
 	$(BROWSER) htmlcov/index.html
 
-docs: ## generate Sphinx HTML documentation, including API docs
-	rm -f docs/tiatoolbox.rst
-	rm -f docs/modules.rst
-	rm -f docs/_autosummary
+docs: clean-docs ## generate Sphinx HTML documentation, including API docs
 	sphinx-apidoc -o docs/ tiatoolbox
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ clean-docs: ## remove documentation artifacts
 	rm -f docs/modules.rst
 	rm -f docs/tiatoolbox.*.rst
 
-
 lint: ## check style with flake8
 	flake8 tiatoolbox tests
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ clean-docs: ## remove documentation artifacts
 	rm -fr docs/_build/
 	rm -rf docs/_autosummary/
 	rm -rf docs/_notebooks/
-	rm -fr docs/html/
+	rm -rf docs/html/
 	rm -f docs/tiatoolbox.rst
 	rm -f docs/modules.rst
 	rm -f docs/tiatoolbox.*.rst


### PR DESCRIPTION
There was a bug in `make docs` where it would try to remove a directory `rm docs/_autosummary` without the required `-r` option. This has been fixed in this PR. Also,  a `clean-docs` command has been added in addition to including generated files in the .gitignore file.