### PR TITLE
[Skip Travis] REL: Release 1.2.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -90,7 +90,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        apt-get install -y libopenslide-dev libopenjp2-7
+        sudo apt-get install -y libopenslide-dev libopenjp2-7
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install build

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,9 +44,9 @@ authors:
   given-names: "Shan E Ahmed"
   orcid: "https://orcid.org/0000-0002-1097-1738"
 title: "TIAToolbox: An End-to-End Toolbox for Advanced Tissue Image Analytics"
-version: 1.1.0
+version: 1.2.0
 doi: 10.5281/zenodo.5802442
-date-released: 2022-05-07
+date-released: 2022-07-05
 url: "https://github.com/TissueImageAnalytics/tiatoolbox"
 preferred-citation:
   type: article

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,35 @@
 History
 =======
 
+1.2.0 (2022-07-05)
+------------------
+### Major Updates and Feature Improvements
+- Adds support for Python 3.10
+- Adds short description for IDARS algorithm #383
+- Adds support for NGFF v0.4 [OME-ZARR](https://ngff.openmicroscopy.org/latest/).
+- Adds CLI for launching tile server.
+
+### Changes to API
+- Renames `stainnorm_target()` function to `stain_norm_target()`.
+- Removes `get_wsireader`
+- Replaces the custom PlattScaler in `tools/scale.py` with the regular Scikit-Learn [LogisticRegression](https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression).
+
+### Bug Fixes and Other Changes
+- Fixes bugs in UNET architecture.
+	- Number of channels in Batchnorm argument in the decoding path to match with the input channels.
+	- Padding `0` creates feature maps in the decoder part with the same size as encoder.
+- Fixes linter issues and typos
+- Fixes incorrect output with overlap in `predictor.merge_predictions()` and `return_raw=True`
+	- Thanks to @paulhacosta for raising #356, Fixed by #358.
+- Fixes errors with JP2 read. Checks input path exists.
+- Fixes errors with torch upgrade to 1.12.
+
+### Development related changes
+- Adds pre-commit hooks for consistency across the repo.
+- Sets up GitHub Actions Workflow.
+    - Travis CI will be removed in future release.
+
+
 1.1.0 (2022-05-07)
 ------------------
 ### Major Updates and Feature Improvements

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.2.0
 commit = True
 tag = False
 
@@ -22,7 +22,7 @@ spellcheck-targets = comments
 dictionaries = en_US,python,technical
 max-cognitive-complexity = 14
 max-expression-complexity = 7
-per-file-ignores =
+per-file-ignores = 
 	test_*: E800
 
 [aliases]

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/TissueImageAnalytics/tiatoolbox",
-    version="1.1.0",
+    version="1.2.0",
     zip_safe=False,
 )

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -7,7 +7,7 @@ import yaml
 
 __author__ = """TIA Lab"""
 __email__ = "tialab@dcs.warwick.ac.uk"
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 # This will set the tiatoolbox external data
 # default to be the user home folder, should work on both Window and Unix/Linux

--- a/tiatoolbox/cli/__init__.py
+++ b/tiatoolbox/cli/__init__.py
@@ -20,7 +20,7 @@ from tiatoolbox.cli.tissue_mask import tissue_mask
 
 def version_msg():
     """Return a string with tiatoolbox package version and python version."""
-    python_version = sys.version[:3]
+    python_version = platform.python_version()
     message = (
         f"tiatoolbox {__version__} (Python {python_version}) on {platform.platform()}."
     )

--- a/tiatoolbox/cli/__init__.py
+++ b/tiatoolbox/cli/__init__.py
@@ -20,11 +20,7 @@ from tiatoolbox.cli.tissue_mask import tissue_mask
 
 def version_msg():
     """Return a string with tiatoolbox package version and python version."""
-    python_version = platform.python_version()
-    message = (
-        f"tiatoolbox {__version__} (Python {python_version}) on {platform.platform()}."
-    )
-    return message
+    return f"tiatoolbox {__version__} (Python {platform.python_version()}) on {platform.platform()}."
 
 
 @tiatoolbox_cli.group(context_settings={"help_option_names": ["-h", "--help"]})


### PR DESCRIPTION
- Bump version: 1.1.0 → 1.2.0
- Fixes Python version info

### Major Updates and Feature Improvements
- Adds support for Python 3.10
- Adds short description for IDARS algorithm #383
- Adds support for NGFF v0.4 [OME-ZARR](https://ngff.openmicroscopy.org/latest/).
- Adds CLI for launching tile server. 

### Changes to API
- Renames `stainnorm_target()` function to `stain_norm_target()`.
- Removes `get_wsireader`
- Replaces the custom PlattScaler in `tools/scale.py` with the regular Scikit-Learn [LogisticRegression](https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression).

### Bug Fixes and Other Changes
- Fixes bugs in UNET architecture.
	- Number of channels in Batchnorm argument in the decoding path to match with the input channels.
	- Padding `0` creates feature maps in the decoder part with the same size as encoder.
- Fixes linter issues and typos
- Fixes incorrect output with overlap in `predictor.merge_predictions()` and `return_raw=True`
	- Thanks to @paulhacosta for raising #356, Fixed by #358.
- Fixes errors with JP2 read. Checks input path exists.
- Fixes errors with torch upgrade to 1.12.

### Development related changes
- Adds pre-commit hooks for consistency across the repo.
- Sets up GitHub Actions Workflow.
	- Travis CI will be removed in future release.