### PR TITLE
🐛 Fix for Recent `wsidicom` Update

### DIFF
--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -3831,7 +3831,7 @@ class DICOMWSIReader(WSIReader):
             )
             for level in self.wsi.levels
         ]
-        dataset = self.wsi.base_level.datasets[0]
+        dataset = self.wsi.levels.base_level.datasets[0]
         # Get pixel spacing in mm from DICOM file and convert to um/px (mpp)
         mm_per_pixel = dataset.pixel_spacing
         mpp = (mm_per_pixel.width * 1e3, mm_per_pixel.height * 1e3)


### PR DESCRIPTION
wsidicom has been updated today. I noticed it makes a change which breaks one of the tests.

our code gets the base level as `dataset = self.wsi.base_level.datasets[0]`

The WsiDicom object has recently been changed so that this base_level is no longer a property of WsiDicom object, it is instead now only in `self.wsi.levels.base_level.datasets[0]` (before the update it was in both).

See [here](https://github.com/imi-bigpicture/wsidicom/commit/90671211ddb87096d19952d5e80a7199dda51b67#diff-c193bbcec87f294abe8cc7a11e0ff209eea7d49407ff301734499e8956477501L98-L101), line 98-101 in wsidicom.py diff.