### PR TITLE
🚨 Use `logger` Instead Of `warnings` for `patchextraction.py`

### DIFF
--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -267,7 +267,7 @@ def test_sliding_windowpatch_extractor(patch_extr_vf_image):
 
 
 def test_get_coordinates():
-    """Test get tile cooordinates functionality."""
+    """Test get tile coordinates functionality."""
     expected_output = np.array(
         [
             [0, 0, 4, 4],
@@ -425,7 +425,7 @@ def test_filter_coordinates():
     mask = np.zeros([9, 6])
     mask[0:4, 3:8] = 1  # will flag first 2
     mask_reader = VirtualWSIReader(mask)
-    slide_shape = [6, 9]  # slide shape (w, h) at requested resolution
+    slide_shape = (6, 9)  # slide shape (w, h) at requested resolution
 
     ###############################################
     # Tests for filter_coordinates (new) method
@@ -485,7 +485,7 @@ def test_filter_coordinates():
         )
 
 
-def test_mask_based_patch_extractor_ndpi(sample_ndpi):
+def test_mask_based_patch_extractor_ndpi(sample_ndpi, caplog):
     """Test SlidingWindowPatchExtractor with mask for ndpi image."""
     res = 0
     patch_size = stride = (400, 400)
@@ -524,7 +524,7 @@ def test_mask_based_patch_extractor_ndpi(sample_ndpi):
     assert patches[0].shape == (patch_size[0], patch_size[1], 3)
 
     # Test None option for mask
-    patches = patchextraction.get_patch_extractor(
+    _ = patchextraction.get_patch_extractor(
         input_img=input_img,
         input_mask=None,
         method_name="slidingwindow",
@@ -536,7 +536,7 @@ def test_mask_based_patch_extractor_ndpi(sample_ndpi):
 
     # Test passing a VirtualWSI for mask
     mask_wsi = VirtualWSIReader(wsi_mask, info=wsi._m_info, mode="bool")
-    patches = patchextraction.get_patch_extractor(
+    _ = patchextraction.get_patch_extractor(
         input_img=wsi,
         input_mask=mask_wsi,
         method_name="slidingwindow",
@@ -547,7 +547,7 @@ def test_mask_based_patch_extractor_ndpi(sample_ndpi):
     )
 
     # Test `otsu` option for mask
-    patches = patchextraction.get_patch_extractor(
+    _ = patchextraction.get_patch_extractor(
         input_img=input_img,
         input_mask="otsu",
         method_name="slidingwindow",
@@ -557,7 +557,7 @@ def test_mask_based_patch_extractor_ndpi(sample_ndpi):
         stride=stride,
     )
 
-    patches = patchextraction.get_patch_extractor(
+    _ = patchextraction.get_patch_extractor(
         input_img=wsi_mask,  # a numpy array to build VirtualSlideReader
         input_mask="morphological",
         method_name="slidingwindow",
@@ -569,13 +569,14 @@ def test_mask_based_patch_extractor_ndpi(sample_ndpi):
 
     # Test passing an empty mask
     wsi_mask = np.zeros(mask_dim, dtype=np.uint8)
-    with pytest.warns(UserWarning, match=".*No candidate coordinates left.*"):
-        _ = patchextraction.get_patch_extractor(
-            input_img=input_img,
-            input_mask=wsi_mask,
-            method_name="slidingwindow",
-            patch_size=patch_size,
-            resolution=res,
-            units="level",
-            stride=stride,
-        )
+
+    _ = patchextraction.get_patch_extractor(
+        input_img=input_img,
+        input_mask=wsi_mask,
+        method_name="slidingwindow",
+        patch_size=patch_size,
+        resolution=res,
+        units="level",
+        stride=stride,
+    )
+    assert "No candidate coordinates left" in caplog.text

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -1,5 +1,4 @@
 """This file defines patch extraction methods for deep learning models."""
-import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Callable, Tuple, Union
@@ -7,6 +6,7 @@ from typing import Callable, Tuple, Union
 import numpy as np
 from pandas import DataFrame
 
+from tiatoolbox import logger
 from tiatoolbox.utils import misc
 from tiatoolbox.utils.exceptions import MethodNotSupported
 from tiatoolbox.wsicore import wsireader
@@ -213,7 +213,7 @@ class PatchExtractor(PatchExtractorABC):
             )
             self.coordinate_list = self.coordinate_list[selected_coord_indices]
             if len(self.coordinate_list) == 0:
-                warnings.warn(
+                logger.warning(
                     "No candidate coordinates left after "
                     "filtering by `input_mask` positions.",
                     stacklevel=2,
@@ -618,7 +618,19 @@ class PointsPatchExtractor(PatchExtractor):
         )
 
 
-def get_patch_extractor(method_name: str, **kwargs: str):
+def get_patch_extractor(
+    method_name: str,
+    **kwargs: Union[
+        Path,
+        wsireader.WSIReader,
+        None,
+        str,
+        int,
+        Tuple[int, int],
+        float,
+        Tuple[float, float],
+    ],
+):
     """Return a patch extractor object as requested.
 
     Args:


### PR DESCRIPTION
- Use `logger` Instead Of `warnings` for `patchextraction.py`