### PR TITLE
:art: Move Models to Top-Level Import

### DIFF
--- a/tests/models/test_arch_idars.py
+++ b/tests/models/test_arch_idars.py
@@ -2,7 +2,7 @@
 
 import torch
 
-from tiatoolbox.models.architecture.idars import IDaRS
+from tiatoolbox.models import IDaRS
 
 
 def test_functional():

--- a/tests/models/test_arch_mapde.py
+++ b/tests/models/test_arch_mapde.py
@@ -3,8 +3,8 @@ import numpy as np
 import torch
 
 from tiatoolbox import utils
+from tiatoolbox.models import MapDe
 from tiatoolbox.models.architecture import fetch_pretrained_weights
-from tiatoolbox.models.architecture.mapde import MapDe
 from tiatoolbox.wsicore.wsireader import WSIReader
 
 

--- a/tests/models/test_arch_micronet.py
+++ b/tests/models/test_arch_micronet.py
@@ -7,8 +7,8 @@ import pytest
 import torch
 
 from tiatoolbox import utils
+from tiatoolbox.models import MicroNet
 from tiatoolbox.models.architecture import fetch_pretrained_weights
-from tiatoolbox.models.architecture.micronet import MicroNet
 from tiatoolbox.models.engine.semantic_segmentor import SemanticSegmentor
 from tiatoolbox.utils import env_detection as toolbox_env
 from tiatoolbox.wsicore.wsireader import WSIReader

--- a/tests/models/test_arch_nuclick.py
+++ b/tests/models/test_arch_nuclick.py
@@ -6,8 +6,8 @@ import numpy as np
 import pytest
 import torch
 
+from tiatoolbox.models import NuClick
 from tiatoolbox.models.architecture import fetch_pretrained_weights
-from tiatoolbox.models.architecture.nuclick import NuClick
 from tiatoolbox.utils.misc import imread
 
 ON_GPU = False

--- a/tests/models/test_arch_sccnn.py
+++ b/tests/models/test_arch_sccnn.py
@@ -3,8 +3,8 @@ import numpy as np
 import torch
 
 from tiatoolbox import utils
+from tiatoolbox.models import SCCNN
 from tiatoolbox.models.architecture import fetch_pretrained_weights
-from tiatoolbox.models.architecture.sccnn import SCCNN
 from tiatoolbox.wsicore.wsireader import WSIReader
 
 

--- a/tests/models/test_hovernet.py
+++ b/tests/models/test_hovernet.py
@@ -5,10 +5,10 @@ import pytest
 import torch
 import torch.nn as nn
 
+from tiatoolbox.models import HoVerNet
 from tiatoolbox.models.architecture import fetch_pretrained_weights
 from tiatoolbox.models.architecture.hovernet import (
     DenseBlock,
-    HoVerNet,
     ResidualBlock,
     TFSamepaddingLayer,
 )

--- a/tests/models/test_hovernetplus.py
+++ b/tests/models/test_hovernetplus.py
@@ -2,8 +2,8 @@
 
 import torch
 
+from tiatoolbox.models import HoVerNetPlus
 from tiatoolbox.models.architecture import fetch_pretrained_weights
-from tiatoolbox.models.architecture.hovernetplus import HoVerNetPlus
 from tiatoolbox.utils.misc import imread
 from tiatoolbox.utils.transforms import imresize
 

--- a/tiatoolbox/models/__init__.py
+++ b/tiatoolbox/models/__init__.py
@@ -13,3 +13,19 @@ from tiatoolbox.models.engine.semantic_segmentor import (
     SemanticSegmentor,
     WSIStreamDataset,
 )
+
+from .architecture.hovernet import HoVerNet
+from .architecture.hovernetplus import HoVerNetPlus
+from .architecture.idars import IDaRS
+from .architecture.mapde import MapDe
+from .architecture.micronet import MicroNet
+from .architecture.nuclick import NuClick
+from .architecture.sccnn import SCCNN
+
+HoVerNet = HoVerNet
+HoVerNetPlus = HoVerNetPlus
+IDaRS = IDaRS
+MapDe = MapDe
+MicroNet = MicroNet
+NuClick = NuClick
+SCCNN = SCCNN


### PR DESCRIPTION
- Move the following models to top-level import
  - HoVerNet
  - HoVerNetPlus
  - IDaRS
  - MapDe
  - MicroNet
  - NuClick
  - SCCNN