### PR TITLE
🚨 Use `logger` Instead Of `warnings` for `pyramid.py` and `storage.py`

### DIFF
--- a/tests/test_annotation_stores.py
+++ b/tests/test_annotation_stores.py
@@ -271,11 +271,11 @@ def test_sqlite_create_index_no_analyze(fill_store, tmp_path):
     assert "test_index" in store.indexes()
 
 
-def test_sqlite_pquery_warn_no_index(fill_store):
+def test_sqlite_pquery_warn_no_index(fill_store, caplog):
     """Test that querying without an index warns."""
     _, store = fill_store(SQLiteStore, ":memory:")
-    with pytest.warns(UserWarning, match="index"):
-        store.pquery("*", unique=False)
+    store.pquery("*", unique=False)
+    assert "Query is not using an index." in caplog.text
     # Check that there is no warning after creating the index
     store.create_index("test_index", "props['class']")
     with pytest.warns(None) as record:

--- a/tests/test_annotation_tilerendering.py
+++ b/tests/test_annotation_tilerendering.py
@@ -266,14 +266,14 @@ def test_unknown_geometry(fill_store, tmp_path):
         tg.get_tile(0, 0, 0)
 
 
-def test_interp_pad_warning(fill_store, tmp_path):
+def test_interp_pad_warning(fill_store, tmp_path, caplog):
     """Test warning when providing unused options."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array)
     _, store = fill_store(SQLiteStore, tmp_path / "test.db")
     tg = AnnotationTileGenerator(wsi.info, store, tile_size=256)
-    with pytest.warns(UserWarning, match="interpolation, pad_mode are unused"):
-        tg.get_tile(0, 0, 0, pad_mode="constant")
+    tg.get_tile(0, 0, 0, pad_mode="constant")
+    assert "interpolation, pad_mode are unused" in caplog.text
 
 
 def test_user_provided_cm(fill_store, tmp_path):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,6 +9,7 @@ import subprocess
 import pytest
 
 import tiatoolbox
+from tiatoolbox import DuplicateFilter, logger
 
 
 def test_set_root_dir():
@@ -104,3 +105,21 @@ def test_logger_output():
 
     # Test CRITICAL is written to stderr
     helper_logger_test(level="critical")
+
+
+def test_duplicate_filter(caplog):
+    """Tests DuplicateFilter for warnings."""
+    for _ in range(2):
+        logger.warning("Test duplicate filter warnings.")
+    assert "Test duplicate filter warnings." in caplog.text
+    assert "\n" in caplog.text[:-2]
+
+    caplog.clear()
+
+    duplicate_filter = DuplicateFilter()
+    logger.addFilter(duplicate_filter)
+    for _ in range(2):
+        logger.warning("Test duplicate filter warnings.")
+    logger.removeFilter(duplicate_filter)
+    assert "Test duplicate filter warnings." in caplog.text
+    assert "\n" not in caplog.text[:-2]

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -44,6 +44,16 @@ if not logging.getLogger().hasHandlers():
 else:
     logger = logging.getLogger()
 
+
+class DuplicateFilter(logging.Filter):
+    def filter(self, record):
+        current_log = (record.module, record.levelno, record.msg)
+        if current_log != getattr(self, "last_log", None):
+            self.last_log = current_log
+            return True
+        return False
+
+
 # runtime context parameters
 rcParam = {"TIATOOLBOX_HOME": os.path.join(os.path.expanduser("~"), ".tiatoolbox")}
 

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -32,7 +32,6 @@ import sqlite3
 import sys
 import tempfile
 import uuid
-import warnings
 import zlib
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -66,7 +65,7 @@ from shapely.geometry import mapping as geometry2feature
 from shapely.geometry import shape as feature2geometry
 
 import tiatoolbox
-from tiatoolbox import logger
+from tiatoolbox import DuplicateFilter, logger
 from tiatoolbox.annotation.dsl import (
     PY_GLOBALS,
     SQL_GLOBALS,
@@ -1985,7 +1984,7 @@ class SQLiteStore(AnnotationStore):
                 "EXPLAIN QUERY PLAN " + query_string, query_parameters
             ).fetchone()
             if "USING INDEX" not in query_plan[-1]:
-                warnings.warn(
+                logger.warning(
                     "Query is not using an index. "
                     "Consider adding an index to improve performance.",
                     stacklevel=2,
@@ -2959,7 +2958,7 @@ class DictionaryStore(AnnotationStore):
 
     def commit(self) -> None:
         if str(self.connection) == ":memory:":
-            warnings.warn("In-memory store. Nothing to commit.", stacklevel=2)
+            logger.warning("In-memory store. Nothing to commit.", stacklevel=2)
             return
         if not self.path.exists():
             self.path.touch()
@@ -2972,8 +2971,8 @@ class DictionaryStore(AnnotationStore):
         return self.to_ndjson()
 
     def close(self) -> None:
-        warnings.simplefilter("ignore")
+        logger.addFilter(DuplicateFilter())
         # Try to commit any changes if the file is still open.
         with contextlib.suppress(ValueError):
             self.commit()
-        warnings.resetwarnings()
+        logger.removeFilter(DuplicateFilter())

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -2971,8 +2971,9 @@ class DictionaryStore(AnnotationStore):
         return self.to_ndjson()
 
     def close(self) -> None:
-        logger.addFilter(DuplicateFilter())
+        duplicate_filter = DuplicateFilter()
+        logger.addFilter(duplicate_filter)
         # Try to commit any changes if the file is still open.
         with contextlib.suppress(ValueError):
             self.commit()
-        logger.removeFilter(DuplicateFilter())
+        logger.removeFilter(duplicate_filter)

--- a/tiatoolbox/tools/pyramid.py
+++ b/tiatoolbox/tools/pyramid.py
@@ -12,7 +12,6 @@ to disk.
 
 import tarfile
 import time
-import warnings
 import zipfile
 from io import BytesIO
 from pathlib import Path
@@ -22,6 +21,7 @@ import defusedxml
 import numpy as np
 from PIL import Image
 
+from tiatoolbox import DuplicateFilter, logger
 from tiatoolbox.annotation.storage import AnnotationStore
 from tiatoolbox.utils.transforms import imresize, locsize2bounds
 from tiatoolbox.utils.visualization import AnnotationRenderer, random_colors
@@ -198,7 +198,7 @@ class TilePyramidGenerator:
         baseline_x = (x * self.tile_size * scale) - (self.overlap * scale)
         baseline_y = (y * self.tile_size * scale) - (self.overlap * scale)
         output_size = [self.output_tile_size] * 2
-        coord = [int(baseline_x), int(baseline_y)]
+        coord = (int(baseline_x), int(baseline_y))
         if level < self.sub_tile_level_count:
             output_size = self.output_tile_size // 2 ** (
                 self.sub_tile_level_count - level
@@ -211,17 +211,17 @@ class TilePyramidGenerator:
         if all(slide_dimensions < [baseline_x, baseline_y]):
             raise IndexError
 
-        # Don't print out any warnings about interpolation etc.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            tile = self.wsi.read_rect(
-                coord,
-                size=[v * res for v in output_size],
-                resolution=res / scale,
-                units="baseline",
-                pad_mode=pad_mode,
-                interpolation=interpolation,
-            )
+        # Don't print out multiple warnings about interpolation etc.
+        logger.addFilter(DuplicateFilter())
+        tile = self.wsi.read_rect(
+            coord,
+            size=[v * res for v in output_size],
+            resolution=res / scale,
+            units="baseline",
+            pad_mode=pad_mode,
+            interpolation=interpolation,
+        )
+        logger.removeFilter(DuplicateFilter())
         return Image.fromarray(tile)
 
     def tile_path(self, level: int, x: int, y: int) -> Path:
@@ -582,7 +582,7 @@ class AnnotationTileGenerator(ZoomifyGenerator):
 
         """
         if pad_mode is not None or interpolation is not None:
-            warnings.warn(
+            logger.warning(
                 "interpolation, pad_mode are unused by AnnotationTileGenerator",
                 stacklevel=2,
             )

--- a/tiatoolbox/tools/pyramid.py
+++ b/tiatoolbox/tools/pyramid.py
@@ -212,7 +212,8 @@ class TilePyramidGenerator:
             raise IndexError
 
         # Don't print out multiple warnings about interpolation etc.
-        logger.addFilter(DuplicateFilter())
+        duplicate_filter = DuplicateFilter()
+        logger.addFilter(duplicate_filter)
         tile = self.wsi.read_rect(
             coord,
             size=[v * res for v in output_size],
@@ -221,7 +222,7 @@ class TilePyramidGenerator:
             pad_mode=pad_mode,
             interpolation=interpolation,
         )
-        logger.removeFilter(DuplicateFilter())
+        logger.removeFilter(duplicate_filter)
         return Image.fromarray(tile)
 
     def tile_path(self, level: int, x: int, y: int) -> Path:


### PR DESCRIPTION
- Use `logger` Instead Of `warnings` for `pyramid.py` and `storage.py`
- Catches duplicate errors and prints them only once.