### PR TITLE
🐛 Fix `deepsource` Errors

### DIFF
--- a/pre-commit/notebook_urls.py
+++ b/pre-commit/notebook_urls.py
@@ -88,7 +88,8 @@ def main(files: List[Path], from_ref: str, to_ref: str) -> bool:
         PatternReplacement(
             pattern=(
                 r"(^\s*[!%]\s*)pip install "
-                r"(git\+https://github\.com/TissueImageAnalytics/tiatoolbox\.git@[\S]*|tiatoolbox)"  # noqa: E501
+                r"(git\+https://github\.com/TissueImageAnalytics/"
+                r"tiatoolbox\.git@[\S]*|tiatoolbox)"
             ),
             replacement=(
                 r"\1pip install "

--- a/tests/models/test_patch_predictor.py
+++ b/tests/models/test_patch_predictor.py
@@ -397,10 +397,12 @@ def test_wsi_patch_dataset(sample_wsi_dict, tmp_path):
 
 
 def test_patch_dataset_abc():
-    """Test for ABC methods."""
+    """Test for ABC methods.
 
-    # test missing definition for abstract
-    # intentionally created to check error
+    Test missing definition for abstract intentionally created to check error.
+
+    """
+
     # skipcq
     class Proto(PatchDatasetABC):
         # skipcq

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -1994,8 +1994,12 @@ def test_store_reader_no_types(tmp_path, remote_sample):
 
 
 def test_store_reader_info_from_base(tmp_path, remote_sample):
-    """Test that AnnotationStoreReader will correctly get metadata
-    from a provided base_wsi if the store has no wsi metadata."""
+    """Test AnnotationStoreReader with no wsi metadata.
+
+    Test that AnnotationStoreReader will correctly get metadata
+    from a provided base_wsi if the store has no wsi metadata.
+
+    """
     SQLiteStore(tmp_path / "store.db")
     wsi_reader = WSIReader.open(remote_sample("svs-1-small"))
     store_reader = AnnotationStoreReader(tmp_path / "store.db", base_wsi=wsi_reader)

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -2189,7 +2189,6 @@ def test_ngff_multiscales_above_max_version(tmp_path, caplog):
 
 def test_ngff_non_numeric_version(tmp_path, monkeypatch):
     """Test that the reader can handle non-numeric omero versions."""
-
     # Patch the is_ngff function to change the min/max version
     if_ngff = wsireader.is_ngff  # noqa: F841
     min_version = Version("0.4")

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -2788,15 +2788,30 @@ class SQLiteStore(AnnotationStore):
         )
 
     def commit(self) -> None:
+        """Commit any in-memory changes to disk."""
         self.con.commit()
 
     def dump(self, fp: Union[Path, str, IO]) -> None:
+        """Serialise a copy of the whole store to a file-like object.
+
+        Args:
+            fp(Path or str or IO):
+                A file path or file handle object for output to disk.
+
+        """
         if hasattr(fp, "write"):
             fp = fp.name
         target = sqlite3.connect(fp)
         self.con.backup(target)
 
     def dumps(self) -> str:
+        """Serialise and return a copy of store as a string or bytes.
+
+        Returns:
+            str or bytes:
+                The serialised store.
+
+        """
         return "\n".join(self.con.iterdump())
 
     def clear(self) -> None:
@@ -2907,7 +2922,22 @@ class DictionaryStore(AnnotationStore):
         self,
         annotation: Annotation,
         key: Optional[str] = None,
-    ) -> int:
+    ) -> str:
+        """Insert a new annotation, returning the key.
+
+        Args:
+            annotation (Annotation):
+                The shapely annotation to insert.
+            key (str):
+                Optional. The unique key used to identify the annotation in the
+                store. If not given a new UUID4 will be generated and returned
+                instead.
+
+        Returns:
+            str:
+                The unique key of the newly inserted annotation.
+
+        """
         if not isinstance(annotation.geometry, (Polygon, Point, LineString)):
             raise TypeError("Invalid geometry type.")
         key = key or str(uuid.uuid4())
@@ -2920,6 +2950,24 @@ class DictionaryStore(AnnotationStore):
         geometry: Optional[Geometry] = None,
         properties: Optional[Dict[str, Any]] = None,
     ) -> None:
+        """Patch an annotation at given key.
+
+        Partial update of an annotation. Providing only a geometry will update
+        the geometry and leave properties unchanged. Providing a properties
+        dictionary applies a patch operation to the properties. Only updating
+        the properties which are given and leaving the rest unchanged. To
+        completely replace an annotation use `__setitem__`.
+
+        Args:
+            key(str):
+                The key of the annotation to update.
+            geometry(Geometry):
+                The new geometry. If None, the geometry is not updated.
+            properties(dict):
+                A dictionary of properties to patch and their new values.
+                If None, the existing properties are not altered.
+
+        """
         if key not in self:
             self.append(Annotation(geometry, properties), key)
             return
@@ -2931,6 +2979,13 @@ class DictionaryStore(AnnotationStore):
         self[key] = Annotation(geometry, new_properties)
 
     def remove(self, key: str) -> None:
+        """Remove annotation from the store with its unique key.
+
+        Args:
+            key (str):
+                The key of the annotation to be removed.
+
+        """
         del self._rows[key]
 
     def __getitem__(self, key: str) -> Annotation:
@@ -2954,9 +3009,11 @@ class DictionaryStore(AnnotationStore):
 
     @classmethod  # noqa: A003
     def open(cls, fp: Union[Path, str, IO]) -> "DictionaryStore":  # noqa: A003
+        """Opens :class:`DictionaryStore` from file pointer or path."""
         return cls.from_ndjson(fp)
 
     def commit(self) -> None:
+        """Commit any in-memory changes to disk."""
         if str(self.connection) == ":memory:":
             logger.warning("In-memory store. Nothing to commit.", stacklevel=2)
             return
@@ -2965,12 +3022,27 @@ class DictionaryStore(AnnotationStore):
         self.dump(self.connection)
 
     def dump(self, fp: Union[Path, str, IO]) -> None:
+        """Serialise a copy of the whole store to a file-like object.
+
+        Args:
+            fp(Path or str or IO):
+                A file path or file handle object for output to disk.
+
+        """
         return self.to_ndjson(fp)
 
     def dumps(self) -> str:
+        """Serialise and return a copy of store as a string or bytes.
+
+        Returns:
+            str or bytes:
+                The serialised store.
+
+        """
         return self.to_ndjson()
 
     def close(self) -> None:
+        """Closes :class:`DictionaryStore` from file pointer or path."""
         duplicate_filter = DuplicateFilter()
         logger.addFilter(duplicate_filter)
         # Try to commit any changes if the file is still open.

--- a/tiatoolbox/models/architecture/unet.py
+++ b/tiatoolbox/models/architecture/unet.py
@@ -79,7 +79,9 @@ class ResNetEncoder(ResNet):
         """
         model = ResNetEncoder(ResNetBottleneck, downsampling_levels)
         if num_input_channels != 3:
-            model.conv1 = nn.Conv2d(num_input_channels, 64, 7, stride=2, padding=3)
+            model.conv1 = nn.Conv2d(  # skipcq: PYL-W0201
+                num_input_channels, 64, 7, stride=2, padding=3
+            )
         return model
 
 

--- a/tiatoolbox/tools/stainaugment.py
+++ b/tiatoolbox/tools/stainaugment.py
@@ -194,7 +194,7 @@ class StainAugmentor(ImageOnlyTransform):
         img_augmented = np.clip(img_augmented, 0, 255)
         return np.uint8(img_augmented)
 
-    def apply(self, img, **params):  # alpha=None, beta=None,
+    def apply(self, img, **params):  # alpha=None, beta=None,  # skipcq: PYL-W0613
         """Call the `fit` and `augment` functions to generate a stain augmented image.
 
         Args:
@@ -216,10 +216,11 @@ class StainAugmentor(ImageOnlyTransform):
         self.beta = random.uniform(-self.sigma2, self.sigma2)
         return {}
 
-    def get_params_dependent_on_targets(self, params):
+    def get_params_dependent_on_targets(self, params):  # skipcq: PYL-W0613, PYL-R0201
         """Does nothing, added to resolve flake 8 error"""
         return {}
 
-    def get_transform_init_args_names(self):
+    @staticmethod
+    def get_transform_init_args_names(**kwargs):
         """Return the argument names for albumentations use."""
-        return ("method", "stain_matrix", "sigma1", "sigma2", "augment_background")
+        return "method", "stain_matrix", "sigma1", "sigma2", "augment_background"

--- a/tiatoolbox/wsicore/metadata/ngff.py
+++ b/tiatoolbox/wsicore/metadata/ngff.py
@@ -266,6 +266,8 @@ class Zattrs:
     """
 
     _creator: Creator = field(default_factory=Creator)
-    multiscales: List[Multiscales] = field(default_factory=lambda: [Multiscales()])
+    multiscales: Union[Multiscales, List[Multiscales]] = field(
+        default_factory=lambda: [Multiscales()]
+    )
     _ARRAY_DIMENSIONS: List[TCZYX] = field(default_factory=lambda: ["y", "x", "c"])
     omero: Omero = field(default_factory=Omero)

--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -1026,6 +1026,10 @@ class WSIReader:
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system
@@ -1217,6 +1221,10 @@ class WSIReader:
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system
@@ -1603,6 +1611,10 @@ class OpenSlideWSIReader(WSIReader):
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system
@@ -1842,6 +1854,10 @@ class OpenSlideWSIReader(WSIReader):
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system
@@ -2126,6 +2142,10 @@ class OmnyxJP2WSIReader(WSIReader):
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system
@@ -2362,6 +2382,10 @@ class OmnyxJP2WSIReader(WSIReader):
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system
@@ -2693,6 +2717,10 @@ class VirtualWSIReader(WSIReader):
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system
@@ -2931,6 +2959,10 @@ class VirtualWSIReader(WSIReader):
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system
@@ -3488,6 +3520,10 @@ class TIFFWSIReader(WSIReader):
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system
@@ -3722,6 +3758,10 @@ class TIFFWSIReader(WSIReader):
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system
@@ -3934,6 +3974,10 @@ class DICOMWSIReader(WSIReader):
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system
@@ -4186,6 +4230,10 @@ class DICOMWSIReader(WSIReader):
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system
@@ -4338,19 +4386,21 @@ class NGFFWSIReader(WSIReader):
                 name=attrs.get("name"),
                 version=attrs.get("version"),
             ),
-            multiscales=ngff.Multiscales(
-                version=multiscales.get("version"),
-                axes=[ngff.Axis(**axis) for axis in axes],
-                datasets=[
-                    ngff.Dataset(
-                        path=dataset["path"],
-                        coordinateTransformations=dataset.get(
-                            "coordinateTransformations",
-                        ),
-                    )
-                    for dataset in datasets
-                ],
-            ),
+            multiscales=[
+                ngff.Multiscales(
+                    version=multiscales.get("version"),
+                    axes=[ngff.Axis(**axis) for axis in axes],
+                    datasets=[
+                        ngff.Dataset(
+                            path=dataset["path"],
+                            coordinateTransformations=dataset.get(
+                                "coordinateTransformations",
+                            ),
+                        )
+                        for dataset in datasets
+                    ],
+                )
+            ],
             omero=ngff.Omero(
                 name=omero.get("name"),
                 id=omero.get("id"),
@@ -4438,6 +4488,187 @@ class NGFFWSIReader(WSIReader):
         coord_space="baseline",
         **kwargs,
     ):
+        """Read a region of the whole slide image at a location and size.
+
+        Location is in terms of the baseline image (level 0  / maximum
+        resolution), and size is the output image size.
+
+        Reads can be performed at different resolutions by supplying a
+        pair of arguments for the resolution and the units of
+        resolution. If metadata does not specify `mpp` or
+        `objective_power` then `baseline` units should be selected with
+        resolution 1.0
+
+        The field of view varies with resolution. For a fixed field of
+        view see :func:`read_bounds`.
+
+        Args:
+            location (tuple(int)):
+                (x, y) tuple giving the top left pixel in the baseline
+                (level 0) reference frame.
+            size (tuple(int)):
+                (width, height) tuple giving the desired output image
+                size.
+            resolution (int or float or tuple(float)):
+                Resolution at which to read the image, default = 0.
+                Either a single number or a sequence of two numbers for
+                x and y are valid. This value is in terms of the
+                corresponding units. For example: resolution=0.5 and
+                units="mpp" will read the slide at 0.5 microns
+                per-pixel, and resolution=3, units="level" will read at
+                level at pyramid level / resolution layer 3.
+            units (str):
+                The units of resolution, default = "level". Supported
+                units are: microns per pixel (mpp), objective power
+                (power), pyramid / resolution level (level), pixels per
+                baseline pixel (baseline).
+            interpolation (str):
+                Method to use when resampling the output image. Possible
+                values are "linear", "cubic", "lanczos", "area", and
+                "optimise". Defaults to 'optimise' which will use cubic
+                interpolation for upscaling and area interpolation for
+                downscaling to avoid moiré patterns.
+            pad_mode (str):
+                Method to use when padding at the edges of the image.
+                Defaults to 'constant'. See :func:`numpy.pad` for
+                available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
+            coord_space (str):
+                Defaults to "baseline". This is a flag to indicate if
+                the input `bounds` is in the baseline coordinate system
+                ("baseline") or is in the requested resolution system
+                ("resolution").
+            **kwargs (dict):
+                Extra key-word arguments for reader specific parameters.
+                Currently only used by VirtualWSIReader. See class
+                docstrings for more information.
+
+        Returns:
+            :class:`numpy.ndarray`:
+                Array of size MxNx3 M=size[0], N=size[1]
+
+        Example:
+            >>> from tiatoolbox.wsicore.wsireader import WSIReader
+            >>> # Load a WSI image
+            >>> wsi = WSIReader.open(input_img="./CMU-1.ome.zarr")
+            >>> location = (0, 0)
+            >>> size = (256, 256)
+            >>> # Read a region at level 0 (baseline / full resolution)
+            >>> img = wsi.read_rect(location, size)
+            >>> # Read a region at 0.5 microns per pixel (mpp)
+            >>> img = wsi.read_rect(location, size, 0.5, "mpp")
+            >>> # This could also be written more verbosely as follows
+            >>> img = wsi.read_rect(
+            ...     location,
+            ...     size,
+            ...     resolution=(0.5, 0.5),
+            ...     units="mpp",
+            ... )
+
+        Note: The field of view varies with resolution when using
+        :func:`read_rect`.
+
+        .. figure:: ../images/read_rect_tissue.png
+            :width: 512
+            :alt: Diagram illustrating read_rect
+
+        As the location is in the baseline reference frame but the size
+        (width and height) is the output image size, the field of view
+        therefore changes as resolution changes.
+
+        If the WSI does not have a resolution layer corresponding
+        exactly to the requested resolution (shown above in white with a
+        dashed outline), a larger resolution is downscaled to achieve
+        the correct requested output resolution.
+
+        If the requested resolution is higher than the baseline (maximum
+        resultion of the image), then bicubic interpolation is applied
+        to the output image.
+
+        .. figure:: ../images/read_rect-interpolated-reads.png
+            :width: 512
+            :alt: Diagram illustrating read_rect interpolting between levels
+
+        When reading between the levels stored in the WSI, the
+        coordinates of the requested region are projected to the next
+        highest resolution. This resolution is then decoded and
+        downsampled to produce the desired output. This is a major
+        source of variability in the time take to perform a read
+        operation. Reads which require reading a large region before
+        downsampling will be significantly slower than reading at a
+        fixed level.
+
+        Examples:
+
+            >>> from tiatoolbox.wsicore.wsireader import WSIReader
+            >>> # Load a WSI image
+            >>> wsi = WSIReader.open(input_img="./CMU-1.ome.zarr")
+            >>> location = (0, 0)
+            >>> size = (256, 256)
+            >>> # The resolution can be different in x and y, e.g.
+            >>> img = wsi.read_rect(
+            ...     location,
+            ...     size,
+            ...     resolution=(0.5, 0.75),
+            ...     units="mpp",
+            ... )
+            >>> # Several units can be used including: objective power,
+            >>> # microns per pixel, pyramid/resolution level, and
+            >>> # fraction of baseline.
+            >>> # E.g. Read a region at an objective power of 10x
+            >>> img = wsi.read_rect(
+            ...     location,
+            ...     size,
+            ...     resolution=10,
+            ...     units="power",
+            ... )
+            >>> # Read a region at pyramid / resolution level 1
+            >>> img = wsi.read_rect(
+            ...     location,
+            ...     size,
+            ...     resolution=1,
+            ...     units="level",
+            ... )
+            >>> # Read at a fractional level, this will linearly
+            >>> # interpolate the downsampling factor between levels.
+            >>> # E.g. if levels 0 and 1 have a downsampling of 1x and
+            >>> # 2x of baseline, then level 0.5 will correspond to a
+            >>> # downsampling factor 1.5x of baseline.
+            >>> img = wsi.read_rect(
+            ...     location,
+            ...     size,
+            ...     resolution=0.5,
+            ...     units="level",
+            ... )
+            >>> # Read a region at half of the full / baseline
+            >>> # resolution.
+            >>> img = wsi.read_rect(
+            ...     location,
+            ...     size,
+            ...     resolution=0.5,
+            ...     units="baseline",
+            ... )
+            >>> # Read at a higher resolution than the baseline
+            >>> # (interpolation applied to output)
+            >>> img = wsi.read_rect(
+            ...     location,
+            ...     size,
+            ...     resolution=1.25,
+            ...     units="baseline",
+            ... )
+            >>> # Assuming the image has a native mpp of 0.5,
+            >>> # interpolation will be applied here.
+            >>> img = wsi.read_rect(
+            ...     location,
+            ...     size,
+            ...     resolution=0.25,
+            ...     units="mpp",
+            ... )
+
+        """
         if coord_space == "resolution":
             im_region = self._read_rect_at_resolution(
                 location,
@@ -4494,6 +4725,106 @@ class NGFFWSIReader(WSIReader):
         coord_space="baseline",
         **kwargs,
     ):
+        """Read a region of the whole slide image within given bounds.
+
+        Bounds are in terms of the baseline image (level 0  / maximum
+        resolution).
+
+        Reads can be performed at different resolutions by supplying a
+        pair of arguments for the resolution and the units of
+        resolution. If metadata does not specify `mpp` or
+        `objective_power` then `baseline` units should be selected with
+        resolution 1.0
+
+        The output image size may be different to the width and height
+        of the bounds as the resolution will affect this. To read a
+        region with a fixed output image size see :func:`read_rect`.
+
+        Args:
+            bounds (tuple(int)):
+                By default, this is a tuple of (start_x, start_y, end_x,
+                end_y) i.e. (left, top, right, bottom) of the region in
+                baseline reference frame. However, with
+                `coord_space="resolution"`, the bound is expected to be
+                at the requested resolution system.
+            resolution (int or float or tuple(float)):
+                Resolution at which to read the image, default = 0.
+                Either a single number or a sequence of two numbers for
+                x and y are valid. This value is in terms of the
+                corresponding units. For example: resolution=0.5 and
+                units="mpp" will read the slide at 0.5 microns
+                per-pixel, and resolution=3, units="level" will read at
+                level at pyramid level / resolution layer 3.
+            units (str):
+                Units of resolution, default="level". Supported units
+                are: microns per pixel (mpp), objective power (power),
+                pyramid / resolution level (level), pixels per baseline
+                pixel (baseline).
+            interpolation (str):
+                Method to use when resampling the output image. Possible
+                values are "linear", "cubic", "lanczos", "area", and
+                "optimise". Defaults to 'optimise' which will use cubic
+                interpolation for upscaling and area interpolation for
+                downscaling to avoid moiré patterns.
+            pad_mode (str):
+                Method to use when padding at the edges of the image.
+                Defaults to 'constant'. See :func:`numpy.pad` for
+                available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
+            coord_space (str):
+                Defaults to "baseline". This is a flag to indicate if
+                the input `bounds` is in the baseline coordinate system
+                ("baseline") or is in the requested resolution system
+                ("resolution").
+            **kwargs (dict):
+                Extra key-word arguments for reader specific parameters.
+                Currently only used by :obj:`VirtualWSIReader`. See
+                class docstrings for more information.
+
+        Returns:
+            :class:`numpy.ndarray`:
+                Array of size MxNx3 M=end_h-start_h, N=end_w-start_w
+
+        Examples:
+            >>> from tiatoolbox.wsicore.wsireader import WSIReader
+            >>> from matplotlib import pyplot as plt
+            >>> wsi = WSIReader.open(input_img="./CMU-1.ome.zarr")
+            >>> # Read a region at level 0 (baseline / full resolution)
+            >>> bounds = [1000, 2000, 2000, 3000]
+            >>> img = wsi.read_bounds(bounds)
+            >>> plt.imshow(img)
+            >>> # This could also be written more verbosely as follows
+            >>> img = wsi.read_bounds(
+            ...     bounds,
+            ...     resolution=0,
+            ...     units="level",
+            ... )
+            >>> plt.imshow(img)
+
+        Note: The field of view remains the same as resolution is varied
+        when using :func:`read_bounds`.
+
+        .. figure:: ../images/read_bounds_tissue.png
+            :width: 512
+            :alt: Diagram illustrating read_bounds
+
+        This is because the bounds are in the baseline (level 0)
+        reference frame. Therefore, varying the resolution does not
+        change what is visible within the output image.
+
+        If the WSI does not have a resolution layer corresponding
+        exactly to the requested resolution (shown above in white with a
+        dashed outline), a larger resolution is downscaled to achieve
+        the correct requested output resolution.
+
+        If the requested resolution is higher than the baseline (maximum
+        resultion of the image), then bicubic interpolation is applied
+        to the output image.
+
+        """
         bounds_at_baseline = bounds
         if coord_space == "resolution":
             bounds_at_baseline = self._bounds_at_resolution_to_baseline(
@@ -4560,7 +4891,7 @@ class AnnotationStoreReader(WSIReader):
     resolutions will be added in the future.
 
     Args:
-        store (AnnotationStore | str):
+        store (AnnotationStore | str | Path):
             An AnnotationStore or a path to an annotation store .db file.
         info (WSIMeta):
             Metadata of the base WSI for the annotations in the store.
@@ -4583,7 +4914,7 @@ class AnnotationStoreReader(WSIReader):
 
     def __init__(
         self,
-        store: Union[AnnotationStore, str],
+        store: Union[AnnotationStore, str, pathlib.Path],
         info: Optional[WSIMeta] = None,
         renderer: AnnotationRenderer = None,
         base_wsi: Union[WSIReader, str] = None,
@@ -4688,6 +5019,10 @@ class AnnotationStoreReader(WSIReader):
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system
@@ -4971,6 +5306,10 @@ class AnnotationStoreReader(WSIReader):
                 Method to use when padding at the edges of the image.
                 Defaults to 'constant'. See :func:`numpy.pad` for
                 available modes.
+            pad_constant_values (int, tuple(int)):
+                Constant values to use when padding with constant pad mode.
+                Passed to the :func:`numpy.pad` `constant_values` argument.
+                Default is 0.
             coord_space (str):
                 Defaults to "baseline". This is a flag to indicate if
                 the input `bounds` is in the baseline coordinate system

--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -4386,21 +4386,19 @@ class NGFFWSIReader(WSIReader):
                 name=attrs.get("name"),
                 version=attrs.get("version"),
             ),
-            multiscales=[
-                ngff.Multiscales(
-                    version=multiscales.get("version"),
-                    axes=[ngff.Axis(**axis) for axis in axes],
-                    datasets=[
-                        ngff.Dataset(
-                            path=dataset["path"],
-                            coordinateTransformations=dataset.get(
-                                "coordinateTransformations",
-                            ),
-                        )
-                        for dataset in datasets
-                    ],
-                )
-            ],
+            multiscales=ngff.Multiscales(
+                version=multiscales.get("version"),
+                axes=[ngff.Axis(**axis) for axis in axes],
+                datasets=[
+                    ngff.Dataset(
+                        path=dataset["path"],
+                        coordinateTransformations=dataset.get(
+                            "coordinateTransformations",
+                        ),
+                    )
+                    for dataset in datasets
+                ],
+            ),
             omero=ngff.Omero(
                 name=omero.get("name"),
                 id=omero.get("id"),

--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -1410,7 +1410,6 @@ class WSIReader:
             >>> slide_param = wsi.info
 
         """
-
         if verbose:
             logger.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
- Fix Multi-line docstring closing quotes should be on a separate line FLK-D209
- Fix No blank lines allowed after function docstring FLK-D202
- Fix Doc line too long FLK-W505
- Fix Attribute defined outside __init__ PYL-W0201
- Fix Function contains unused argument PYL-W0613
- Fix Consider decorating method with @staticmethod PYL-R0201
- Fix Missing module/function docstring PY-D0003