### PR TITLE
TST: Make Stain Norm CLI Tests Use Temp Dir

### DIFF
--- a/tests/models/test_arch_micronet.py
+++ b/tests/models/test_arch_micronet.py
@@ -47,7 +47,7 @@ def test_functionality(remote_sample, tmp_path):
     patch = MicroNet.preproc(patch)
     batch = torch.from_numpy(patch)[None]
     model = MicroNet()
-    fetch_pretrained_weights("micronet_hovernet-consep", f"{tmp_path}/weights.pth")
+    fetch_pretrained_weights("micronet-consep", f"{tmp_path}/weights.pth")
     map_location = utils.misc.select_device(utils.env_detection.has_gpu())
     pretrained = torch.load(f"{tmp_path}/weights.pth", map_location=map_location)
     model.load_state_dict(pretrained)
@@ -70,7 +70,7 @@ def test_micronet_output(remote_sample, tmp_path):
     """Tests the output of MicroNet."""
     svs_1_small = pathlib.Path(remote_sample("svs-1-small"))
     micronet_output = pathlib.Path(remote_sample("micronet-output"))
-    pretrained_model = "micronet_hovernet-consep"
+    pretrained_model = "micronet-consep"
     batch_size = 5
     num_loader_workers = 0
     num_postproc_workers = 0

--- a/tests/test_stainnorm.py
+++ b/tests/test_stainnorm.py
@@ -152,7 +152,7 @@ def test_vahadane_normalize(source_image, norm_vahadane):
 # -------------------------------------------------------------------------------------
 
 
-def test_command_line_stainnorm(source_image):
+def test_command_line_stainnorm(source_image, tmp_path):
     """Test for the stain normalization CLI."""
     source_img = pathlib.Path(source_image)
     target_img = _local_sample_path("target_image.png")
@@ -165,6 +165,8 @@ def test_command_line_stainnorm(source_image):
             source_img,
             "--target-input",
             target_img,
+            "--output-path",
+            str(tmp_path / "stainnorm_output"),
             "--method",
             "reinhard",
         ],
@@ -180,6 +182,8 @@ def test_command_line_stainnorm(source_image):
             source_img,
             "--target-input",
             target_img,
+            "--output-path",
+            str(tmp_path / "stainnorm_output"),
             "--method",
             "ruifrok",
         ],
@@ -195,6 +199,8 @@ def test_command_line_stainnorm(source_image):
             source_img,
             "--target-input",
             target_img,
+            "--output-path",
+            str(tmp_path / "stainnorm_output"),
             "--method",
             "macenko",
         ],
@@ -210,6 +216,8 @@ def test_command_line_stainnorm(source_image):
             source_img,
             "--target-input",
             target_img,
+            "--output-path",
+            str(tmp_path / "stainnorm_output"),
             "--method",
             "vahadane",
         ],
@@ -218,7 +226,7 @@ def test_command_line_stainnorm(source_image):
     assert stainnorm_result.exit_code == 0
 
 
-def test_cli_stainnorm_dir(source_image):
+def test_cli_stainnorm_dir(source_image, tmp_path):
     """Test directory input for the stain normalization CLI."""
     source_img = source_image.parent
     target_img = _local_sample_path("target_image.png")
@@ -231,6 +239,8 @@ def test_cli_stainnorm_dir(source_image):
             str(source_img),
             "--target-input",
             target_img,
+            "--output-path",
+            str(tmp_path / "stainnorm_ouput"),
             "--method",
             "vahadane",
         ],
@@ -239,7 +249,7 @@ def test_cli_stainnorm_dir(source_image):
     assert stainnorm_result.exit_code == 0
 
 
-def test_cli_stainnorm_file_not_found_error(source_image):
+def test_cli_stainnorm_file_not_found_error(source_image, tmp_path):
     """Test file not found error for the stain normalization CLI."""
     source_img = pathlib.Path(source_image)
     target_img = stain_norm_target()
@@ -252,6 +262,8 @@ def test_cli_stainnorm_file_not_found_error(source_image):
             str(source_img)[:-1],
             "--target-input",
             target_img,
+            "--output-path",
+            str(tmp_path / "stainnorm_output"),
             "--method",
             "vahadane",
         ],
@@ -262,7 +274,7 @@ def test_cli_stainnorm_file_not_found_error(source_image):
     assert isinstance(stainnorm_result.exception, FileNotFoundError)
 
 
-def test_cli_stainnorm_method_not_supported(source_image):
+def test_cli_stainnorm_method_not_supported(source_image, tmp_path):
     """Test method not supported for the stain normalization CLI."""
     source_img = pathlib.Path(source_image)
     target_img = stain_norm_target()
@@ -275,6 +287,8 @@ def test_cli_stainnorm_method_not_supported(source_image):
             str(source_img),
             "--target-input",
             target_img,
+            "--output-path",
+            str(tmp_path / "stainnorm_output"),
             "--method",
             "Test",
         ],

--- a/tiatoolbox/data/pretrained_model.yaml
+++ b/tiatoolbox/data/pretrained_model.yaml
@@ -726,8 +726,8 @@ hovernetplus-oed:
             stride_shape: [164, 164]
             save_resolution: {'units': 'mpp', 'resolution': 0.50}
 
-micronet_hovernet-consep:
-    url: https://tiatoolbox.dcs.warwick.ac.uk/models/seg/micronet_hovernet-consep.pth
+micronet-consep:
+    url: https://tiatoolbox.dcs.warwick.ac.uk/models/seg/micronet-consep.pth
     architecture:
         class: micronet.MicroNet
         kwargs:

--- a/tiatoolbox/models/architecture/micronet.py
+++ b/tiatoolbox/models/architecture/micronet.py
@@ -334,7 +334,7 @@ def out_arch_branch(in_ch, num_class=2):
 class MicroNet(ModelABC):
     """Initialise MicroNet [1].
     The following models have been included in tiatoolbox.
-    1. `micronet_hovernet-consep`: This is trained on
+    1. `micronet-consep`: This is trained on
     `ConSep dataset <https://warwick.ac.uk/fac/cross_fac/tia/data/hovernet/>`_
     The model is retrained in torch as the original model with results on ConSep [2]
     was trained in TensorFlow.
@@ -367,12 +367,12 @@ class MicroNet(ModelABC):
         num_class (int): Number of output channels. default=2.
 
     References:
-        [1] Raza, SEA et al., “Micro-Net: A unified model for segmentation of
-        various objects in microscopy images,” Medical Image Analysis,
-        Dec. 2018, vol. 52, p. 160–173.
+        [1] Raza, Shan E Ahmed, et al. "Micro-Net: A unified model for
+        segmentation of various objects in microscopy images."
+        Medical image analysis 52 (2019): 160-173.
 
-        [2] Graham, Simon, et al. "Hover-net: Simultaneous segmentation and
-        classification of nuclei in multi-tissue histology images."
+        [2] Graham, Simon, et al. "Hover-net: Simultaneous segmentation
+        and classification of nuclei in multi-tissue histology images."
         Medical Image Analysis 58 (2019): 101563.
 
     """


### PR DESCRIPTION
Fix the stain normalisation CLI test which would dump output into the project root directory by specifying an output to a temporary test directory.