### PR TITLE
🚨 Use `logger` Instead Of `warnings` for `utils` Package

### DIFF
--- a/tests/test_annotation_tilerendering.py
+++ b/tests/test_annotation_tilerendering.py
@@ -249,7 +249,7 @@ def test_sub_tile_levels(fill_store, tmp_path):
     assert tile.size == (112, 112)
 
 
-def test_unknown_geometry(fill_store, tmp_path):
+def test_unknown_geometry(fill_store, tmp_path, caplog):
     """Test warning when unknown geometries are present that cannot
     be rendered.
     """
@@ -262,8 +262,8 @@ def test_unknown_geometry(fill_store, tmp_path):
     store.commit()
     renderer = AnnotationRenderer(max_scale=8, edge_thickness=0)
     tg = AnnotationTileGenerator(wsi.info, store, renderer, tile_size=256)
-    with pytest.warns(UserWarning, match="Unknown geometry"):
-        tg.get_tile(0, 0, 0)
+    tg.get_tile(0, 0, 0)
+    assert "Unknown geometry" in caplog.text
 
 
 def test_interp_pad_warning(fill_store, tmp_path):

--- a/tests/test_annotation_tilerendering.py
+++ b/tests/test_annotation_tilerendering.py
@@ -250,8 +250,10 @@ def test_sub_tile_levels(fill_store, tmp_path):
 
 
 def test_unknown_geometry(fill_store, tmp_path, caplog):
-    """Test warning when unknown geometries are present that cannot
+    """
+    Test warning when unknown geometries are present that cannot
     be rendered.
+
     """
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array)
@@ -327,8 +329,10 @@ def test_categorical_mapper(fill_store, tmp_path):
 
 
 def test_colour_prop_warning(fill_store, tmp_path, caplog):
-    """Test warning when rendering annotations in which the provided
+    """
+    Test warning when rendering annotations in which the provided
     score_prop does not exist.
+
     """
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))

--- a/tests/test_annotation_tilerendering.py
+++ b/tests/test_annotation_tilerendering.py
@@ -326,7 +326,7 @@ def test_categorical_mapper(fill_store, tmp_path):
             assert 0 <= val <= 1
 
 
-def test_colour_prop_warning(fill_store, tmp_path):
+def test_colour_prop_warning(fill_store, tmp_path, caplog):
     """Test warning when rendering annotations in which the provided
     score_prop does not exist.
     """
@@ -335,8 +335,8 @@ def test_colour_prop_warning(fill_store, tmp_path):
     _, store = fill_store(SQLiteStore, tmp_path / "test.db")
     renderer = AnnotationRenderer(score_prop="nonexistant_prop")
     tg = AnnotationTileGenerator(wsi.info, store, renderer, tile_size=256)
-    with pytest.warns(UserWarning, match="not found in properties"):
-        tg.get_tile(1, 0, 0)
+    tg.get_tile(1, 0, 0)
+    assert "not found in properties" in caplog.text
 
 
 def test_blur(fill_store, tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1435,7 +1435,7 @@ def test_from_multi_head_dat(tmp_path):
     assert len(result) == 1
 
 
-def test_invalid_poly(tmp_path):
+def test_invalid_poly(tmp_path, caplog):
     """Test that invalid polygons are dealt with correctly."""
     coords = [(0, 0), (0, 2), (1, 1), (2, 2), (2, 0), (1, 1), (0, 0)]
     poly = Polygon(coords)
@@ -1447,8 +1447,9 @@ def test_invalid_poly(tmp_path):
         "type": 2,
     }
     joblib.dump(data, tmp_path / "test.dat")
-    with pytest.warns(UserWarning, match="Invalid geometry found, fix"):
-        store = utils.misc.store_from_dat(tmp_path / "test.dat")
+    store = utils.misc.store_from_dat(tmp_path / "test.dat")
+
+    assert "Invalid geometry found, fix" in caplog.text
 
     result = store.query(where="props['type'] == 2")
     assert next(iter(result.values())).geometry.is_valid

--- a/tiatoolbox/utils/image.py
+++ b/tiatoolbox/utils/image.py
@@ -547,7 +547,9 @@ def sub_pixel_read(  # noqa: CCR001
     # than the right/end_x and bottom/end_y values.
     bounds, fliplr, flipud = make_bounds_size_positive(bounds)
     if fliplr or flipud:
-        logger.warning("Bounds have a negative size, output will be flipped.", stacklevel=2)
+        logger.warning(
+            "Bounds have a negative size, output will be flipped.", stacklevel=2
+        )
 
     if isinstance(image, Image.Image):
         image = np.array(image)

--- a/tiatoolbox/utils/image.py
+++ b/tiatoolbox/utils/image.py
@@ -547,7 +547,7 @@ def sub_pixel_read(  # noqa: CCR001
     # than the right/end_x and bottom/end_y values.
     bounds, fliplr, flipud = make_bounds_size_positive(bounds)
     if fliplr or flipud:
-        logger.warning("Bounds have a negative size, output will be flipped.")
+        logger.warning("Bounds have a negative size, output will be flipped.", stacklevel=2)
 
     if isinstance(image, Image.Image):
         image = np.array(image)

--- a/tiatoolbox/utils/image.py
+++ b/tiatoolbox/utils/image.py
@@ -1,10 +1,10 @@
 """Miscellaneous utilities which operate on image data."""
-import warnings
 from typing import Tuple, Union
 
 import numpy as np
 from PIL import Image
 
+from tiatoolbox import logger
 from tiatoolbox.utils.misc import conv_out_size
 from tiatoolbox.utils.transforms import (
     bounds2locsize,
@@ -547,9 +547,7 @@ def sub_pixel_read(  # noqa: CCR001
     # than the right/end_x and bottom/end_y values.
     bounds, fliplr, flipud = make_bounds_size_positive(bounds)
     if fliplr or flipud:
-        warnings.warn(
-            "Bounds have a negative size, output will be flipped.", stacklevel=2
-        )
+        logger.warning("Bounds have a negative size, output will be flipped.")
 
     if isinstance(image, Image.Image):
         image = np.array(image)
@@ -574,7 +572,6 @@ def sub_pixel_read(  # noqa: CCR001
     overlap_bounds = find_overlap(*bounds2locsize(bounds), image_size=image_size)
     if pad_mode is None:
         read_bounds = overlap_bounds
-    pad_width = np.zeros((2, 2), int)
 
     baseline_padding = padding
     if not pad_at_baseline:

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -914,7 +914,7 @@ def make_valid_poly(poly, origin=None):
         poly = translate(poly, -origin[0], -origin[1])
     if poly.is_valid:
         return poly
-    logger.warning("Invalid geometry found, fix using buffer().")
+    logger.warning("Invalid geometry found, fix using buffer().", stacklevel=3)
     return poly.buffer(0.01)
 
 

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -3,7 +3,6 @@ import copy
 import json
 import os
 import pathlib
-import warnings
 import zipfile
 from typing import IO, Dict, Optional, Tuple, Union
 
@@ -18,6 +17,7 @@ from shapely.affinity import translate
 from shapely.geometry import shape as feature2geometry
 from skimage import exposure
 
+from tiatoolbox import logger
 from tiatoolbox.annotation.storage import Annotation, AnnotationStore, SQLiteStore
 from tiatoolbox.utils.exceptions import FileNotSupported
 
@@ -857,7 +857,7 @@ def select_cv2_interpolation(scale_factor):
 
 
 def store_from_dat(
-    fp: Union[IO, str],
+    fp: Union[IO, str, pathlib.Path],
     scale_factor: Tuple[float, float] = (1, 1),
     typedict: Optional[Dict] = None,
     origin: Tuple[float, float] = (0, 0),
@@ -914,7 +914,7 @@ def make_valid_poly(poly, origin=None):
         poly = translate(poly, -origin[0], -origin[1])
     if poly.is_valid:
         return poly
-    warnings.warn("Invalid geometry found, fix using buffer().", stacklevel=3)
+    logger.warning("Invalid geometry found, fix using buffer().")
     return poly.buffer(0.01)
 
 

--- a/tiatoolbox/utils/visualization.py
+++ b/tiatoolbox/utils/visualization.py
@@ -1,7 +1,6 @@
 """Visualisation and overlay functions used in tiatoolbox."""
 import colorsys
 import random
-import warnings
 from typing import Dict, List, Tuple, Union
 
 import cv2
@@ -14,6 +13,7 @@ from PIL import Image, ImageFilter, ImageOps
 from shapely import speedups
 from shapely.geometry import Polygon
 
+from tiatoolbox import logger
 from tiatoolbox.annotation.storage import Annotation, AnnotationStore
 
 if speedups.available:  # pragma: no branch
@@ -640,9 +640,7 @@ class AnnotationRenderer:
                     )
                 )
         except KeyError:
-            warnings.warn(
-                "score_prop not found in properties. Using default color.", stacklevel=2
-            )
+            logger.warning("'score_prop' not found in properties. Using default color.")
         if edge:
             return (0, 0, 0, 255)  # default to black for edge
         return 0, 255, 0, 255  # default color if no score_prop given
@@ -872,4 +870,4 @@ class AnnotationRenderer:
         elif geom_type == "LineString":
             self.render_line(tile, annotation, top_left, scale)
         else:
-            warnings.warn(f"Unknown geometry: {geom_type}", stacklevel=3)
+            logger.warning("Unknown geometry: %s", geom_type)

--- a/tiatoolbox/utils/visualization.py
+++ b/tiatoolbox/utils/visualization.py
@@ -640,7 +640,10 @@ class AnnotationRenderer:
                     )
                 )
         except KeyError:
-            logger.warning("'score_prop' not found in properties. Using default color.", stacklevel=2)
+            logger.warning(
+                "'score_prop' not found in properties. Using default color.",
+                stacklevel=2,
+            )
         if edge:
             return (0, 0, 0, 255)  # default to black for edge
         return 0, 255, 0, 255  # default color if no score_prop given

--- a/tiatoolbox/utils/visualization.py
+++ b/tiatoolbox/utils/visualization.py
@@ -640,7 +640,7 @@ class AnnotationRenderer:
                     )
                 )
         except KeyError:
-            logger.warning("'score_prop' not found in properties. Using default color.")
+            logger.warning("'score_prop' not found in properties. Using default color.", stacklevel=2)
         if edge:
             return (0, 0, 0, 255)  # default to black for edge
         return 0, 255, 0, 255  # default color if no score_prop given
@@ -870,4 +870,4 @@ class AnnotationRenderer:
         elif geom_type == "LineString":
             self.render_line(tile, annotation, top_left, scale)
         else:
-            logger.warning("Unknown geometry: %s", geom_type)
+            logger.warning("Unknown geometry: %s", geom_type, stacklevel=3)


### PR DESCRIPTION
- Use `logger` Instead Of `warnings` for `utils` Package