### PR TITLE
:wrench: Use `pyproject.toml` for `bdist_wheel` Configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,10 @@
   ]
   ignore_errors = true
   omit = ['tests/*', 'tiatoolbox/__main__.py', '*/utils/env_detection.py']
+
+[build-system]
+  requires = ["setuptools"]
+  build-backend = "setuptools.build_meta"
+
+[tool.distutils.bdist_wheel]
+  universal = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,9 +19,6 @@ replace = version: {new_version}  # TIAToolbox version
 search = TOOLBOX_VER: {current_version}
 replace = TOOLBOX_VER: {new_version}
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 exclude = docs, *__init__*, setup.py
 max-line-length = 88
@@ -30,9 +27,6 @@ spellcheck-targets = comments
 dictionaries = en_US,python,technical
 max-cognitive-complexity = 14
 max-expression-complexity = 7
-
-[aliases]
-test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py', 'benchmark/']


### PR DESCRIPTION
- Use `pyproject.toml` for `bdist_wheel` configuration
- Remove `aliases`