### PR TITLE
BUG: Update sqlite compile option checking

### DIFF
--- a/tests/test_annotation_stores.py
+++ b/tests/test_annotation_stores.py
@@ -168,8 +168,25 @@ def test_sqlite_store_compile_options():
 
 
 def test_sqlite_store_compile_options_exception(monkeypatch):
+    monkeypatch.setattr(sqlite3, "sqlite_version_info", (3, 37, 0))
+    monkeypatch.setattr(
+        SQLiteStore,
+        "compile_options",
+        lambda x: ["ENABLE_RTREE", "ENABLE_JSON1"],
+        raising=True,
+    )
+    SQLiteStore()
     monkeypatch.setattr(SQLiteStore, "compile_options", lambda x: [], raising=True)
     with pytest.raises(Exception, match="RTREE and JSON1"):
+        SQLiteStore()
+
+
+def test_sqlite_store_compile_options_exception_v3_38(monkeypatch):
+    monkeypatch.setattr(sqlite3, "sqlite_version_info", (3, 38, 0))
+    monkeypatch.setattr(
+        SQLiteStore, "compile_options", lambda x: ["OMIT_JSON"], raising=True
+    )
+    with pytest.raises(Exception, match="JSON must not"):
         SQLiteStore()
 
 

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -993,10 +993,19 @@ class SQLiteStore(AnnotationStore):
         super().__init__()
         # Check that JSON and RTree support is enabled
         compile_options = self.compile_options()
-        if not all(
-            ["ENABLE_JSON1" in compile_options, "ENABLE_RTREE" in compile_options]
-        ):
-            raise Exception("RTREE and JSON1 sqlite3 compile options are required.")
+        if sqlite3.sqlite_version_info >= (3, 38, 0):
+            if not all(
+                ["OMIT_JSON" not in compile_options, "ENABLE_RTREE" in compile_options]
+            ):
+                raise Exception(
+                    """RTREE sqlite3 compile option is required, and
+                    JSON must not be disabled with OMIT_JSON compile option"""
+                )
+        else:
+            if not all(
+                ["ENABLE_JSON1" in compile_options, "ENABLE_RTREE" in compile_options]
+            ):
+                raise Exception("RTREE and JSON1 sqlite3 compile options are required.")
 
         # Check that math functions are enabled
         if "ENABLE_MATH_FUNCTIONS" not in compile_options:


### PR DESCRIPTION
Fix for test_annotation_stores.py

This has been failing due to a change in the compile flags of recent versions of sqlite3. JSON functions are now a core component of SQLite, not an extension that must be enabled via a compile option. Because of this the ENABLE_JSON1 flag was removed and OMIT_JSON flag added. 

For more info see: https://sqlite.org/src/doc/json-enhancements/doc/json-enhancements.md

The fix just adds a version check, and checks the compile options appropriately to the version.