### PR TITLE
:wastebasket: Remove `shapely.speedups`

### DIFF
--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -58,7 +58,7 @@ from typing import (
 
 import numpy as np
 import pandas as pd
-from shapely import speedups, wkb, wkt
+from shapely import wkb, wkt
 from shapely.affinity import scale, translate
 from shapely.geometry import LineString, Point, Polygon
 from shapely.geometry import mapping as geometry2feature
@@ -75,9 +75,6 @@ from tiatoolbox.annotation.dsl import (
 )
 
 sqlite3.enable_callback_tracebacks(True)
-
-if speedups.available:  # pragma: no branch
-    speedups.enable()
 
 Geometry = Union[Point, Polygon, LineString]
 Properties = Dict[str, Union[Dict, List, Number, str]]

--- a/tiatoolbox/utils/visualization.py
+++ b/tiatoolbox/utils/visualization.py
@@ -10,14 +10,10 @@ import numpy as np
 from matplotlib import colormaps
 from numpy.typing import ArrayLike
 from PIL import Image, ImageFilter, ImageOps
-from shapely import speedups
 from shapely.geometry import Polygon
 
 from tiatoolbox import logger
 from tiatoolbox.annotation.storage import Annotation, AnnotationStore
-
-if speedups.available:  # pragma: no branch
-    speedups.enable()
 
 
 def random_colors(num_colors, bright=True):


### PR DESCRIPTION
- Remove `shapely.speedups`.
- [The shapely.speedups module (the enable and disable functions) is deprecated and will be removed in the future. The module no longer has any affect in Shapely >=2.0.](https://shapely.readthedocs.io/en/stable/release/2.x.html#shapely-2-0-api-changes-deprecated-in-1-8)