### PR TITLE
fix level when using dicom read_region

### DIFF
--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -4072,7 +4072,8 @@ class DICOMWSIReader(WSIReader):
         _, constrained_read_size = utils.transforms.bounds2locsize(
             constrained_read_bounds
         )
-        im_region = wsi.read_region(location, read_level, constrained_read_size)
+        dicom_level = wsi.levels[read_level].level
+        im_region = wsi.read_region(location, dicom_level, constrained_read_size)
         im_region = np.array(im_region)
 
         # Apply padding outside the slide area
@@ -4246,8 +4247,9 @@ class DICOMWSIReader(WSIReader):
             level_location, size_at_read_level, level_size
         )
         _, read_size = utils.transforms.bounds2locsize(read_bounds)
+        dicom_level = wsi.levels[read_level].level
         im_region = wsi.read_region(
-            location=location_at_baseline, level=read_level, size=read_size
+            location=location_at_baseline, level=dicom_level, size=read_size
         )
         im_region = np.array(im_region)
 


### PR DESCRIPTION
This PR fixes the dicom slide thunbnail issue (maybe). the issue seems to arise from a difference in how the wsidicom reader treats levels, in that it labels them by their relative magnification.

so the levels in the wsidicom reader are [0, 2, 4]

whereas in our WSIReader level is just an index [0, 1, 2], and the level_downsamples are separate.

My knowledge of DICOM is nonexistant, so it may be that the fix is wrong - hopefully john can have a look at it. It fixed the thumbnail issue for me though.