### PR TITLE
🩹 BUG: Fix Parsing Missing Omero Version NGFF Metadata

### DIFF
--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -2034,7 +2034,7 @@ def test_ngff_empty_datasets_mpp(tmp_path):
     assert wsi.info.mpp is None
 
 
-def test_nff_no_scale_transforms_mpp(tmp_path):
+def test_ngff_no_scale_transforms_mpp(tmp_path):
     """Test that mpp is None if no scale transforms are present."""
     sample = _fetch_remote_sample("ngff-1")
     # Create a copy of the sample with no axes

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -2102,6 +2102,38 @@ def test_ngff_wrong_format_metadata(tmp_path, caplog):
     assert "must be present and of the correct type" in caplog.text
 
 
+def test_ngff_below_min_version(tmp_path):
+    """Test for FileNotSupported when version is below minimum."""
+    sample = _fetch_remote_sample("ngff-1")
+    # Create a copy of the sample
+    sample_copy = tmp_path / "ngff-1.zarr"
+    shutil.copytree(sample, sample_copy)
+    with open(sample_copy / ".zattrs", "r") as fh:
+        zattrs = json.load(fh)
+    # Change the format to something else
+    zattrs["omero"]["version"] = "0.0"
+    with open(sample_copy / ".zattrs", "w") as fh:
+        json.dump(zattrs, fh, indent=2)
+    with pytest.raises(FileNotSupported):
+        wsireader.WSIReader.open(sample_copy)
+
+
+def test_ngff_above_max_version(tmp_path):
+    """Test for FileNotSupported when version is above maximum."""
+    sample = _fetch_remote_sample("ngff-1")
+    # Create a copy of the sample
+    sample_copy = tmp_path / "ngff-1.zarr"
+    shutil.copytree(sample, sample_copy)
+    with open(sample_copy / ".zattrs", "r") as fh:
+        zattrs = json.load(fh)
+    # Change the format to something else
+    zattrs["omero"]["version"] = "10.0"
+    with open(sample_copy / ".zattrs", "w") as fh:
+        json.dump(zattrs, fh, indent=2)
+    with pytest.raises(FileNotSupported):
+        wsireader.WSIReader.open(sample_copy)
+
+
 def test_ngff_non_numeric_version(tmp_path, monkeypatch):
     """Test that the reader can handle non-numeric omero versions."""
 

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -2038,7 +2038,7 @@ def test_ngff_no_scale_transforms_mpp(tmp_path):
     """Test that mpp is None if no scale transforms are present."""
     sample = _fetch_remote_sample("ngff-1")
     # Create a copy of the sample with no axes
-    sample_copy = tmp_path / "ngff-1"
+    sample_copy = tmp_path / "ngff-1.zarr"
     shutil.copytree(sample, sample_copy)
     with open(sample_copy / ".zattrs", "r") as fh:
         zattrs = json.load(fh)
@@ -2049,6 +2049,21 @@ def test_ngff_no_scale_transforms_mpp(tmp_path):
         json.dump(zattrs, fh, indent=2)
     wsi = wsireader.NGFFWSIReader(sample_copy)
     assert wsi.info.mpp is None
+
+
+def test_ngff_missing_omero_version(tmp_path):
+    """Test that the reader can handle missing omero version."""
+    sample = _fetch_remote_sample("ngff-1")
+    # Create a copy of the sample with no axes
+    sample_copy = tmp_path / "ngff-1.zarr"
+    shutil.copytree(sample, sample_copy)
+    with open(sample_copy / ".zattrs", "r") as fh:
+        zattrs = json.load(fh)
+    # Remove the omero version
+    del zattrs["omero"]["version"]
+    with open(sample_copy / ".zattrs", "w") as fh:
+        json.dump(zattrs, fh, indent=2)
+    wsireader.WSIReader.open(sample_copy)
 
 
 class TestReader:

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -2102,8 +2102,8 @@ def test_ngff_wrong_format_metadata(tmp_path, caplog):
     assert "must be present and of the correct type" in caplog.text
 
 
-def test_ngff_below_min_version(tmp_path):
-    """Test for FileNotSupported when version is below minimum."""
+def test_ngff_omero_below_min_version(tmp_path):
+    """Test for FileNotSupported when omero version is below minimum."""
     sample = _fetch_remote_sample("ngff-1")
     # Create a copy of the sample
     sample_copy = tmp_path / "ngff-1.zarr"
@@ -2118,8 +2118,8 @@ def test_ngff_below_min_version(tmp_path):
         wsireader.WSIReader.open(sample_copy)
 
 
-def test_ngff_above_max_version(tmp_path):
-    """Test for FileNotSupported when version is above maximum."""
+def test_ngff_omero_above_max_version(tmp_path):
+    """Test for FileNotSupported when omero version is above maximum."""
     sample = _fetch_remote_sample("ngff-1")
     # Create a copy of the sample
     sample_copy = tmp_path / "ngff-1.zarr"
@@ -2128,6 +2128,38 @@ def test_ngff_above_max_version(tmp_path):
         zattrs = json.load(fh)
     # Change the format to something else
     zattrs["omero"]["version"] = "10.0"
+    with open(sample_copy / ".zattrs", "w") as fh:
+        json.dump(zattrs, fh, indent=2)
+    with pytest.raises(FileNotSupported):
+        wsireader.WSIReader.open(sample_copy)
+
+
+def test_ngff_multiscales_below_min_version(tmp_path):
+    """Test for FileNotSupported when multiscales version is below minimum."""
+    sample = _fetch_remote_sample("ngff-1")
+    # Create a copy of the sample
+    sample_copy = tmp_path / "ngff-1.zarr"
+    shutil.copytree(sample, sample_copy)
+    with open(sample_copy / ".zattrs", "r") as fh:
+        zattrs = json.load(fh)
+    # Change the format to something else
+    zattrs["multiscales"][0]["version"] = "0.0"
+    with open(sample_copy / ".zattrs", "w") as fh:
+        json.dump(zattrs, fh, indent=2)
+    with pytest.raises(FileNotSupported):
+        wsireader.WSIReader.open(sample_copy)
+
+
+def test_ngff_multiscales_above_max_version(tmp_path):
+    """Test for FileNotSupported when multiscales version is above maximum."""
+    sample = _fetch_remote_sample("ngff-1")
+    # Create a copy of the sample
+    sample_copy = tmp_path / "ngff-1.zarr"
+    shutil.copytree(sample, sample_copy)
+    with open(sample_copy / ".zattrs", "r") as fh:
+        zattrs = json.load(fh)
+    # Change the format to something else
+    zattrs["multiscales"][0]["version"] = "10.0"
     with open(sample_copy / ".zattrs", "w") as fh:
         json.dump(zattrs, fh, indent=2)
     with pytest.raises(FileNotSupported):

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -2066,6 +2066,21 @@ def test_ngff_missing_omero_version(tmp_path):
     wsireader.WSIReader.open(sample_copy)
 
 
+def test_ngff_non_numeric_version(tmp_path):
+    """Test that the reader can handle non-numeric omero versions."""
+    sample = _fetch_remote_sample("ngff-1")
+    # Create a copy of the sample
+    sample_copy = tmp_path / "ngff-1.zarr"
+    shutil.copytree(sample, sample_copy)
+    with open(sample_copy / ".zattrs", "r") as fh:
+        zattrs = json.load(fh)
+    # Set the omero version to a non-numeric string
+    zattrs["omero"]["version"] = "0.5-dev"
+    with open(sample_copy / ".zattrs", "w") as fh:
+        json.dump(zattrs, fh, indent=2)
+    wsireader.WSIReader.open(sample_copy)
+
+
 class TestReader:
     scenarios = [
         (

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -2054,7 +2054,7 @@ def test_ngff_no_scale_transforms_mpp(tmp_path):
 def test_ngff_missing_omero_version(tmp_path):
     """Test that the reader can handle missing omero version."""
     sample = _fetch_remote_sample("ngff-1")
-    # Create a copy of the sample with no axes
+    # Create a copy of the sample
     sample_copy = tmp_path / "ngff-1.zarr"
     shutil.copytree(sample, sample_copy)
     with open(sample_copy / ".zattrs", "r") as fh:

--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -97,7 +97,7 @@ def is_zarr(path: pathlib.Path) -> bool:
         return False
 
 
-def is_ngff(path: pathlib.Path, min_version: Tuple[int, ...] = (0, 4)) -> bool:
+def is_ngff(path: pathlib.Path, min_version: Tuple[str, ...] = ("0", "4")) -> bool:
     """Check if the input is a NGFF file.
 
     Args:

--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -139,10 +139,11 @@ def is_ngff(path: pathlib.Path, min_version: Tuple[int, ...] = (0, 4)) -> bool:
     omero_version = omero.get("verion")
     if omero_version:
         omero_version = tuple(omero_version.split("."))
+        if omero_version < min_version:
+            return False
     if any(version < min_version for version in multiscales_versions):
         return False
-    if omero_version < min_version:
-        return False
+
     return is_zarr(path)
 
 

--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -136,7 +136,9 @@ def is_ngff(path: pathlib.Path, min_version: Tuple[int, ...] = (0, 4)) -> bool:
         tuple(int(part) for part in scale.get("version", "").split("."))
         for scale in multiscales
     )
-    omero_version = tuple(int(part) for part in omero.get("version", "").split("."))
+    omero_version = omero.get("verion")
+    if omero_version:
+        omero_version = tuple(omero_version.split("."))
     if any(version < min_version for version in multiscales_versions):
         return False
     if omero_version < min_version:

--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -136,7 +136,7 @@ def is_ngff(path: pathlib.Path, min_version: Tuple[int, ...] = (0, 4)) -> bool:
         tuple(int(part) for part in scale.get("version", "").split("."))
         for scale in multiscales
     )
-    omero_version = omero.get("verion")
+    omero_version = omero.get("version")
     if omero_version:
         omero_version = tuple(omero_version.split("."))
         if omero_version < min_version:

--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -136,6 +136,11 @@ def is_ngff(
                 all(isinstance(m, dict) for m in multiscales),
             ]
         ):
+            logger.warning(
+                "The NGFF file is not valid. "
+                "The multiscales, _ARRAY_DIMENSIONS and omero attributes "
+                "must be present and of the correct type."
+            )
             return False
     except KeyError:
         return False

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -129,8 +129,10 @@ macports
 memray
 mpp
 mse
+multiscales
 natively
 ndarray
+ngff
 nn
 noinspection
 normalizer

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -41,6 +41,7 @@ Nx4
 NxM
 NxN
 OME
+Omero
 Omnyx
 OpenCV
 Otsu's


### PR DESCRIPTION
# To-Do

- [x] Handle missing version keys and null values.
- [x] Add test for missing value
- [x] Add test for non-numeric values e.g. "0.5-dev" [see current spec doc](https://ngff.openmicroscopy.org/latest/#omero-md)
- [x] Warn if version < or > 0.4
- [x] Warn for inconsistent versions