### PR TITLE
DOC: Copy Sample SVS Loader From docs-examples-1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,8 @@ spellcheck-targets = comments
 dictionaries = en_US,python,technical
 max-cognitive-complexity = 14
 max-expression-complexity = 7
-per-file-ignores =
-	test_*: E800
+# Use the command below ignore any flake8 checks
+# per-file-ignores = test_*: E800
 
 [aliases]
 test = pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,8 @@ spellcheck-targets = comments
 dictionaries = en_US,python,technical
 max-cognitive-complexity = 14
 max-expression-complexity = 7
-# Use the command below ignore any flake8 checks
-# per-file-ignores = test_*: E800
+per-file-ignores =
+	test_*: E800
 
 [aliases]
 test = pytest

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -6,7 +6,7 @@ import pathlib
 import numpy as np
 import pytest
 
-from tiatoolbox.data import _fetch_remote_sample, stain_norm_target
+from tiatoolbox.data import _fetch_remote_sample, small_svs, stain_norm_target
 from tiatoolbox.wsicore.wsireader import WSIReader
 
 
@@ -63,3 +63,13 @@ def test_fetch_sample_skip(tmp_path):
     assert isinstance(arr, np.ndarray)
 
     _ = _fetch_remote_sample("stainnorm-source", tmp_path)
+
+
+def test_small_svs():
+    """Test for fetching small SVS (CMU-1-Small-Region) sample image."""
+    path = small_svs()
+    # Check it exists
+    assert path.exists()
+    assert path.is_file()
+    # Test if corrupted
+    WSIReader.open(path)

--- a/tiatoolbox/data/__init__.py
+++ b/tiatoolbox/data/__init__.py
@@ -108,3 +108,8 @@ def stain_norm_target() -> np.ndarray:
     from tiatoolbox.utils.misc import imread
 
     return imread(_local_sample_path("target_image.png"))
+
+
+def small_svs() -> pathlib.Path:
+    """Small SVS file for testing."""
+    return _fetch_remote_sample("svs-1-small")


### PR DESCRIPTION
This mirrors a subset of changes from #503 to add a sample SVS loading function `tiatoolbox.data.small_svs()` to the data module for use in documentation examples.