### PR TITLE
DEV: Downgrade `albumentations` requirements

### DIFF
--- a/requirements.conda.yml
+++ b/requirements.conda.yml
@@ -5,7 +5,7 @@ channels:
   - pytorch
   - defaults
 dependencies:
-  - albumentations>=1.1.0
+  - albumentations>=1.0.3
   - black>=22.3.0
   - Click>=8.1.2
   - cython

--- a/requirements.dev.conda.yml
+++ b/requirements.dev.conda.yml
@@ -5,7 +5,7 @@ channels:
   - pytorch
   - defaults
 dependencies:
-  - albumentations>=1.1.0
+  - albumentations>=1.0.3
   - black>=22.3.0
   - bump2version==1.0.1
   - Click>=8.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-albumentations>=1.1.0
+albumentations>=1.0.3
 Click>=8.1.2
 defusedxml>=0.7.1
 flask>=2.1.1

--- a/requirements.win64.conda.yml
+++ b/requirements.win64.conda.yml
@@ -5,7 +5,7 @@ channels:
   - pytorch
   - defaults
 dependencies:
-  - albumentations>=1.1.0
+  - albumentations>=1.0.3
   - black>=22.3.0
   - Click>=8.1.2
   - cython

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-albumentations>=1.1.0
+albumentations>=1.0.3
 black>=22.3.0
 bump2version==1.0.1
 Click>=8.1.2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("HISTORY.md") as history_file:
     history = history_file.read()
 
 requirements = [
-    "albumentations>=1.1.0",
+    "albumentations>=1.0.3",
     "Click>=8.1.2",
     "defusedxml>=0.7.1",
     "glymur>=0.9.9",


### PR DESCRIPTION
- Downgrade albumentations requirement to 1.0.3 as the latest version didn't pass on conda feedstock.