### PR TITLE
🔧 Use `pyproject.toml` for `pytest` Configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.pytest.ini_options]
-collect_ignore = ["setup.py", "benchmark/"]
+  collect_ignore = ["setup.py", "benchmark/"]
 
 [tool.black]
   exclude = '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,3 @@ spellcheck-targets = comments
 dictionaries = en_US,python,technical
 max-cognitive-complexity = 14
 max-expression-complexity = 7
-
-[tool:pytest]
-collect_ignore = ['setup.py', 'benchmark/']


### PR DESCRIPTION
- Use `pyproject.toml` for `pytest` Configuration