### PR TITLE
:wrench: DEV: Filter Logger Output to `stdout` and `stderr`

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -40,14 +40,34 @@ def test_set_logger():
     logger.handlers = []  # reset first to overwrite import
     handler_1 = logging.StreamHandler()
     handler_2 = logging.StreamHandler()
+    handler_3 = logging.StreamHandler()
     logger.addHandler(handler_1)
     logger.addHandler(handler_2)
-    assert len(logger.handlers) == 2
+    logger.addHandler(handler_3)
+    assert len(logger.handlers) == 3
     # skipcq
     importlib.reload(tiatoolbox)
     # should not overwrite, so still have 2 handler
-    assert len(logger.handlers) == 2
+    assert len(logger.handlers) == 3
     logger.handlers = []  # remove all handler
     # skipcq
     importlib.reload(tiatoolbox)
-    assert len(logger.handlers) == 1
+    assert len(logger.handlers) == 2
+
+def test_logger_output():
+    """Tests if logger is writing output to correct value."""
+    from tiatoolbox import logger
+    logger.setLevel(logging.DEBUG)
+    logger.debug("Test if debug is written to stdout.")
+
+    logger.setLevel(logging.INFO)
+    logger.info("Test if info written to stdout.")
+
+    logger.setLevel(logging.WARNING)
+    logger.warning("Test if warning written to stderr.")
+
+    logger.setLevel(logging.ERROR)
+    logger.error("Test if error is written to stderr.")
+
+    logger.setLevel(logging.CRITICAL)
+    logger.critical("Test if critical is written to stderr.")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,6 +4,7 @@ import importlib
 import logging
 import os
 import shutil
+import subprocess
 
 import pytest
 
@@ -55,21 +56,84 @@ def test_set_logger():
     assert len(logger.handlers) == 2
 
 
+def helper_logger_test(run_statement: str):
+    """Helper for logger tests."""
+    proc = subprocess.Popen(
+        [
+            "python",
+            "-c",
+            run_statement,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return proc.communicate()[0], proc.communicate()[1]
+
+
 def test_logger_output():
     """Tests if logger is writing output to correct value."""
-    from tiatoolbox import logger
+    # Test DEBUG is written to stdout
+    run_statement = (
+        "from tiatoolbox import logger; "
+        "import logging; "
+        "logger.setLevel(logging.DEBUG); "
+        'logger.debug("Test if debug is written to stdout.")'
+    )
+    out, err = helper_logger_test(run_statement=run_statement)
+    assert b"[DEBUG] Test if debug is written to stdout." in out
+    assert err == b""
 
-    logger.setLevel(logging.DEBUG)
-    logger.debug("Test if debug is written to stdout.")
+    # Test INFO is written to stdout
+    run_statement = (
+        "from tiatoolbox import logger; "
+        "import logging; "
+        "logger.setLevel(logging.INFO); "
+        'logger.info("Test if info is written to stdout.")'
+    )
+    out, err = helper_logger_test(run_statement=run_statement)
+    assert b"[INFO] Test if info is written to stdout." in out
+    assert err == b""
 
-    logger.setLevel(logging.INFO)
-    logger.info("Test if info written to stdout.")
+    # Test WARNING is written to stderr
+    run_statement = (
+        "from tiatoolbox import logger; "
+        "import logging; "
+        "logger.setLevel(logging.WARNING); "
+        'logger.warning("Test if warning is written to stderr.")'
+    )
+    out, err = helper_logger_test(run_statement=run_statement)
+    assert out == b""
+    assert b"[WARNING] Test if warning is written to stderr." in err
 
-    logger.setLevel(logging.WARNING)
-    logger.warning("Test if warning written to stderr.")
+    # Test ERROR is written to stderr
+    run_statement = (
+        "from tiatoolbox import logger; "
+        "import logging; "
+        "logger.setLevel(logging.ERROR); "
+        'logger.error("Test if error is written to stderr.")'
+    )
+    out, err = helper_logger_test(run_statement=run_statement)
+    assert out == b""
+    assert b"[ERROR] Test if error is written to stderr." in err
 
-    logger.setLevel(logging.ERROR)
-    logger.error("Test if error is written to stderr.")
+    # Test ERROR is written to stderr
+    run_statement = (
+        "from tiatoolbox import logger; "
+        "import logging; "
+        "logger.setLevel(logging.ERROR); "
+        'logger.error("Test if error is written to stderr.")'
+    )
+    out, err = helper_logger_test(run_statement=run_statement)
+    assert out == b""
+    assert b"[ERROR] Test if error is written to stderr." in err
 
-    logger.setLevel(logging.CRITICAL)
-    logger.critical("Test if critical is written to stderr.")
+    # Test CRITICAL is written to stderr
+    run_statement = (
+        "from tiatoolbox import logger; "
+        "import logging; "
+        "logger.setLevel(logging.CRITICAL); "
+        'logger.critical("Test if critical is written to stderr.")'
+    )
+    out, err = helper_logger_test(run_statement=run_statement)
+    assert out == b""
+    assert b"[CRITICAL] Test if critical is written to stderr." in err

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -54,9 +54,11 @@ def test_set_logger():
     importlib.reload(tiatoolbox)
     assert len(logger.handlers) == 2
 
+
 def test_logger_output():
     """Tests if logger is writing output to correct value."""
     from tiatoolbox import logger
+
     logger.setLevel(logging.DEBUG)
     logger.debug("Test if debug is written to stdout.")
 

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -5,6 +5,8 @@ from click.testing import CliRunner
 
 from tiatoolbox import __version__, cli
 
+import logging
+
 # -------------------------------------------------------------------------------------
 # Command Line Interface
 # -------------------------------------------------------------------------------------
@@ -27,3 +29,25 @@ def test_command_line_version():
     assert __version__ in version_result.output
     version_result = runner.invoke(cli.main, ["--version"])
     assert __version__ in version_result.output
+
+
+def test_logger_output(capsys):
+    """Tests if logger is writing output to correct value."""
+    from tiatoolbox import logger
+    logger.setLevel(logging.DEBUG)
+    logger.debug("Test if debug is written to stdout.")
+
+    logger.setLevel(logging.INFO)
+    logger.info("Test if info written to stdout.")
+
+    logger.setLevel(logging.WARNING)
+    logger.warning("Test if warning written to stderr.")
+
+    logger.setLevel(logging.ERROR)
+    logger.error("Test if error is written to stderr.")
+
+    logger.setLevel(logging.CRITICAL)
+    logger.critical("Test if critical is written to stderr.")
+
+    print("not working")
+    capsys

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -5,8 +5,6 @@ from click.testing import CliRunner
 
 from tiatoolbox import __version__, cli
 
-import logging
-
 # -------------------------------------------------------------------------------------
 # Command Line Interface
 # -------------------------------------------------------------------------------------
@@ -29,25 +27,3 @@ def test_command_line_version():
     assert __version__ in version_result.output
     version_result = runner.invoke(cli.main, ["--version"])
     assert __version__ in version_result.output
-
-
-def test_logger_output(capsys):
-    """Tests if logger is writing output to correct value."""
-    from tiatoolbox import logger
-    logger.setLevel(logging.DEBUG)
-    logger.debug("Test if debug is written to stdout.")
-
-    logger.setLevel(logging.INFO)
-    logger.info("Test if info written to stdout.")
-
-    logger.setLevel(logging.WARNING)
-    logger.warning("Test if warning written to stderr.")
-
-    logger.setLevel(logging.ERROR)
-    logger.error("Test if error is written to stderr.")
-
-    logger.setLevel(logging.CRITICAL)
-    logger.critical("Test if critical is written to stderr.")
-
-    print("not working")
-    capsys

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -25,7 +25,7 @@ import logging
 # logging
 logging.captureWarnings(True)
 if not logging.getLogger().hasHandlers():
-    handler = logging.StreamHandler()
+    handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter(
         "|%(asctime)s.%(msecs)03d| [%(levelname)s] %(message)s",
         datefmt="%Y-%m-%d|%H:%M:%S",

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -25,15 +25,22 @@ import logging
 # logging
 logging.captureWarnings(True)
 if not logging.getLogger().hasHandlers():
-    handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter(
         "|%(asctime)s.%(msecs)03d| [%(levelname)s] %(message)s",
         datefmt="%Y-%m-%d|%H:%M:%S",
     )
-    handler.setFormatter(formatter)
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(formatter)
+    stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)
+
+    stderr_handler = logging.StreamHandler()
+    stderr_handler.setFormatter(formatter)
+    stderr_handler.setLevel(logging.WARNING)
+
     logger = logging.getLogger()  # get root logger
     logger.setLevel(logging.INFO)
-    logger.addHandler(handler)
+    logger.addHandler(stdout_handler)
+    logger.addHandler(stderr_handler)
 else:
     logger = logging.getLogger()
 


### PR DESCRIPTION
- Filter logger output to `stdout` instead of `stderr`