### PR TITLE
DEV: Fix Flake8 E800 for tests

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 furo>=2022.6.21
-jinja2>=3.0.3
+jinja2>=3.0.3, <3.1.0
 myst-nb>=0.17.1
 myst-parser>=0.18.1
 sphinx-copybutton>=0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # torch installation
---extra-index-url https://download.pytorch.org/whl/cu113; sys_platform != "darwin"
+--extra-index-url https://download.pytorch.org/whl/cu116; sys_platform != "darwin"
 albumentations>=1.3.0
 Click>=8.1.3
 defusedxml>=0.7.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,8 @@ universal = 1
 [flake8]
 exclude = docs, *__init__*, setup.py
 max-line-length = 88
-extend-ignore = E203 # For black compatibility
+# For black compatibility
+extend-ignore = E203
 spellcheck-targets = comments
 dictionaries = en_US,python,technical
 max-cognitive-complexity = 14

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,8 @@ spellcheck-targets = comments
 dictionaries = en_US,python,technical
 max-cognitive-complexity = 14
 max-expression-complexity = 7
-per-file-ignores = test_*: E800
+# Use the command below ignore any flake8 checks
+# per-file-ignores = test_*: E800
 
 [aliases]
 test = pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,7 @@ spellcheck-targets = comments
 dictionaries = en_US,python,technical
 max-cognitive-complexity = 14
 max-expression-complexity = 7
-per-file-ignores =
-	test_*: E800
+per-file-ignores = test_*: E800
 
 [aliases]
 test = pytest

--- a/tests/models/test_arch_micronet.py
+++ b/tests/models/test_arch_micronet.py
@@ -1,4 +1,3 @@
-# skipcq: PTC-W6004
 """Unit test package for MicroNet."""
 
 import pathlib

--- a/tests/models/test_nucleus_instance_segmentor.py
+++ b/tests/models/test_nucleus_instance_segmentor.py
@@ -1,4 +1,3 @@
-# skipcq: PTC-W6004
 """Tests for Nucleus Instance Segmentor."""
 
 import copy

--- a/tests/test_annotation_stores.py
+++ b/tests/test_annotation_stores.py
@@ -1,4 +1,3 @@
-# skipcq: PTC-W6004, PYL-W0105
 """Tests for annotation store classes."""
 import json
 import pickle
@@ -1007,7 +1006,7 @@ class TestStore:
         keys, store = fill_store(store_cls, ":memory:")
         store.patch(keys[0], properties={"class": 123})
         results = store.query(
-            # (0, 0, 1024, 1024),
+            # (0, 0, 1024, 1024),  # noqa: E800
             where=lambda props: props.get("class")
             == 123,
         )

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -1,5 +1,4 @@
 """Tests for predicate module."""
-# skipcq: PYL-W0123
 import json
 import sqlite3
 from numbers import Number

--- a/tests/test_pyramid.py
+++ b/tests/test_pyramid.py
@@ -1,4 +1,3 @@
-# skipcq: PTC-W6004
 """Tests for tile pyramid generation."""
 import re
 from pathlib import Path

--- a/tests/test_slide_info.py
+++ b/tests/test_slide_info.py
@@ -1,4 +1,3 @@
-# skipcq: PTC-W6004
 """Tests for code related to obtaining slide information."""
 
 import pathlib

--- a/tests/test_stainnorm.py
+++ b/tests/test_stainnorm.py
@@ -1,4 +1,3 @@
-# skipcq: PTC-W6004
 """Tests for stain normalization code."""
 
 import pathlib

--- a/tests/test_stainnorm.py
+++ b/tests/test_stainnorm.py
@@ -50,7 +50,7 @@ def test_h_e_in_correct_order():
     he = stainextract.h_and_e_in_right_order(v1, v2)
     assert np.all(he == np.array([v1, v2]))
 
-    he = stainextract.h_and_e_in_right_order(v2, v1)
+    he = stainextract.h_and_e_in_right_order(v1=v2, v2=v1)
     assert np.all(he == np.array([v1, v2]))
 
 

--- a/tests/test_wsimeta.py
+++ b/tests/test_wsimeta.py
@@ -9,8 +9,9 @@ from tiatoolbox.wsicore import wsimeta, wsireader
 # noinspection PyTypeChecker
 def test_wsimeta_init_fail():
     """Test incorrect init for WSIMeta raises TypeError."""
+    dimensions = (None, None)
     with pytest.raises(TypeError):
-        wsimeta.WSIMeta(slide_dimensions=(None, None))
+        wsimeta.WSIMeta(slide_dimensions=dimensions)
 
 
 @pytest.mark.filterwarnings("ignore")

--- a/tests/test_wsimeta.py
+++ b/tests/test_wsimeta.py
@@ -9,9 +9,8 @@ from tiatoolbox.wsicore import wsimeta, wsireader
 # noinspection PyTypeChecker
 def test_wsimeta_init_fail():
     """Test incorrect init for WSIMeta raises TypeError."""
-    dimensions = (None, None)
     with pytest.raises(TypeError):
-        wsimeta.WSIMeta(slide_dimensions=dimensions)
+        wsimeta.WSIMeta(slide_dimensions=(None, None), axes="YXS")
 
 
 @pytest.mark.filterwarnings("ignore")

--- a/tests/test_wsimeta.py
+++ b/tests/test_wsimeta.py
@@ -10,7 +10,6 @@ from tiatoolbox.wsicore import wsimeta, wsireader
 def test_wsimeta_init_fail():
     """Test incorrect init for WSIMeta raises TypeError."""
     with pytest.raises(TypeError):
-        # skipcq: PYL-E1120
         wsimeta.WSIMeta(slide_dimensions=(None, None))
 
 

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -1,4 +1,3 @@
-# skipcq: PTC-W6004
 """Tests for reading whole-slide images."""
 
 import json


### PR DESCRIPTION
- Update `setup.cfg` for flake8 E800.
- Enables `E800` checks - "Found commented out code".
- Remove DeepSource ignore flags from test files.
- Update `requirements.txt` files
- Move comment in `setup.cfg` which is now causing an error.
- Fix DeepSource Errors.