### PR TITLE
:technologist: Use `poetry` for Version Updates

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -120,7 +120,7 @@ A reminder for the maintainers on how to deploy.
 Make sure all your changes are committed (including an entry in HISTORY.rst).
 Then run::
 
-$ bump2version patch # possible: major / minor / patch
+$ poetry version patch # use: "poetry version --help" for other options
 $ git push
 $ git push --tags
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,29 @@
 
 [tool.distutils.bdist_wheel]
   universal = true
+
+[tool.poetry]
+name = "TIA Centre"
+version = "1.4.0"
+description = "test"
+authors = ["TIA Centre <tialab@dcs.warwick.ac.uk>"]
+
+[tool.poetry_bumpversion.file."tiatoolbox/__init__.py"]
+search = '__version__ = "{current_version}"'
+replace = '__version__ = "{new_version}"'
+
+
+[[tool.poetry_bumpversion.replacements]]
+files = ["setup.py"]
+search = 'version="{current_version}"'
+replace = 'version="{new_version}"'
+
+[[tool.poetry_bumpversion.replacements]]
+files = ["CITATION.cff"]
+search = 'version: {current_version}  # TIAToolbox version'
+replace = 'version: {new_version}  # TIAToolbox version'
+
+[[tool.poetry_bumpversion.replacements]]
+files = [".github/workflows/docker-publish.yml"]
+search = 'TOOLBOX_VER: {current_version}'
+replace = 'TOOLBOX_VER: {new_version}'

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -9,6 +9,7 @@ flake8-bugbear>=22.10.27
 isort==5.12.0
 jinja2>=3.0.3, <3.1.0
 pip>=22.3
+poetry-bumpversion>=0.3.1
 pre-commit>=2.20.0
 pytest>=7.2.0
 pytest-cov>=4.0.0

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 -r ../docs/requirements.txt
 black>=23.3.0
-bump2version>=1.0.1
 coverage>=7.0.0
 docutils>=0.18.1
 flake8>=5.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,24 +1,3 @@
-[bumpversion]
-current_version = 1.4.0
-commit = True
-tag = False
-
-[bumpversion:file:setup.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
-[bumpversion:file:tiatoolbox/__init__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"
-
-[bumpversion:file:CITATION.cff]
-search = version: {current_version}  # TIAToolbox version
-replace = version: {new_version}  # TIAToolbox version
-
-[bumpversion:file:.github/workflows/docker-publish.yml]
-search = TOOLBOX_VER: {current_version}
-replace = TOOLBOX_VER: {new_version}
-
 [flake8]
 exclude = docs, *__init__*, setup.py
 max-line-length = 88

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pkg_resources
 import yaml
 
-__author__ = """TIA Lab"""
+__author__ = """TIA Centre"""
 __email__ = "tialab@dcs.warwick.ac.uk"
 __version__ = "1.4.0"
 


### PR DESCRIPTION
- Use [`poetry-bumpversion`](https://pypi.org/project/poetry-bumpversion/) for version number updates instead of bump2version as bump2version is no longer being maintained https://github.com/c4urself/bump2version/issues/42#issuecomment-1582436696.