### PR TITLE
BUG: Correct error in nucleus instance segmentor engine

### DIFF
--- a/tiatoolbox/models/engine/nucleus_instance_segmentor.py
+++ b/tiatoolbox/models/engine/nucleus_instance_segmentor.py
@@ -431,7 +431,7 @@ class NucleusInstanceSegmentor(SemanticSegmentor):
                 removal_flag[sel_indices, idx] = 0
             return removal_flag
 
-        h, w = image_shape
+        w, h = image_shape
         boxes = tile_outputs
         #  expand to full four corners
         boxes_br = boxes[:, 2:]


### PR DESCRIPTION
Correct error in nucleus instance segmentor engine where for tiles of different size widths/heights there are boundary artefacts.