### PR TITLE
MAINT: Add Checks To User Provided Paths

### DIFF
--- a/tests/test_annotation_stores.py
+++ b/tests/test_annotation_stores.py
@@ -1,3 +1,4 @@
+  # skipcq: PTC-W6004
 """Tests for annotation store classes."""
 import json
 import pickle
@@ -185,8 +186,8 @@ def test_sqlite_store_compile_options_missing_math(monkeypatch, caplog):
 
 
 def test_sqlite_store_multiple_connection(tmp_path):
-    store = SQLiteStore(tmp_path / "annotations.db")
-    store2 = SQLiteStore(tmp_path / "annotations.db")
+    store = SQLiteStore(tmp_path / "annotations.db")  
+    store2 = SQLiteStore(tmp_path / "annotations.db")  
     assert len(store) == len(store2)
 
 
@@ -207,7 +208,7 @@ def test_sqlite_store_index_version_error(monkeypatch):
 
 def test_sqlite_store_index_str(fill_store, tmp_path):
     """Test that adding an index improves performance."""
-    _, store = fill_store(SQLiteStore, tmp_path / "polygon.db")
+    _, store = fill_store(SQLiteStore, tmp_path / "polygon.db")  
 
     def query():
         """Test query."""
@@ -338,7 +339,7 @@ class TestStore:
     @staticmethod
     def test_open_close(fill_store, tmp_path, store_cls):
         """Test opening and closing a store."""
-        path = tmp_path / "polygons"
+        path = tmp_path / "polygons"  
         keys, store = fill_store(store_cls, path)
         store.close()
         store2 = store.open(path)
@@ -347,7 +348,7 @@ class TestStore:
     @staticmethod
     def test_append_many(cell_grid, tmp_path, store_cls):
         """Test bulk append of annotations."""
-        store = store_cls(tmp_path / "polygons")
+        store = store_cls(tmp_path / "polygons")  
         annotations = [
             Annotation(cell, {"class": random.randint(0, 6)}) for cell in cell_grid
         ]
@@ -357,7 +358,7 @@ class TestStore:
     @staticmethod
     def test_append_many_with_keys(cell_grid, tmp_path, store_cls):
         """Test bulk append of annotations with keys."""
-        store = store_cls(tmp_path / "polygons")
+        store = store_cls(tmp_path / "polygons")  
         annotations = [
             Annotation(cell, {"class": random.randint(0, 6)}) for cell in cell_grid
         ]
@@ -369,7 +370,7 @@ class TestStore:
     @staticmethod
     def test_append_many_with_keys_len_mismatch(cell_grid, tmp_path, store_cls):
         """Test bulk append of annotations with keys of wrong length."""
-        store = store_cls(tmp_path / "polygons")
+        store = store_cls(tmp_path / "polygons")  
         annotations = [
             Annotation(cell, {"class": random.randint(0, 6)}) for cell in cell_grid
         ]
@@ -380,14 +381,14 @@ class TestStore:
     @staticmethod
     def test_query_bbox(fill_store, tmp_path, store_cls):
         """Test query with a bounding box."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         results = store.query((0, 0, 25, 25))
         assert len(results) == 8
 
     @staticmethod
     def test_iquery_bbox(fill_store, tmp_path, store_cls):
         """Test iquery with a bounding box."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         results = store.iquery((0, 0, 25, 25))
         assert len(results) == 8
         assert all(isinstance(key, str) for key in results)
@@ -395,7 +396,7 @@ class TestStore:
     @staticmethod
     def test_query_polygon(fill_store, tmp_path, store_cls):
         """Test query with a non-rectangular geometry."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         results = store.query(Polygon([(0, 0), (0, 25), (1, 1), (25, 0)]))
         assert len(results) == 6
         assert all(isinstance(ann, Annotation) for ann in results)
@@ -403,7 +404,7 @@ class TestStore:
     @staticmethod
     def test_iquery_polygon(fill_store, tmp_path, store_cls):
         """Test iquery with a non-rectangular geometry."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         results = store.iquery(Polygon([(0, 0), (0, 25), (1, 1), (25, 0)]))
         assert len(results) == 6
         assert all(isinstance(key, str) for key in results)
@@ -411,7 +412,9 @@ class TestStore:
     @staticmethod
     def test_patch(fill_store, tmp_path, store_cls):
         """Test patching an annotation."""
-        keys, store = fill_store(store_cls, tmp_path / "polygon.db")
+        keys, store = fill_store(
+            store_cls, tmp_path / "polygon.db"
+        )  
         key = keys[0]
         new_geometry = Polygon([(0, 0), (1, 1), (2, 2)])
         # Geometry update
@@ -424,7 +427,7 @@ class TestStore:
     @staticmethod
     def test_patch_append(fill_store, tmp_path, store_cls):
         """Test patching an annotation that does not exist."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         new_geometry = Polygon([(0, 0), (1, 1), (2, 2)])
         store.patch("foo", new_geometry)
         assert store["foo"].geometry == new_geometry
@@ -432,7 +435,9 @@ class TestStore:
     @staticmethod
     def test_patch_many(fill_store, tmp_path, store_cls):
         """Test bulk patch."""
-        keys, store = fill_store(store_cls, tmp_path / "polygon.db")
+        keys, store = fill_store(
+            store_cls, tmp_path / "polygon.db"  
+        )
         new_geometry = Polygon([(0, 0), (1, 1), (2, 2)])
         store.patch_many(
             keys, repeat(new_geometry, len(keys)), repeat({"abc": 123}, len(keys))
@@ -445,7 +450,9 @@ class TestStore:
     @staticmethod
     def test_patch_many_no_properies(fill_store, tmp_path, store_cls):
         """Test bulk patch with no properties."""
-        keys, store = fill_store(store_cls, tmp_path / "polygon.db")
+        keys, store = fill_store(
+            store_cls, tmp_path / "polygon.db"  
+        )
         new_geometry = Polygon([(0, 0), (1, 1), (2, 2)])
         store.patch_many(keys, repeat(new_geometry, len(keys)))
 
@@ -456,7 +463,9 @@ class TestStore:
     @staticmethod
     def test_patch_many_no_geometry(fill_store, tmp_path, store_cls):
         """Test bulk patch with no geometry."""
-        keys, store = fill_store(store_cls, tmp_path / "polygon.db")
+        keys, store = fill_store(
+            store_cls, tmp_path / "polygon.db"  
+        )
         store.patch_many(keys, properties_iter=repeat({"abc": 123}, len(keys)))
 
         for _, key in enumerate(keys[:10]):
@@ -466,14 +475,16 @@ class TestStore:
     @staticmethod
     def test_patch_many_no_geometry_no_properties(fill_store, tmp_path, store_cls):
         """Test bulk patch with no geometry and no properties."""
-        keys, store = fill_store(store_cls, tmp_path / "polygon.db")
+        keys, store = fill_store(
+            store_cls, tmp_path / "polygon.db"
+        )  
         with pytest.raises(ValueError, match="At least one"):
             store.patch_many(keys)
 
     @staticmethod
     def test_patch_many_append(fill_store, tmp_path, store_cls):
         """Test bulk patching annotations that do not exist."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         new_geometry = Polygon([(0, 0), (1, 1), (2, 2)])
         store.patch_many(["foo", "bar"], repeat(new_geometry, 2))
         assert store["foo"].geometry == new_geometry
@@ -482,7 +493,9 @@ class TestStore:
     @staticmethod
     def test_patch_many_len_mismatch(fill_store, tmp_path, store_cls):
         """Test bulk patch with wrong number of keys."""
-        keys, store = fill_store(store_cls, tmp_path / "polygon.db")
+        keys, store = fill_store(
+            store_cls, tmp_path / "polygon.db"
+        )  
         new_geometry = Polygon([(0, 0), (1, 1), (2, 2)])
         with pytest.raises(ValueError, match="equal"):
             store.patch_many(keys[1:], repeat(new_geometry, 10))
@@ -490,7 +503,9 @@ class TestStore:
     @staticmethod
     def test_keys(fill_store, tmp_path, store_cls):
         """Test getting an keys iterator."""
-        keys, store = fill_store(store_cls, tmp_path / "polygon.db")
+        keys, store = fill_store(
+            store_cls, tmp_path / "polygon.db"  
+        )
         keys = list(keys)
         assert len(list(store.keys())) == len(keys)
         assert isinstance(list(store.keys())[0], type(keys[0]))
@@ -498,7 +513,9 @@ class TestStore:
     @staticmethod
     def test_remove(fill_store, tmp_path, store_cls):
         """Test removing an annotation."""
-        keys, store = fill_store(store_cls, tmp_path / "polygon.db")
+        keys, store = fill_store(
+            store_cls, tmp_path / "polygon.db"
+        )  
         key = keys[0]
         store.remove(key)
         assert len(store) == FILLED_LEN - 1
@@ -506,7 +523,9 @@ class TestStore:
     @staticmethod
     def test_delitem(fill_store, tmp_path, store_cls):
         """Test using the delitem syntax."""
-        keys, store = fill_store(store_cls, tmp_path / "polygon.db")
+        keys, store = fill_store(
+            store_cls, tmp_path / "polygon.db"  
+        )
         key = keys[0]
         del store[key]
         assert len(store) == FILLED_LEN - 1
@@ -514,34 +533,40 @@ class TestStore:
     @staticmethod
     def test_remove_many(fill_store, tmp_path, store_cls):
         """Test bulk deletion."""
-        keys, store = fill_store(store_cls, tmp_path / "polygon.db")
+        keys, store = fill_store(
+            store_cls, tmp_path / "polygon.db"
+        )  
         store.remove_many(keys)
         assert len(store) == 0
 
     @staticmethod
     def test_len(fill_store, tmp_path, store_cls):
         """Test finding the number of annotation via the len operator."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         assert len(store) == FILLED_LEN
 
     @staticmethod
     def test_contains(fill_store, tmp_path, store_cls):
         """Test using the contains (in) operator."""
-        keys, store = fill_store(store_cls, tmp_path / "polygon.db")
+        keys, store = fill_store(
+            store_cls, tmp_path / "polygon.db"  
+        )
         for key in keys:
             assert key in store
 
     @staticmethod
     def test_iter(fill_store, tmp_path, store_cls):
         """Test iterating over the store."""
-        keys, store = fill_store(store_cls, tmp_path / "polygon.db")
+        keys, store = fill_store(
+            store_cls, tmp_path / "polygon.db"  
+        )
         for key in store:
             assert key in keys
 
     @staticmethod
     def test_getitem(fill_store, tmp_path, sample_triangle, store_cls):
         """Test the getitem syntax."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         key = store.append(Annotation(sample_triangle))
         annotation = store[key]
         assert annotation.geometry == sample_triangle
@@ -550,7 +575,7 @@ class TestStore:
     @staticmethod
     def test_setitem(fill_store, tmp_path, sample_triangle, store_cls):
         """Test the setitem syntax."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         key = store.append(Annotation(sample_triangle))
         new_geometry = Polygon([(0, 0), (1, 1), (2, 2)])
         new_properties = {"abc": 123}
@@ -560,7 +585,7 @@ class TestStore:
     @staticmethod
     def test_getitem_setitem_cycle(fill_store, tmp_path, sample_triangle, store_cls):
         """Test getting an setting an annotation."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         key = store.append(Annotation(sample_triangle, {"class": 0}))
         annotation = store[key]
         store[key] = annotation
@@ -586,7 +611,7 @@ class TestStore:
     @staticmethod
     def test_to_dataframe(fill_store, tmp_path, store_cls):
         """Test converting to a pandas dataframe."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         df = store.to_dataframe()
         assert isinstance(df, pd.DataFrame)
         assert len(df) == FILLED_LEN
@@ -597,7 +622,7 @@ class TestStore:
     @staticmethod
     def test_features(fill_store, tmp_path, store_cls):
         """Test converting to a features dictionaries."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         features = store.features()
         assert isinstance(features, Generator)
         features = list(features)
@@ -610,7 +635,7 @@ class TestStore:
     @staticmethod
     def test_to_geodict(fill_store, tmp_path, store_cls):
         """Test converting to a geodict."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         geodict = store.to_geodict()
         assert isinstance(geodict, dict)
         assert "features" in geodict
@@ -621,7 +646,7 @@ class TestStore:
     @staticmethod
     def test_from_geojson_str(fill_store, tmp_path, store_cls):
         """Test loading from geojson with a file path string."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         geojson = store.to_geojson()
         store2 = store_cls.from_geojson(geojson)
         assert len(store) == len(store2)
@@ -629,24 +654,24 @@ class TestStore:
     @staticmethod
     def test_from_geojson_file(fill_store, tmp_path, store_cls):
         """Test loading from geojson with a file handle."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
-        store.to_geojson(tmp_path / "polygon.json")
-        with open(tmp_path / "polygon.json", "r") as file_handle:
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
+        store.to_geojson(tmp_path / "polygon.json")  
+        with open(tmp_path / "polygon.json", "r") as file_handle:  
             store2 = store_cls.from_geojson(file_handle)
         assert len(store) == len(store2)
 
     @staticmethod
     def test_from_geojson_path(fill_store, tmp_path, store_cls):
         """Test loading from geojson with a file path."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
-        store.to_geojson(tmp_path / "polygon.json")
-        store2 = store_cls.from_geojson(tmp_path / "polygon.json")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
+        store.to_geojson(tmp_path / "polygon.json")  
+        store2 = store_cls.from_geojson(tmp_path / "polygon.json")  
         assert len(store) == len(store2)
 
     @staticmethod
     def test_to_geojson_str(fill_store, tmp_path, store_cls):
         """Test exporting to ndjson with a file path string."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         geojson = store.to_geojson()
         assert isinstance(geojson, str)
         geodict = json.loads(geojson)
@@ -658,11 +683,11 @@ class TestStore:
     @staticmethod
     def test_to_geojson_file(fill_store, tmp_path, store_cls):
         """Test exporting to ndjson with a file handle."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
-        with open(tmp_path / "polygon.json", "w") as fh:
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
+        with open(tmp_path / "polygon.json", "w") as fh:  
             geojson = store.to_geojson(fp=fh)
         assert geojson is None
-        with open(tmp_path / "polygon.json", "r") as fh:
+        with open(tmp_path / "polygon.json", "r") as fh:  
             geodict = json.load(fh)
         assert "features" in geodict
         assert "type" in geodict
@@ -672,10 +697,10 @@ class TestStore:
     @staticmethod
     def test_to_geojson_path(fill_store, tmp_path, store_cls):
         """Test exporting to geojson with a file path."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
-        geojson = store.to_geojson(fp=tmp_path / "polygon.json")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
+        geojson = store.to_geojson(fp=tmp_path / "polygon.json")  
         assert geojson is None
-        with open(tmp_path / "polygon.json", "r") as fh:
+        with open(tmp_path / "polygon.json", "r") as fh:  
             geodict = json.load(fh)
         assert "features" in geodict
         assert "type" in geodict
@@ -685,7 +710,7 @@ class TestStore:
     @staticmethod
     def test_to_ndjson_str(fill_store, tmp_path, store_cls):
         """Test exporting to ndjson with a file path string."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
         ndjson = store.to_ndjson()
         for line in ndjson.split():
             assert isinstance(line, str)
@@ -697,11 +722,11 @@ class TestStore:
     @staticmethod
     def test_to_ndjson_file(fill_store, tmp_path, store_cls):
         """Test exporting to ndjson with a file handle."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
-        with open(tmp_path / "polygon.ndjson", "w") as fh:
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
+        with open(tmp_path / "polygon.ndjson", "w") as fh:  
             ndjson = store.to_ndjson(fp=fh)
         assert ndjson is None
-        with open(tmp_path / "polygon.ndjson", "r") as fh:
+        with open(tmp_path / "polygon.ndjson", "r") as fh:  
             for line in fh.readlines():
                 assert isinstance(line, str)
                 feature = json.loads(line)
@@ -712,10 +737,10 @@ class TestStore:
     @staticmethod
     def test_to_ndjson_path(fill_store, tmp_path, store_cls):
         """Test exporting to ndjson with a file path."""
-        _, store = fill_store(store_cls, tmp_path / "polygon.db")
-        ndjson = store.to_ndjson(fp=tmp_path / "polygon.ndjson")
+        _, store = fill_store(store_cls, tmp_path / "polygon.db")  
+        ndjson = store.to_ndjson(fp=tmp_path / "polygon.ndjson")  
         assert ndjson is None
-        with open(tmp_path / "polygon.ndjson", "r") as fh:
+        with open(tmp_path / "polygon.ndjson", "r") as fh:  
             for line in fh.readlines():
                 assert isinstance(line, str)
                 feature = json.loads(line)
@@ -727,16 +752,16 @@ class TestStore:
     def test_dump(fill_store, tmp_path, store_cls):
         """Test dumping to a file path."""
         _, store = fill_store(store_cls, ":memory:")
-        store.dump(tmp_path / "dump_test.db")
-        assert (tmp_path / "dump_test.db").stat().st_size > 0
+        store.dump(tmp_path / "dump_test.db")  
+        assert (tmp_path / "dump_test.db").stat().st_size > 0  
 
     @staticmethod
     def test_dump_file_handle(fill_store, tmp_path, store_cls):
         """Test dumping to a file handle."""
         _, store = fill_store(store_cls, ":memory:")
-        with open(tmp_path / "dump_test.db", "w") as fh:
+        with open(tmp_path / "dump_test.db", "w") as fh:  
             store.dump(fh)
-        assert (tmp_path / "dump_test.db").stat().st_size > 0
+        assert (tmp_path / "dump_test.db").stat().st_size > 0  
 
     @staticmethod
     def test_dumps(fill_store, store_cls):
@@ -961,7 +986,7 @@ class TestStore:
     @staticmethod
     def test_commit(fill_store, store_cls, tmp_path):
         """Test committing a store."""
-        store_path = tmp_path / "test_store"
+        store_path = tmp_path / "test_store"  
         test_store = store_cls(store_path)
         test_store["foo"] = Annotation(Point(0, 0))
         test_store.commit()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1245,6 +1245,38 @@ def test_save_as_json():
     os.remove("sample_json.json")
 
 
+def test_save_as_json_exists(tmp_path):
+    """Test save data to json which already exists."""
+    dictionary = {"a": 1, "b": 2}
+    utils.misc.save_as_json(dictionary, tmp_path / "sample_json.json")
+    with pytest.raises(FileExistsError, match="File already exists"):
+        utils.misc.save_as_json(dictionary, tmp_path / "sample_json.json")
+    utils.misc.save_as_json(dictionary, tmp_path / "sample_json.json", exist_ok=True)
+
+
+def test_save_as_json_parents(tmp_path):
+    """Test save data to json where parents need to be created."""
+    dictionary = {"a": 1, "b": 2}
+    with pytest.raises(FileNotFoundError, match="No such file or directory"):
+        utils.misc.save_as_json(dictionary, tmp_path / "foo" / "sample_json.json")
+
+
+def test_save_yaml_exists(tmp_path):
+    """Test save data to yaml which already exists."""
+    dictionary = {"a": 1, "b": 2}
+    utils.misc.save_yaml(dictionary, tmp_path / "sample_yaml.yaml")
+    with pytest.raises(FileExistsError, match="File already exists"):
+        utils.misc.save_yaml(dictionary, tmp_path / "sample_yaml.yaml")
+    utils.misc.save_yaml(dictionary, tmp_path / "sample_yaml.yaml", exist_ok=True)
+
+
+def test_save_yaml_parents(tmp_path):
+    """Test save data to yaml where parents need to be created."""
+    dictionary = {"a": 1, "b": 2}
+    with pytest.raises(FileNotFoundError, match="No such file or directory"):
+        utils.misc.save_yaml(dictionary, tmp_path / "foo" / "sample_yaml.yaml")
+
+
 def test_imread_none_args():
     img = np.zeros((10, 10, 3))
     with pytest.raises(TypeError):

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -94,12 +94,25 @@ def grab_files_from_dir(input_path, file_types=("*.jpg", "*.png", "*.tif")):
     return list(files_grabbed)
 
 
-def save_yaml(input_dict, output_path="output.yaml"):
+def save_yaml(
+    input_dict: dict,
+    output_path="output.yaml",
+    parents: bool = False,
+    exist_ok: bool = False,
+):
     """Save dictionary as yaml.
 
     Args:
-        input_dict (dict): A variable of type 'dict'
-        output_path (str or pathlib.Path): Path to save the output file
+        input_dict (dict):
+            A variable of type 'dict'
+        output_path (str or pathlib.Path):
+            Path to save the output file
+        parents (bool):
+            Make parent directories if they do not exist. Default is
+            False.
+        exist_ok (bool):
+            Overwrite the output file if it exists. Default is False.
+
 
     Returns:
 
@@ -109,7 +122,14 @@ def save_yaml(input_dict, output_path="output.yaml"):
         >>> utils.misc.save_yaml(input_dict, './hello.yaml')
 
     """
-    with open(str(pathlib.Path(output_path)), "w") as yaml_file:
+    path = pathlib.Path(output_path)
+    if path.exists() and not exist_ok:
+        raise FileExistsError("File already exists.")
+    if parents:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    with open(  # skipcq: PTC-W6004: PTC-W6004
+        str(pathlib.Path(output_path)), "w"
+    ) as yaml_file:
         yaml.dump(input_dict, yaml_file)
 
 
@@ -660,7 +680,12 @@ def __walk_dict(dct):
         dct[k] = __walk_list_dict(v)
 
 
-def save_as_json(data, save_path):
+def save_as_json(
+    data: Union[dict, list],
+    save_path: Union[str, pathlib.Path],
+    parents: bool = False,
+    exist_ok: bool = False,
+):
     """Save data to a json file.
 
     The function will deepcopy the `data` and then jsonify the content
@@ -668,8 +693,16 @@ def save_as_json(data, save_path):
     `bool` and their np.ndarray respectively.
 
     Args:
-        data (dict or list): Input data to save.
-        save_path (str): Output to save the json of `input`.
+        data (dict or list):
+            Input data to save.
+        save_path (str):
+            Output to save the json of `input`.
+        parents (bool):
+            Make parent directories if they do not exist. Default is
+            False.
+        exist_ok (bool):
+            Overwrite the output file if it exists. Default is False.
+
 
     """
     shadow_data = copy.deepcopy(data)  # make a copy of source input
@@ -681,7 +714,12 @@ def save_as_json(data, save_path):
     else:
         __walk_list(shadow_data)
 
-    with open(save_path, "w") as handle:
+    save_path = pathlib.Path(save_path)
+    if save_path.exists() and not exist_ok:
+        raise FileExistsError("File already exists.")
+    if parents:
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(save_path, "w") as handle:  # skipcq: PTC-W6004: PTC-W6004
         json.dump(shadow_data, handle)
 
 


### PR DESCRIPTION
This is to satisfy Deepsource security issues and also avoid the user from accidentally overwriting files or writing to a directory that doesn't exists.