### PR TITLE
:recycle: Use `__all__` for High Level Imports

### DIFF
--- a/tiatoolbox/wsicore/__init__.py
+++ b/tiatoolbox/wsicore/__init__.py
@@ -1,6 +1,11 @@
 """Package to read whole slide images"""
 from tiatoolbox.wsicore import metadata, wsimeta, wsireader
 
+from .wsimeta import WSIMeta
+from .wsireader import WSIReader
+
 # Top level imports
-WSIReader = wsireader.WSIReader
-WSIMeta = wsimeta.WSIMeta
+__all__ = [
+    "WSIReader",
+    "WSIMeta",
+]


### PR DESCRIPTION
- Use `__all__` for high level imports