### PR TITLE
TST: Set Test Number of Workers Based on CPU Count

### DIFF
--- a/requirements.dev.conda.yml
+++ b/requirements.dev.conda.yml
@@ -20,6 +20,7 @@ dependencies:
   - imagecodecs>2021.11.20
   - jupyterlab
   - matplotlib>=3.5.1
+  - nbsphinx
   - numpy>=1.21.5
   - opencv>=4.5.5
   - openjpeg>=2.4.0

--- a/tests/models/test_multi_task_segmentor.py
+++ b/tests/models/test_multi_task_segmentor.py
@@ -11,7 +11,7 @@ from tiatoolbox.models import SemanticSegmentor
 from tiatoolbox.utils import env_detection as toolbox_env
 
 ON_GPU = toolbox_env.has_gpu()
-# The value is based on 2 TitanXP each with 12GB
+# The batch size value here is based on 2xTitanXP each with 12GB
 BATCH_SIZE = 1 if not ON_GPU else 16
 try:
     NUM_POSTPROC_WORKERS = multiprocessing.cpu_count()

--- a/tests/models/test_multi_task_segmentor.py
+++ b/tests/models/test_multi_task_segmentor.py
@@ -1,5 +1,6 @@
 """Unit test package for HoVerNet+."""
 
+import multiprocessing
 import pathlib
 import shutil
 
@@ -12,7 +13,10 @@ from tiatoolbox.utils import env_detection as toolbox_env
 ON_GPU = toolbox_env.has_gpu()
 # The value is based on 2 TitanXP each with 12GB
 BATCH_SIZE = 1 if not ON_GPU else 16
-NUM_POSTPROC_WORKERS = 2 if not toolbox_env.running_on_travis() else 8
+try:
+    NUM_POSTPROC_WORKERS = multiprocessing.cpu_count()
+except NotImplementedError:
+    NUM_POSTPROC_WORKERS = 2
 
 # ----------------------------------------------------
 

--- a/tests/models/test_multi_task_segmentor.py
+++ b/tests/models/test_multi_task_segmentor.py
@@ -11,7 +11,7 @@ from tiatoolbox.models import SemanticSegmentor
 from tiatoolbox.utils import env_detection as toolbox_env
 
 ON_GPU = toolbox_env.has_gpu()
-# The batch size value here is based on 2xTitanXP each with 12GB
+# The batch size value here is based on two TitanXP, each with 12GB
 BATCH_SIZE = 1 if not ON_GPU else 16
 try:
     NUM_POSTPROC_WORKERS = multiprocessing.cpu_count()

--- a/tests/models/test_semantic_segmentation.py
+++ b/tests/models/test_semantic_segmentation.py
@@ -34,7 +34,10 @@ from tiatoolbox.wsicore.wsireader import WSIReader
 ON_GPU = toolbox_env.has_gpu()
 # The value is based on 2 TitanXP each with 12GB
 BATCH_SIZE = 1 if not ON_GPU else 16
-NUM_POSTPROC_WORKERS = multiprocessing.cpu_count()
+try:
+    NUM_POSTPROC_WORKERS = multiprocessing.cpu_count()
+except NotImplementedError:
+    NUM_POSTPROC_WORKERS = 2
 
 # ----------------------------------------------------
 

--- a/tests/models/test_semantic_segmentation.py
+++ b/tests/models/test_semantic_segmentation.py
@@ -4,6 +4,7 @@ import copy
 
 # ! The garbage collector
 import gc
+import multiprocessing
 import os
 import pathlib
 import shutil
@@ -33,7 +34,7 @@ from tiatoolbox.wsicore.wsireader import WSIReader
 ON_GPU = toolbox_env.has_gpu()
 # The value is based on 2 TitanXP each with 12GB
 BATCH_SIZE = 1 if not ON_GPU else 16
-NUM_POSTPROC_WORKERS = 2 if not toolbox_env.running_on_ci() else 8
+NUM_POSTPROC_WORKERS = multiprocessing.cpu_count()
 
 # ----------------------------------------------------
 


### PR DESCRIPTION
This PR simply sets the number of works used in tests to use the `multiprocessing.cpu_count()` with a fallback to 2.