### PR TITLE
TST: Validate Docstring Examples

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,19 @@
 
 import pathlib
 import shutil
+from pathlib import Path
 from typing import Callable
 
 import pytest
 from _pytest.tmpdir import TempPathFactory
 
 from tiatoolbox.data import _fetch_remote_sample
+
+
+@pytest.fixture(scope="session")
+def root_path(request) -> Path:
+    """Return the root path of the project."""
+    return Path(request.config.rootdir) / "tiatoolbox"
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -4,7 +4,7 @@ import importlib
 import os
 import sys
 from pathlib import Path
-from typing import List, Type, Union
+from typing import List, Union
 
 import pytest
 
@@ -22,21 +22,6 @@ def source_files(root_path):
                 yield Path(root, file)
 
     return generator()
-
-
-def extract_examples(docstring: str) -> str:
-    """Extract doctest examples from a docstring.
-
-    Args:
-        docstring (str):
-            The docstring to extract examples from.
-
-    Returns:
-        str:
-            The doctest examples.
-
-    """
-    return
 
 
 def test_iter_sources(source_files, root_path):
@@ -101,7 +86,7 @@ def import_node_names(import_node: Union[ast.Import, ast.ImportFrom]) -> List[st
         return [import_node.module]
     if isinstance(import_node, ast.Import):
         return [name.name for name in import_node.names]
-    raise Type("Unknown node type")
+    raise TypeError("Unknown node type")
 
 
 def check_ast(doc, rel_path) -> ast.AST:
@@ -112,3 +97,4 @@ def check_ast(doc, rel_path) -> ast.AST:
     except SyntaxError as e:
         lineno = doc.lineno + doc.examples[0].lineno + e.lineno
         pytest.fail(f"{rel_path}:{lineno}: SyntaxError: {e.msg}")
+    return None

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -28,7 +28,7 @@ def test_validate_docstring_examples(source_files, root_path):
     """Test that all docstring examples are valid.
 
     Validity checks are:
-    1. The docstring examples are syntactically valid (can parse and AST).
+    1. The docstring examples are syntactically valid (can parse an AST).
     2. That the imports can be resolved.
 
     """

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -34,8 +34,7 @@ def test_validate_docstring_examples(source_files, root_path):
     """
     for file in source_files:
 
-        with open(file) as fh:
-            source = fh.read()
+        source = Path(file).read_text()
         tree = ast.parse(source)
         parser = doctest.DocTestParser()
         for node in ast.walk(tree):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -24,8 +24,14 @@ def source_files(root_path):
     return generator()
 
 
-def test_iter_sources(source_files, root_path):
-    """Test that all source files exist."""
+def test_validate_docstring_examples(source_files, root_path):
+    """Test that all docstring examples are valid.
+
+    Validity checks are:
+    1. The docstring examples are syntactically valid (can parse and AST).
+    2. That the imports can be resolved.
+
+    """
     for file in source_files:
 
         with open(file) as fh:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,120 @@
+import ast
+import doctest
+import importlib
+import os
+import sys
+from pathlib import Path
+from typing import List, Type, Union
+
+import pytest
+
+
+@pytest.fixture()
+def source_files(root_path):
+    """Recursively yield source files from the project."""
+    ignore = {"__pycache__"}
+
+    def generator():
+        for root, dirs, files in os.walk(root_path):
+            files = [f for f in files if f.endswith(".py") and f[0] != "."]
+            dirs[:] = [d for d in dirs if d not in ignore and d[0] != "."]
+            for file in files:
+                yield Path(root, file)
+
+    return generator()
+
+
+def extract_examples(docstring: str) -> str:
+    """Extract doctest examples from a docstring.
+
+    Args:
+        docstring (str):
+            The docstring to extract examples from.
+
+    Returns:
+        str:
+            The doctest examples.
+
+    """
+    return
+
+
+def test_iter_sources(source_files, root_path):
+    """Test that all source files exist."""
+    for file in source_files:
+
+        with open(file) as fh:
+            source = fh.read()
+        tree = ast.parse(source)
+        parser = doctest.DocTestParser()
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.ClassDef)):
+                continue
+            docstring = ast.get_docstring(node)
+            if not docstring:
+                continue
+            doc = parser.get_doctest(docstring, [], node.name, file.name, node.lineno)
+            if not doc.examples:
+                continue
+
+            # Find how many lines the class/function signature spans
+            # (for accurate line numbers)
+            signature_lines = (
+                node.body[0].lineno
+                - (node.lineno + len(doc.docstring.splitlines()))
+                - 1
+            )
+            doc.lineno += signature_lines - 1
+
+            # Check syntax is valid
+            source_tree = check_ast(doc, file.relative_to(root_path))
+
+            check_imports(source_tree, root_path, file, doc)
+
+
+def check_imports(
+    source_tree: ast.AST, root_path: Path, file: Path, doc: doctest.DocTest
+) -> None:
+    """Check that imports in the source AST are valid."""
+    imports = [
+        node
+        for node in ast.walk(source_tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+    ]
+    sys.modules["tiatoolbox"] = importlib.import_module("tiatoolbox", root_path)
+    for import_node in imports:
+        names = import_node_names(import_node)
+        # Resolve the import
+        for name in names:
+            lineno = doc.lineno + doc.examples[0].lineno + import_node.lineno
+            try:
+                spec = importlib.util.find_spec(name, package=root_path)
+            except ModuleNotFoundError as e:
+                pytest.fail(
+                    f"{file.relative_to(root_path)}:{lineno}:"
+                    f" ModuleNotFoundError: {e.msg}"
+                )
+            if not (spec or name in sys.modules):
+                pytest.fail(
+                    f"{file.relative_to(root_path)}:{lineno}: "
+                    f"ImportError: No module named '{name}'"
+                )
+
+
+def import_node_names(import_node: Union[ast.Import, ast.ImportFrom]) -> List[str]:
+    """Get the names being imported by import nodes."""
+    if isinstance(import_node, ast.ImportFrom):
+        return [import_node.module]
+    if isinstance(import_node, ast.Import):
+        return [name.name for name in import_node.names]
+    raise Type("Unknown node type")
+
+
+def check_ast(doc, rel_path) -> ast.AST:
+    """Check that the source syntax is valid."""
+    source = "".join(eg.source for eg in doc.examples)
+    try:
+        return ast.parse(source)
+    except SyntaxError as e:
+        lineno = doc.lineno + doc.examples[0].lineno + e.lineno
+        pytest.fail(f"{rel_path}:{lineno}: SyntaxError: {e.msg}")

--- a/tiatoolbox/tools/pyramid.py
+++ b/tiatoolbox/tools/pyramid.py
@@ -264,7 +264,7 @@ class TilePyramidGenerator:
             ...   wsi=reader,
             ...   tile_size=256,
             ... )
-            >>>  tile_generator.dump(
+            >>> tile_generator.dump(
             ...    path="sample.gz.zip",
             ...    container="zip",
             ...    compression="gzip",

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -32,9 +32,8 @@ def split_path_name_ext(full_path):
             - :py:obj:`list(str)` - File extensions
 
     Examples:
-        >>> from tiatoolbox import utils
-        >>> dir_path, file_name, extensions =
-        ...     utils.misc.split_path_name_ext(full_path)
+        >>> from tiatoolbox.utils.misc import split_path_name_ext
+        >>> dir_path, file_name, extensions = split_path_name_ext(full_path)
 
     """
     input_path = pathlib.Path(full_path)

--- a/tiatoolbox/utils/transforms.py
+++ b/tiatoolbox/utils/transforms.py
@@ -29,8 +29,9 @@ def background_composite(image, fill=255, alpha=False):
         >>> from matplotlib import pyplot as plt
         >>> img_with_alpha = np.zeros((2000, 2000, 4)).astype('uint8')
         >>> img_with_alpha[:1000, :, 3] = 255 # edit alpha channel
-        >>> img_back_composite = transforms
-        ...     .background_composite(img_with_alpha)
+        >>> img_back_composite = transforms.background_composite(
+        ...     img_with_alpha
+        ... )
         >>> plt.imshow(img_with_alpha)
         >>> plt.imshow(img_back_composite)
         >>> plt.show()

--- a/tiatoolbox/visualization/tileserver.py
+++ b/tiatoolbox/visualization/tileserver.py
@@ -31,7 +31,7 @@ class TileServer(Flask):
             colourized using the 'viridis' colourmap
 
     Examples:
-        >>> from tiatoolbox.wsiscore.wsireader import WSIReader
+        >>> from tiatoolbox.wsicore.wsireader import WSIReader
         >>> from tiatoolbox.visualization.tileserver import TileServer
         >>> wsi = WSIReader.open("CMU-1.svs")
         >>> app = TileServer(

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -87,6 +87,7 @@ cuda
 cv2
 dataframe
 dataset
+doctest
 downsample
 downsampled
 downsampling


### PR DESCRIPTION
This adds a unit test which will:

1. Check that all docstring examples have a valid python syntax (checks that they parse to an abstract syntax tree).
2. That the imports in the example can be resolved.
3. Report exact source line number and reason for violation.

This has been used to correct several errors in docstring examples in this PR (See examples below).

This avoids actually executing the code. This is good for checking examples that:
- Require network access.
- Download large files.
- Require a GPU.
- Take a long time to run.
- Use dummy variables.

This could potentially be a pre-commit hook instead. The import detection part works well as a unit test because it uses the already set up environment of dependencies. This could however be done with a cached conda env hook. It can also be done by statically analyzing the requirements files as in #408. Although this is less reliable than actually installing the packages in an environment (because the import name can differ from the package name and there isn't a way to verify this short of downloading the packages from PyPI).

## Example Detected Syntax Errors

### Error
```
Failed: utils/misc.py:36: SyntaxError: invalid syntax
```

<details>

### Original
```
035 >>> from tiatoolbox import utils
036 >>> dir_path, file_name, extensions =
037 ...     utils.misc.split_path_name_ext(full_path)
```

### Corrected
```
035 >>> from tiatoolbox.utils.misc import split_path_name_ext
036 >>> dir_path, file_name, extensions = split_path_name_ext(
037 ...     full_path
038 ... )
```
</details>

---


### Error
```
Failed: utils/transforms.py:33: SyntaxError: unexpected indent
```

<details>

### Original
```
027 >>> from tiatoolbox.utils import transforms
028 >>> import numpy as np
029 >>> from matplotlib import pyplot as plt
030 >>> img_with_alpha = np.zeros((2000, 2000, 4)).astype('uint8')
031 >>> img_with_alpha[:1000, :, 3] = 255 # edit alpha channel
032 >>> img_back_composite = transforms
033 ...     .background_composite(img_with_alpha)
034 >>> plt.imshow(img_with_alpha)
035 >>> plt.imshow(img_back_composite)
036 >>> plt.show()
```

### Corrected
```
027 >>> from tiatoolbox.utils import transforms
028 >>> import numpy as np
029 >>> from matplotlib import pyplot as plt
030 >>> img_with_alpha = np.zeros((2000, 2000, 4)).astype('uint8')
031 >>> img_with_alpha[:1000, :, 3] = 255 # edit alpha channel
032 >>> img_back_composite = transforms.background_composite(
033 ...     img_with_alpha
034 ... )
035 >>> plt.imshow(img_with_alpha)
036 >>> plt.imshow(img_back_composite)
037 >>> plt.show()
```

</details>

---

### Error

```
Failed: visualization/tileserver.py:33: ModuleNotFoundError: No module named 'tiatoolbox.wsiscore'
```

<details>

### Original
```
034 >>> from tiatoolbox.wsiscore.wsireader import WSIReader
```

### Corrected
```
034 >>> from tiatoolbox.wsicore.wsireader import WSIReader
```

</details>