### PR TITLE
:technologist: Reduce Test runtime for JP2

### DIFF
--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -2441,6 +2441,10 @@ class TestReader:
         wsi = reader_class(sample, **kwargs)
         width, height = wsi.info.slide_dimensions
         iterations = 50
+
+        if sample_key == "jp2-omnyx-1":
+            iterations = 5
+
         for _ in range(iterations):
             size = (random.randint(1, 512), random.randint(1, 512))
             location = (


### PR DESCRIPTION
- Reduce Test runtime for JP2 `test_fuzz_read_region_baseline_size`
- This test takes longest time to run on CI. Number of iterations is quite high which can be reduced to improve tests run time.