### PR TITLE
BUG: Check That An Input Path Actually Exists

### DIFF
--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -2060,3 +2060,14 @@ class TestReader:
         cc = np.corrcoef(roi1[..., 0].flatten(), roi2[..., 0].flatten())
         # This control the harshness of similarity test, how much should be?
         assert np.min(cc) > 0.95
+
+    @staticmethod
+    def test_file_path_doesnt_exist(sample_key, reader_class):
+        """Test that the file_path attribute is set correctly.
+
+        The file_path attribute should be set to the path of the file
+        that was opened.
+
+        """
+        with pytest.raises(FileNotFoundError):
+            _ = reader_class("./foo.bar")

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -2062,7 +2062,7 @@ class TestReader:
         assert np.min(cc) > 0.95
 
     @staticmethod
-    def test_file_path_doesnt_exist(sample_key, reader_class):
+    def test_file_path_does_not_exist(sample_key, reader_class):
         """Test that the file_path attribute is set correctly.
 
         The file_path attribute should be set to the path of the file

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -2081,11 +2081,6 @@ class TestReader:
 
     @staticmethod
     def test_file_path_does_not_exist(sample_key, reader_class):
-        """Test that the file_path attribute is set correctly.
-
-        The file_path attribute should be set to the path of the file
-        that was opened.
-
-        """
+        """Test that FileNotFoundError is raised when file does not exist."""
         with pytest.raises(FileNotFoundError):
             _ = reader_class("./foo.bar")

--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -203,39 +203,45 @@ class WSIReader:
         if isinstance(input_img, WSIReader):
             return input_img
 
-        WSIReader.verify_supported_wsi(input_img)
+        # Input is a string or pathlib.Path, normalise to pathlib.Path
+        input_path = pathlib.Path(input_img)
+        WSIReader.verify_supported_wsi(input_path)
+
+        # Check file / directory exists
+        if not input_path.exists():
+            raise FileNotFoundError(f"Input path does not exist {input_path}")
 
         # Handle special cases first (DICOM, Zarr/NGFF, OME-TIFF)
 
-        if is_dicom(input_img):
-            return DICOMWSIReader(input_img, mpp=mpp, power=power)
+        if is_dicom(input_path):
+            return DICOMWSIReader(input_path, mpp=mpp, power=power)
 
-        _, _, suffixes = utils.misc.split_path_name_ext(input_img)
+        _, _, suffixes = utils.misc.split_path_name_ext(input_path)
         last_suffix = suffixes[-1]
 
         if last_suffix in (".zarr",):
-            if not is_ngff(input_img):
+            if not is_ngff(input_path):
                 raise FileNotSupported(
-                    f"File {input_img} does not appear to be a v0.4 NGFF zarr."
+                    f"File {input_path} does not appear to be a v0.4 NGFF zarr."
                 )
-            return NGFFWSIReader(input_img, mpp=mpp, power=power)
+            return NGFFWSIReader(input_path, mpp=mpp, power=power)
 
         if suffixes[-2:] in ([".ome", ".tiff"],):
-            return TIFFWSIReader(input_img, mpp=mpp, power=power)
+            return TIFFWSIReader(input_path, mpp=mpp, power=power)
 
-        if last_suffix in (".tif", ".tiff") and is_tiled_tiff(input_img):
+        if last_suffix in (".tif", ".tiff") and is_tiled_tiff(input_path):
             try:
-                return OpenSlideWSIReader(input_img, mpp=mpp, power=power)
+                return OpenSlideWSIReader(input_path, mpp=mpp, power=power)
             except openslide.OpenSlideError:
-                return TIFFWSIReader(input_img, mpp=mpp, power=power)
+                return TIFFWSIReader(input_path, mpp=mpp, power=power)
 
         # Handle homogeneous cases (based on final suffix)
 
         def np_virtual_wsi(
-            input_img: np.ndarray, *args, **kwargs
+            input_path: np.ndarray, *args, **kwargs
         ) -> "VirtualWSIReader":
             """Create a virtual WSI from a numpy array."""
-            return VirtualWSIReader(input_img, *args, **kwargs)
+            return VirtualWSIReader(input_path, *args, **kwargs)
 
         suffix_to_reader = {
             ".npy": np_virtual_wsi,
@@ -248,13 +254,13 @@ class WSIReader:
         }
 
         if last_suffix in suffix_to_reader:
-            return suffix_to_reader[last_suffix](input_img, mpp=mpp, power=power)
+            return suffix_to_reader[last_suffix](input_path, mpp=mpp, power=power)
 
         # Try openslide last
-        return OpenSlideWSIReader(input_img, mpp=mpp, power=power)
+        return OpenSlideWSIReader(input_path, mpp=mpp, power=power)
 
     @staticmethod
-    def verify_supported_wsi(input_img):
+    def verify_supported_wsi(input_path):
         """Verify that an input image is supported.
 
         Raises:
@@ -262,10 +268,10 @@ class WSIReader:
                 If the input image is not supported.
 
         """
-        if is_ngff(input_img) or is_dicom(input_img):
+        if is_ngff(input_path) or is_dicom(input_path):
             return
 
-        _, _, suffixes = utils.misc.split_path_name_ext(input_img)
+        _, _, suffixes = utils.misc.split_path_name_ext(input_path)
 
         if suffixes and suffixes[-1] not in [
             ".svs",
@@ -280,7 +286,7 @@ class WSIReader:
             ".jpeg",
             ".zarr",
         ]:
-            raise FileNotSupported(f"File {input_img} is not a supported file format.")
+            raise FileNotSupported(f"File {input_path} is not a supported file format.")
 
     def __init__(
         self,

--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -207,10 +207,6 @@ class WSIReader:
         input_path = pathlib.Path(input_img)
         WSIReader.verify_supported_wsi(input_path)
 
-        # Check file / directory exists
-        if not input_path.exists():
-            raise FileNotFoundError(f"Input path does not exist {input_path}")
-
         # Handle special cases first (DICOM, Zarr/NGFF, OME-TIFF)
 
         if is_dicom(input_path):
@@ -302,6 +298,8 @@ class WSIReader:
             self.input_path = None
         else:
             self.input_path = pathlib.Path(input_img)
+            if not self.input_path.exists():
+                raise FileNotFoundError(f"Input path does not exist: {self.input_path}")
         self._m_info = None
 
         # Set a manual mpp value

--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -260,8 +260,12 @@ class WSIReader:
         return OpenSlideWSIReader(input_path, mpp=mpp, power=power)
 
     @staticmethod
-    def verify_supported_wsi(input_path):
+    def verify_supported_wsi(input_path: pathlib.Path) -> None:
         """Verify that an input image is supported.
+
+        Args:
+            input_path (pathlib.Path):
+                Input path to WSI.
 
         Raises:
             FileNotSupported:

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -41,6 +41,7 @@ OME
 Omnyx
 OpenCV
 Otsu's
+PSNR
 PTC
 PYL
 Peter
@@ -50,6 +51,7 @@ RGB
 RGBA
 ROI
 Ruifrok
+SSIM
 Segmentor
 Vahadane
 Ver


### PR DESCRIPTION
- Add path check to WSIReader base init
- Minor refactoring / renaming
- Add to parameterized WSIReader test (Add JP2 and improve content checks - corrcoef could be NaN).