### PR TITLE
🐛 Fix `MultiTaskSegmentor` Example

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -8,8 +8,6 @@ from typing import List, Optional, Union
 
 import pytest
 
-from tiatoolbox.utils import env_detection as toolbox_env
-
 
 @pytest.fixture()
 def source_files(root_path):
@@ -26,10 +24,6 @@ def source_files(root_path):
     return generator()
 
 
-@pytest.mark.skipif(
-    toolbox_env.running_on_ci(),
-    reason="Error with test",
-)
 def test_validate_docstring_examples(source_files, root_path):
     """Test that all docstring examples are valid.
 

--- a/tiatoolbox/models/engine/multi_task_segmentor.py
+++ b/tiatoolbox/models/engine/multi_task_segmentor.py
@@ -218,7 +218,7 @@ class MultiTaskSegmentor(NucleusInstanceSegmentor):
     Examples:
         >>> # Sample output of a network
         >>> wsis = ['A/wsi.svs', 'B/wsi.svs']
-        >>> predictor = MultiTaskSegmentor(model='hovernetplus-oed',
+        >>> predictor = MultiTaskSegmentor(model='hovernetplus-oed', \
             output_type=['instance', 'semantic'])
         >>> output = predictor.predict(wsis, mode='wsi')
         >>> list(output.keys())

--- a/tiatoolbox/models/engine/multi_task_segmentor.py
+++ b/tiatoolbox/models/engine/multi_task_segmentor.py
@@ -218,8 +218,10 @@ class MultiTaskSegmentor(NucleusInstanceSegmentor):
     Examples:
         >>> # Sample output of a network
         >>> wsis = ['A/wsi.svs', 'B/wsi.svs']
-        >>> predictor = MultiTaskSegmentor(model='hovernetplus-oed', \
-            output_type=['instance', 'semantic'])
+        >>> predictor = MultiTaskSegmentor(
+        ...     model='hovernetplus-oed',
+        ...     output_type=['instance', 'semantic'],
+        ... )
         >>> output = predictor.predict(wsis, mode='wsi')
         >>> list(output.keys())
         [('A/wsi.svs', 'output/0') , ('B/wsi.svs', 'output/1')]


### PR DESCRIPTION
- Fix `test_validate_docstring_examples`
- Revert to `test_validate_docstring_examples` execution in CI, as now it passes