### PR TITLE
ENH: Improve Docstring Validity Test Error Output

### DIFF
--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -852,7 +852,7 @@ class AnnotationStore(ABC, MutableMapping):
                 ...     Annotation(
                 ...         geometry=Polygon.from_bounds(0, 0, 1, 1),
                 ...         properties={"class": 42},
-                ...     )
+                ...     ),
                 ...     key="foo",
                 ... )
                 >>> store.bquery(where="props['class'] == 42")


### PR DESCRIPTION
This PR improves the error output from docstring tests which fail by reducing error output and highlighting the offending line in the output.

This also fixes an error in a docstring which triggered the failing test.