### PR TITLE
DEV: Restore `nbsphinx` To `requirements.dev.conda.yml`

### DIFF
--- a/requirements.dev.conda.yml
+++ b/requirements.dev.conda.yml
@@ -20,6 +20,7 @@ dependencies:
   - imagecodecs>2021.11.20
   - jupyterlab
   - matplotlib>=3.5.1
+  - nbsphinx
   - numpy>=1.21.5
   - opencv>=4.5.5
   - openjpeg>=2.4.0


### PR DESCRIPTION
"make html" fails without nbsphinx

