### PR TITLE
🔧 Use `pyproject.toml` for `pytest` Configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.pytest.ini_options]
+collect_ignore = ["setup.py", "benchmark/"]
+
 [tool.black]
   exclude = '''
   /(


### PR DESCRIPTION
- Use `pyproject.toml` for `pytest` Configuration