### PR TITLE
DOC: Add Metrics Tables To Documentation

### DIFF
--- a/tiatoolbox/models/architecture/__init__.py
+++ b/tiatoolbox/models/architecture/__init__.py
@@ -49,7 +49,7 @@ def get_pretrained_model(
                 - resnet34
                 - resnet50
                 - resnet101
-                - resnext5032x4d
+                - resnext50_32x4d
                 - resnext101_32x8d
                 - wide_resnet50_2
                 - wide_resnet101_2

--- a/tiatoolbox/models/architecture/hovernet.py
+++ b/tiatoolbox/models/architecture/hovernet.py
@@ -258,7 +258,47 @@ class ResidualBlock(nn.Module):
 
 
 class HoVerNet(ModelABC):
-    """HoVerNet Architecture.
+    """Initialise HoVerNet [1].
+
+    The tiatoolbox models should produce the following results:
+
+    .. list-table:: HoVerNet segmentation performance on the Kumar dataset [2]
+       :widths: 15 15 15 15 15 15 15
+       :header-rows: 1
+
+       * - Model name
+         - Data set
+         - DICE
+         - AJI
+         - DQ
+         - SQ
+         - PQ
+       * - hovernet-original-kumar
+         - Kumar
+         - 0.83
+         - 0.62
+         - 0.77
+         - 0.77
+         - 0.60
+    
+    .. list-table:: HoVerNet segmentation performance on the CoNSeP dataset [1]
+       :widths: 15 15 15 15 15 15 15
+       :header-rows: 1
+
+       * - Model name
+         - Data set
+         - DICE
+         - AJI
+         - DQ
+         - SQ
+         - PQ
+       * - hovernet-original-consep
+         - PanNuke
+         - 0.85
+         - 0.57
+         - 0.70
+         - 0.78
+         - 0.55
 
     Args:
         num_input_channels (int):
@@ -272,12 +312,14 @@ class HoVerNet(ModelABC):
             (`original`) or the one used in PanNuke paper (`fast`).
 
     References:
-        Graham, Simon, et al. "HoVerNet: Simultaneous segmentation and
+        [1] Graham, Simon, et al. "HoVerNet: Simultaneous segmentation and
         classification of nuclei in multi-tissue histology images."
         Medical Image Analysis 58 (2019): 101563.
+        
+        [2] Kumar, Neeraj, et al. "A dataset and a technique for generalized
+        nuclear segmentation for computational pathology."
+        IEEE transactions on medical imaging 36.7 (2017): 1550-1560.
 
-        Gamper, Jevgenij, et al. "PanNuke dataset extension, insights
-        and baselines." arXiv preprint arXiv:2003.10778 (2020).
 
     """
 

--- a/tiatoolbox/models/architecture/hovernet.py
+++ b/tiatoolbox/models/architecture/hovernet.py
@@ -261,7 +261,7 @@ class HoVerNet(ModelABC):
     """Initialise HoVerNet [1].
 
     The tiatoolbox models should produce the following results:
-    
+
     .. list-table:: HoVerNet segmentation performance on the CoNSeP dataset [1]
        :widths: 15 15 15 15 15 15 15
        :header-rows: 1
@@ -280,7 +280,7 @@ class HoVerNet(ModelABC):
          - 0.70
          - 0.78
          - 0.55
-    
+
     .. list-table:: HoVerNet segmentation performance on the Kumar dataset [2]
        :widths: 15 15 15 15 15 15 15
        :header-rows: 1

--- a/tiatoolbox/models/architecture/hovernet.py
+++ b/tiatoolbox/models/architecture/hovernet.py
@@ -261,7 +261,26 @@ class HoVerNet(ModelABC):
     """Initialise HoVerNet [1].
 
     The tiatoolbox models should produce the following results:
+    
+    .. list-table:: HoVerNet segmentation performance on the CoNSeP dataset [1]
+       :widths: 15 15 15 15 15 15 15
+       :header-rows: 1
 
+       * - Model name
+         - Data set
+         - DICE
+         - AJI
+         - DQ
+         - SQ
+         - PQ
+       * - hovernet-original-consep
+         - CoNSeP
+         - 0.85
+         - 0.57
+         - 0.70
+         - 0.78
+         - 0.55
+    
     .. list-table:: HoVerNet segmentation performance on the Kumar dataset [2]
        :widths: 15 15 15 15 15 15 15
        :header-rows: 1
@@ -280,25 +299,6 @@ class HoVerNet(ModelABC):
          - 0.77
          - 0.77
          - 0.60
-    
-    .. list-table:: HoVerNet segmentation performance on the CoNSeP dataset [1]
-       :widths: 15 15 15 15 15 15 15
-       :header-rows: 1
-
-       * - Model name
-         - Data set
-         - DICE
-         - AJI
-         - DQ
-         - SQ
-         - PQ
-       * - hovernet-original-consep
-         - PanNuke
-         - 0.85
-         - 0.57
-         - 0.70
-         - 0.78
-         - 0.55
 
     Args:
         num_input_channels (int):
@@ -315,7 +315,7 @@ class HoVerNet(ModelABC):
         [1] Graham, Simon, et al. "HoVerNet: Simultaneous segmentation and
         classification of nuclei in multi-tissue histology images."
         Medical Image Analysis 58 (2019): 101563.
-        
+
         [2] Kumar, Neeraj, et al. "A dataset and a technique for generalized
         nuclear segmentation for computational pathology."
         IEEE transactions on medical imaging 36.7 (2017): 1550-1560.

--- a/tiatoolbox/models/architecture/idars.py
+++ b/tiatoolbox/models/architecture/idars.py
@@ -18,7 +18,7 @@ class IDaRS(CNNModel):
 
     The tiatoolbox model should produce the following results:
 
-    .. list-table:: IDaRS performance
+    .. list-table:: IDaRS performance measured by AUROC.
        :widths: 15 15 15 15 15 15 15
        :header-rows: 1
 

--- a/tiatoolbox/models/architecture/idars.py
+++ b/tiatoolbox/models/architecture/idars.py
@@ -14,13 +14,47 @@ TRANSFORM = transforms.Compose(
 
 
 class IDaRS(CNNModel):
-    """Retrieve the model and add custom preprocessing used in IDaRS paper.
+    """Initialise IDaRS and add custom preprocessing as used in the original paper [1].
+
+    The tiatoolbox model should produce the following results:
+
+    .. list-table:: IDaRS performance
+       :widths: 15 15 15 15 15 15 15
+       :header-rows: 1
+
+       * - 
+         - MSI
+         - TP53
+         - BRAF
+         - CIMP
+         - CIN
+         - HM
+       * - Bilal et al.
+         - 0.828
+         - 0.755
+         - 0.813
+         - 0.853
+         - 0.860
+         - 0.846
+       * - TIAToolbox
+         - 0.870
+         - 0.747
+         - 0.750
+         - 0.748
+         - 0.810
+         - 0.790
 
     Args:
         backbone (str):
             Model name.
         num_classes (int):
             Number of classes output by model.
+    
+    References:
+        [1] Bilal, Mohsin, et al. "Development and validation of a weakly supervised 
+        deep learning framework to predict the status of molecular pathways and key 
+        mutations in colorectal cancer from routine histology images: a retrospective
+        study." The Lancet Digital Health 3.12 (2021): e763-e772.
 
     """
 

--- a/tiatoolbox/models/architecture/idars.py
+++ b/tiatoolbox/models/architecture/idars.py
@@ -22,7 +22,7 @@ class IDaRS(CNNModel):
        :widths: 15 15 15 15 15 15 15
        :header-rows: 1
 
-       * - 
+       * -
          - MSI
          - TP53
          - BRAF
@@ -49,10 +49,10 @@ class IDaRS(CNNModel):
             Model name.
         num_classes (int):
             Number of classes output by model.
-    
+
     References:
-        [1] Bilal, Mohsin, et al. "Development and validation of a weakly supervised 
-        deep learning framework to predict the status of molecular pathways and key 
+        [1] Bilal, Mohsin, et al. "Development and validation of a weakly supervised
+        deep learning framework to predict the status of molecular pathways and key
         mutations in colorectal cancer from routine histology images: a retrospective
         study." The Lancet Digital Health 3.12 (2021): e763-e772.
 

--- a/tiatoolbox/models/architecture/micronet.py
+++ b/tiatoolbox/models/architecture/micronet.py
@@ -347,15 +347,14 @@ class MicroNet(ModelABC):
 
     The following models have been included in tiatoolbox:
     1. `micronet-consep`:
-        This is trained on `ConSep dataset
+        This is trained on `CoNSeP dataset
         <https://warwick.ac.uk/fac/cross_fac/tia/data/hovernet/>`_ The
         model is retrained in torch as the original model with results
-        on ConSep [2] was trained in TensorFlow.
+        on CoNSeP [2] was trained in TensorFlow.
 
-    The tiatoolbox model should produce following results on the ConSep
-    dataset.
+    The tiatoolbox model should produce the following results on the CoNSeP dataset:
 
-    .. list-table:: MicroNet Performance
+    .. list-table:: MicroNet performance
        :widths: 15 15 15 15 15 15 15 15
        :header-rows: 1
 
@@ -366,15 +365,13 @@ class MicroNet(ModelABC):
          - DQ
          - SQ
          - PQ
-         - AJI+
        * - micronet-consep
-         - ConSep
+         - CoNSeP
          - 0.80
          - 0.49
          - 0.62
          - 0.75
          - 0.47
-         - 0.54
 
     Args:
         num_input_channels (int):

--- a/tiatoolbox/models/architecture/micronet.py
+++ b/tiatoolbox/models/architecture/micronet.py
@@ -355,7 +355,7 @@ class MicroNet(ModelABC):
     The tiatoolbox model should produce the following results on the CoNSeP dataset:
 
     .. list-table:: MicroNet performance
-       :widths: 15 15 15 15 15 15 15 15
+       :widths: 15 15 15 15 15 15 15
        :header-rows: 1
 
        * - Model name

--- a/tiatoolbox/models/engine/patch_predictor.py
+++ b/tiatoolbox/models/engine/patch_predictor.py
@@ -51,7 +51,7 @@ class PatchPredictor:
        :header-rows: 1
 
        * - Model name
-         - F$_1$ score
+         - F_1 score
        * - alexnet-kather100k
          - 0.965
        * - resnet18-kather100k
@@ -92,7 +92,7 @@ class PatchPredictor:
        :header-rows: 1
 
        * - Model name
-         - F$_1$ score
+         - F_1 score
        * - alexnet-pcam
          - 0.840
        * - resnet18-pcam

--- a/tiatoolbox/models/engine/patch_predictor.py
+++ b/tiatoolbox/models/engine/patch_predictor.py
@@ -86,7 +86,7 @@ class PatchPredictor:
          - 0.992
        * - googlenet-kather100k
          - 0.992
-    
+
     .. list-table:: PatchPredictor performance on the PCam dataset [2]
        :widths: 15 15
        :header-rows: 1
@@ -207,10 +207,10 @@ class PatchPredictor:
         >>> wsi_file = ['path/wsi1.svs', 'path/wsi2.svs']
         >>> predictor = PatchPredictor(pretraind_model="resnet18-kather100k")
         >>> output = predictor.predict(wsi_file, mode='wsi')
-    
+
     References:
         [1] Kather, Jakob Nikolas, et al. "Predicting survival from colorectal cancer
-        histology slides using deep learning: A retrospective multicenter study." 
+        histology slides using deep learning: A retrospective multicenter study."
         PLoS medicine 16.1 (2019): e1002730.
 
         [2] Veeling, Bastiaan S., et al. "Rotation equivariant CNNs for digital

--- a/tiatoolbox/models/engine/patch_predictor.py
+++ b/tiatoolbox/models/engine/patch_predictor.py
@@ -51,7 +51,7 @@ class PatchPredictor:
        :header-rows: 1
 
        * - Model name
-         - F_1 score
+         - F$_1$ score
        * - alexnet-kather100k
          - 0.965
        * - resnet18-kather100k
@@ -92,7 +92,7 @@ class PatchPredictor:
        :header-rows: 1
 
        * - Model name
-         - F_1 score
+         - F$_1$ score
        * - alexnet-pcam
          - 0.840
        * - resnet18-pcam

--- a/tiatoolbox/models/engine/patch_predictor.py
+++ b/tiatoolbox/models/engine/patch_predictor.py
@@ -44,6 +44,90 @@ class IOPatchPredictorConfig(IOSegmentorConfig):
 class PatchPredictor:
     """Patch-level predictor.
 
+    The models provided by tiatoolbox should give the following results:
+
+    .. list-table:: PatchPredictor performance on the Kather100K dataset [1]
+       :widths: 15 15
+       :header-rows: 1
+
+       * - Model name
+         - F_1 score
+       * - alexnet-kather100k
+         - 0.965
+       * - resnet18-kather100k
+         - 0.990
+       * - resnet34-kather100k
+         - 0.991
+       * - resnet50-kather100k
+         - 0.989
+       * - resnet101-kather100k
+         - 0.989
+       * - resnext50_32x4d-kather100k
+         - 0.992
+       * - resnext101_32x8d-kather100k
+         - 0.991
+       * - wide_resnet50_2-kather100k
+         - 0.989
+       * - wide_resnet101_2-kather100k
+         - 0.990
+       * - densenet121-kather100k
+         - 0.993
+       * - densenet161-kather100k
+         - 0.992
+       * - densenet169-kather100k
+         - 0.992
+       * - densenet201-kather100k
+         - 0.991
+       * - mobilenet_v2-kather100k
+         - 0.990
+       * - mobilenet_v3_large-kather100k
+         - 0.991
+       * - mobilenet_v3_small-kather100k
+         - 0.992
+       * - googlenet-kather100k
+         - 0.992
+    
+    .. list-table:: PatchPredictor performance on the PCam dataset [2]
+       :widths: 15 15
+       :header-rows: 1
+
+       * - Model name
+         - F_1 score
+       * - alexnet-pcam
+         - 0.840
+       * - resnet18-pcam
+         - 0.888
+       * - resnet34-pcam
+         - 0.889
+       * - resnet50-pcam
+         - 0.892
+       * - resnet101-pcam
+         - 0.888
+       * - resnext50_32x4d-pcam
+         - 0.900
+       * - resnext101_32x8d-pcam
+         - 0.892
+       * - wide_resnet50_2-pcam
+         - 0.901
+       * - wide_resnet101_2-pcam
+         - 0.898
+       * - densenet121-pcam
+         - 0.897
+       * - densenet161-pcam
+         - 0.893
+       * - densenet169-pcam
+         - 0.895
+       * - densenet201-pcam
+         - 0.891
+       * - mobilenet_v2-pcam
+         - 0.899
+       * - mobilenet_v3_large-pcam
+         - 0.895
+       * - mobilenet_v3_small-pcam
+         - 0.890
+       * - googlenet-pcam
+         - 0.867
+
     Args:
         model (nn.Module):
             Use externally defined PyTorch model for prediction with.
@@ -123,6 +207,15 @@ class PatchPredictor:
         >>> wsi_file = ['path/wsi1.svs', 'path/wsi2.svs']
         >>> predictor = PatchPredictor(pretraind_model="resnet18-kather100k")
         >>> output = predictor.predict(wsi_file, mode='wsi')
+    
+    References:
+        [1] Kather, Jakob Nikolas, et al. "Predicting survival from colorectal cancer
+        histology slides using deep learning: A retrospective multicenter study." 
+        PLoS medicine 16.1 (2019): e1002730.
+
+        [2] Veeling, Bastiaan S., et al. "Rotation equivariant CNNs for digital
+        pathology." International Conference on Medical image computing and
+        computer-assisted intervention. Springer, Cham, 2018.
 
     """
 

--- a/tiatoolbox/models/engine/patch_predictor.py
+++ b/tiatoolbox/models/engine/patch_predictor.py
@@ -51,7 +51,7 @@ class PatchPredictor:
        :header-rows: 1
 
        * - Model name
-         - F:sub:`1` score
+         - F\ :sub:`1`\ score
        * - alexnet-kather100k
          - 0.965
        * - resnet18-kather100k
@@ -92,7 +92,7 @@ class PatchPredictor:
        :header-rows: 1
 
        * - Model name
-         - F:sub:`1` score
+         - F\ :sub:`1`\ score
        * - alexnet-pcam
          - 0.840
        * - resnet18-pcam

--- a/tiatoolbox/models/engine/patch_predictor.py
+++ b/tiatoolbox/models/engine/patch_predictor.py
@@ -51,7 +51,7 @@ class PatchPredictor:
        :header-rows: 1
 
        * - Model name
-         - F\ :sub:`1`\ score
+         - F:sub:`1` score
        * - alexnet-kather100k
          - 0.965
        * - resnet18-kather100k
@@ -92,7 +92,7 @@ class PatchPredictor:
        :header-rows: 1
 
        * - Model name
-         - F\ :sub:`1`\ score
+         - F:sub:`1` score
        * - alexnet-pcam
          - 0.840
        * - resnet18-pcam

--- a/tiatoolbox/models/engine/patch_predictor.py
+++ b/tiatoolbox/models/engine/patch_predictor.py
@@ -51,7 +51,7 @@ class PatchPredictor:
        :header-rows: 1
 
        * - Model name
-         - F_1 score
+         - F\ :sub:`1`\ score
        * - alexnet-kather100k
          - 0.965
        * - resnet18-kather100k
@@ -92,7 +92,7 @@ class PatchPredictor:
        :header-rows: 1
 
        * - Model name
-         - F_1 score
+         - F\ :sub:`1`\ score
        * - alexnet-pcam
          - 0.840
        * - resnet18-pcam

--- a/tiatoolbox/models/engine/patch_predictor.py
+++ b/tiatoolbox/models/engine/patch_predictor.py
@@ -158,8 +158,7 @@ class PatchPredictor:
             Whether to output logging information.
 
     Attributes:
-        img (:obj:`str` or :obj:`pathlib.Path` or
-        :class:`numpy.ndarray`):
+        img (:obj:`str` or :obj:`pathlib.Path` or :obj:`numpy.ndarray`):
             A HWC image or a path to WSI.
         mode (str):
             Type of input to process. Choose from either `patch`, `tile`
@@ -217,7 +216,7 @@ class PatchPredictor:
         pathology." International Conference on Medical image computing and
         computer-assisted intervention. Springer, Cham, 2018.
 
-    """
+    """  # noqa: W605
 
     def __init__(
         self,

--- a/tiatoolbox/models/engine/semantic_segmentor.py
+++ b/tiatoolbox/models/engine/semantic_segmentor.py
@@ -358,7 +358,7 @@ class SemanticSegmentor:
        :widths: 15 15 15 15 15 15 15
        :header-rows: 1
 
-       * - 
+       * -
          - Tumour
          - Stroma
          - Inflammatory

--- a/tiatoolbox/models/engine/semantic_segmentor.py
+++ b/tiatoolbox/models/engine/semantic_segmentor.py
@@ -357,6 +357,7 @@ class SemanticSegmentor:
     .. list-table:: Semantic segmentation performance on the BCSS dataset
        :widths: 15 15 15 15 15 15 15
        :header-rows: 1
+
        * - 
          - Tumour
          - Stroma

--- a/tiatoolbox/models/engine/semantic_segmentor.py
+++ b/tiatoolbox/models/engine/semantic_segmentor.py
@@ -351,6 +351,34 @@ class WSIStreamDataset(torch_data.Dataset):
 class SemanticSegmentor:
     """Pixel-wise segmentation predictor.
 
+    The tiatoolbox model should produce the following results on the BCSS dataset
+    using fcn_resnet50_unet-bcss.
+
+    .. list-table:: Semantic segmentation performance on the BCSS dataset
+       :widths: 15 15 15 15 15 15 15
+       :header-rows: 1
+       * - 
+         - Tumour
+         - Stroma
+         - Inflammatory
+         - Necrosis
+         - Other
+         - All
+       * - Amgad et al.
+         - 0.851
+         - 0.800
+         - 0.712
+         - 0.723
+         - 0.666
+         - 0.750
+       * - TIAToolbox
+         - 0.885
+         - 0.825
+         - 0.761
+         - 0.765
+         - 0.581
+         - 0.763
+
     Note, if `model` is supplied in the arguments, it will ignore the
     `pretrained_model` and `pretrained_weights` arguments.
 


### PR DESCRIPTION
Added tables of metrics to the documentation of TIAToolbox.

- [x] HoVer-Net results
- [x] IDaRS results
- [x] Patch predictor results
- [x] Semantic segmentation results