### PR TITLE
✨ WIP: Add SlidingWindowInRegionsPatchExtractor

### DIFF
--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -1026,13 +1026,13 @@ class PointsPatchExtractor(PatchExtractor):
         )
 
 
-def get_patch_extractor(method_name: str, **kwargs: str):
+def get_patch_extractor(method_name: str, *args, **kwargs: str):
     """Return a patch extractor object as requested.
 
     Args:
         method_name (str):
-            Name of patch extraction method, must be one of "point" or
-            "slidingwindow". The method name is case-insensitive.
+            Name of patch extraction method, must be one of "point",
+            "slidingwindow", or "region". The method name is case-insensitive.
         **kwargs:
             Keyword arguments passed to :obj:`PatchExtractor`.
 
@@ -1047,12 +1047,16 @@ def get_patch_extractor(method_name: str, **kwargs: str):
         ...  'point', img_patch_h=200, img_patch_w=200)
 
     """
-    if method_name.lower() not in ["point", "slidingwindow"]:
+
+    __availible_extractors = {
+        "point": PointsPatchExtractor,
+        "slidingwindow": SlidingWindowPatchExtractor,
+        "region": SlidingWindowInRegionsPatchExtractor,
+    }
+
+    try:
+        return __availible_extractors[method_name.lower()](*args, **kwargs)
+    except KeyError:
         raise MethodNotSupported(
             f"{method_name.lower()} method is not currently supported."
         )
-
-    if method_name.lower() == "point":
-        return PointsPatchExtractor(**kwargs)
-
-    return SlidingWindowPatchExtractor(**kwargs)

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -727,7 +727,8 @@ class SlidingWindowInRegionsPatchExtractor(PatchExtractorABC):
 
             if not isinstance(patch_size[0], int) or not isinstance(patch_size[1], int):
                 raise ValueError("patch_size should be a tuple of integers")
-                # NOTE: since casting float to int loses precision, we do not do that implicitly here and in stride
+                # NOTE: since casting float to int loses precision,
+                # we do not do that implicitly here and in stride
 
             self.patch_size = tuple(patch_size)
 
@@ -847,7 +848,8 @@ class SlidingWindowInRegionsPatchExtractor(PatchExtractorABC):
         for reg in regions:
             if len(reg) != 4:
                 raise ValueError(
-                    f"Size of each region should be 4 but got a region with size {len(reg)}"
+                    f"Size of each region should be 4 "
+                    f"but got a region with size {len(reg)}"
                 )
 
             x1, y1, w, h = reg


### PR DESCRIPTION
This PR adds `SlidingWindowInRegionsPatchExtractor`, which quickly samples regions of interest (ROI or regions) from an image into patches. 

Regions of interest are rectangles on an image that only need processing. For example, they are helpful if you train a pathology model on a bunch of images, and for each image, you only have specific annotated regions that can be used in learning. The concept of ROI is used when working with [Tumor-infiltrating lymphocytes](https://pubmed.ncbi.nlm.nih.gov/25214542/): for example, [the TIGER challenge](https://tiger.grand-challenge.org/Home/) contained train data as manually annotated regions of interest.

The task above can be solved with the existing `SlidingWindowPatchExtractor` with a manually created binary mask of whether a pixel is located in an ROI). However, this approach:
- requires **a lot** of memory: for each image, it creates and stores in RAM an array of all possible coordinate pairs that will be used for iteration;
- is slow because of the same reason;
- relies on the method which uses super unclear [magic numbers](https://github.com/TissueImageAnalytics/tiatoolbox/blob/0cbef86d62f87f5f4d8bb58351198c8f05831d9a/tiatoolbox/tools/patchextraction.py#L298) inside. 

Solving a simple ML task with `SlidingWindowPatchExtractor` required me an infinite number of time and memory. 
Thus, I wrote a new patch extractor for tasks that need fast data sampling and do not need mask support. 

https://user-images.githubusercontent.com/19199204/223590149-2f69957a-384d-4269-9c80-d7895f275273.mp4

---

The extractor does not store the coordinates inside but counts them on every request. That's why **it is much faster ⚡️:** [processing](https://gist.github.com/blaginin/01c518f2050370c083cffe9d21910d27) the same file takes 30 times less time and 450 times less memory than `SlidingWindowPatchExtractor`. 

To simplify data processing, I added support for coordinates extraction: if `return_coordinates` is set, the iterator will return a patch and its coordinates. For example, this can be useful to find the metadata objects in this patch. 

Because there exist many methods of sampling a region in batches, I added a few arguments to the class:
  - `within_region_bound` guarantees that all samples will be fully located inside the wsi;
- `within_wsi_bound` guarantees that all samples will be fully located inside the wsi. Same as in the original class;
- `min_region_covered` is the minimum number of pixels inside a region that all images have to have;
- `patch_size`, `resolution`, and `stride` from the original class are also supported. 

This image illustrates some of the arguments above:
![wsi](https://user-images.githubusercontent.com/19199204/223590012-49c0235d-c189-434d-ba36-030d06036346.png)
