### PR TITLE
🚨 Use `logger` Instead Of `warnings` for `wsi_registration.py`

### DIFF
--- a/tests/test_wsi_registration.py
+++ b/tests/test_wsi_registration.py
@@ -187,6 +187,7 @@ def test_warning(
     moving_image,
     fixed_mask,
     moving_mask,
+    caplog,
 ):
     """Test for displaying warning in prealignment function."""
     fixed_img = imread(pathlib.Path(fixed_image))
@@ -194,10 +195,10 @@ def test_warning(
     fixed_mask = imread(pathlib.Path(fixed_mask))
     moving_mask = imread(pathlib.Path(moving_mask))
     fixed_img, moving_img = fixed_img[:, :, 0], moving_img[:, :, 0]
-    with pytest.warns(UserWarning):
-        _ = prealignment(
-            fixed_img, moving_img, fixed_mask, moving_mask, dice_overlap=0.9
-        )
+
+    _ = prealignment(fixed_img, moving_img, fixed_mask, moving_mask, dice_overlap=0.9)
+
+    assert "Not able to find the best transformation" in caplog.text
 
 
 def test_match_histogram_inputs():

--- a/tests/test_wsi_registration.py
+++ b/tests/test_wsi_registration.py
@@ -215,8 +215,14 @@ def test_match_histogram_inputs():
 def test_match_histograms():
     """Test for preprocessing/normalization of an image pair."""
     image_a = np.random.randint(256, size=(256, 256))
-    image_b = np.random.randint(256, size=(256, 256))
-    _, _ = match_histograms(image_a, image_b, 3)
+    image_b = np.zeros(shape=(256, 256), dtype=int)
+    out_a, out_b = match_histograms(image_a, image_b, 3)
+    assert np.all(out_a == image_a)
+    assert np.all(out_b == 255)
+
+    out_a, out_b = match_histograms(image_b, image_a, 3)
+    assert np.all(out_a == 255)
+    assert np.all(out_b == image_a)
 
     image_a = np.random.randint(256, size=(256, 256, 1))
     image_b = np.random.randint(256, size=(256, 256, 1))

--- a/tiatoolbox/tools/registration/wsi_registration.py
+++ b/tiatoolbox/tools/registration/wsi_registration.py
@@ -87,7 +87,7 @@ def compute_center_of_mass(mask: np.ndarray) -> tuple:
 
 
 def apply_affine_transformation(fixed_img, moving_img, transform_initializer):
-    """Apply affine transformation using opencv.
+    """Apply affine transformation using OpenCV.
 
     Args:
         fixed_img (:class:`numpy.ndarray`):

--- a/tiatoolbox/tools/registration/wsi_registration.py
+++ b/tiatoolbox/tools/registration/wsi_registration.py
@@ -102,8 +102,6 @@ def apply_affine_transformation(fixed_img, moving_img, transform_initializer):
             A transformed image.
 
     Examples:
-        >>> from tiatoolbox.tools.registration.wsi_registration import \
-        ...    apply_affine_transformation
         >>> moving_image = apply_affine_transformation(
         ...     fixed_image, moving_image, transform_initializer
         ... )

--- a/tiatoolbox/tools/registration/wsi_registration.py
+++ b/tiatoolbox/tools/registration/wsi_registration.py
@@ -1,5 +1,4 @@
 import itertools
-import warnings
 from numbers import Number
 from typing import Dict, Tuple, Union
 
@@ -13,6 +12,7 @@ from skimage import exposure, filters
 from skimage.registration import phase_cross_correlation
 from skimage.util import img_as_float
 
+from tiatoolbox import logger
 from tiatoolbox.tools.patchextraction import PatchExtractor
 from tiatoolbox.utils.metrics import dice
 from tiatoolbox.utils.transforms import imresize
@@ -218,10 +218,9 @@ def prealignment(
         )
         return pre_transform, moving_img, moving_mask, dice_after
 
-    warnings.warn(
+    logger.warning(
         "Not able to find the best transformation for pre-alignment. "
         "Try changing the values for 'dice_overlap' and 'rotation_step'.",
-        stacklevel=2,
     )
     return np.eye(3), moving_img, moving_mask, dice_before
 


### PR DESCRIPTION
- Use `logger` Instead Of `warnings` for `wsi_registration.py`
- Refactor duplicate code fragments