### PR TITLE
:recycle: Replace deprecated input `pretrained` with `weights`

### DIFF
--- a/tiatoolbox/models/architecture/vanilla.py
+++ b/tiatoolbox/models/architecture/vanilla.py
@@ -48,7 +48,7 @@ def _get_architecture(arch_name, pretrained=True, **kwargs):
         raise ValueError(f"Backbone `{arch_name}` is not supported.")
 
     creator = backbone_dict[arch_name]
-    model = creator(pretrained=pretrained, **kwargs)
+    model = creator(weights="DEFAULT", **kwargs)
 
     # Unroll all the definition and strip off the final GAP and FCN
     if "resnet" in arch_name or "resnext" in arch_name:

--- a/tiatoolbox/models/architecture/vanilla.py
+++ b/tiatoolbox/models/architecture/vanilla.py
@@ -9,7 +9,7 @@ from tiatoolbox.models.models_abc import ModelABC
 from tiatoolbox.utils.misc import select_device
 
 
-def _get_architecture(arch_name, weights="Default", **kwargs):
+def _get_architecture(arch_name, weights="DEFAULT", **kwargs):
     """Get a model.
 
     Model architectures are either already defined within torchvision or

--- a/tiatoolbox/models/architecture/vanilla.py
+++ b/tiatoolbox/models/architecture/vanilla.py
@@ -9,7 +9,7 @@ from tiatoolbox.models.models_abc import ModelABC
 from tiatoolbox.utils.misc import select_device
 
 
-def _get_architecture(arch_name, pretrained=True, **kwargs):
+def _get_architecture(arch_name, weights="Default", **kwargs):
     """Get a model.
 
     Model architectures are either already defined within torchvision or
@@ -48,7 +48,7 @@ def _get_architecture(arch_name, pretrained=True, **kwargs):
         raise ValueError(f"Backbone `{arch_name}` is not supported.")
 
     creator = backbone_dict[arch_name]
-    model = creator(weights="DEFAULT", **kwargs)
+    model = creator(weights=weights, **kwargs)
 
     # Unroll all the definition and strip off the final GAP and FCN
     if "resnet" in arch_name or "resnext" in arch_name:

--- a/tiatoolbox/tools/registration/wsi_registration.py
+++ b/tiatoolbox/tools/registration/wsi_registration.py
@@ -10,6 +10,7 @@ from numpy.linalg import inv
 from skimage import exposure, filters
 from skimage.registration import phase_cross_correlation
 from skimage.util import img_as_float
+from torchvision.models import VGG16_Weights
 
 from tiatoolbox import logger
 from tiatoolbox.tools.patchextraction import PatchExtractor
@@ -306,7 +307,7 @@ class DFBRFeatureExtractor(torch.nn.Module):
         output_layers_key: list[str] = ["block3_pool", "block4_pool", "block5_pool"]
         self.features: dict = dict.fromkeys(output_layers_key, None)
         self.pretrained: torch.nn.Sequential = torchvision.models.vgg16(
-            pretrained=True
+            weights=VGG16_Weights.IMAGENET1K_V1
         ).features
         self.f_hooks = []
 


### PR DESCRIPTION
- Replace deprecated input `pretrained` with `weights` according to the new API.