### PR TITLE
:recycle: Small tests improvements

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from tiatoolbox.utils.env_detection import running_on_ci
 
 def pytest_configure(config):
     logger.info(
-        "🏁 Starting tests. Tiatoolbox version: %s. CI: %s",
+        "🏁 Starting tests. TIAToolbox Version: %s. CI: %s",
         tiatoolbox.__version__,
         running_on_ci(),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,22 @@ from typing import Callable
 import pytest
 from _pytest.tmpdir import TempPathFactory
 
+import tiatoolbox
+from tiatoolbox import logger
 from tiatoolbox.data import _fetch_remote_sample
+from tiatoolbox.utils.env_detection import running_on_ci
 
 # -------------------------------------------------------------------------------------
 # Generate Parameterized Tests
 # -------------------------------------------------------------------------------------
+
+
+def pytest_configure(config):
+    logger.info(
+        "🏁 Starting tests. Tiatoolbox version: %s. CI: %s",
+        tiatoolbox.__version__,
+        running_on_ci(),
+    )
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1219,7 +1219,7 @@ def test_model_to():
     # no GPU on Travis so this will crash
     if not utils.env_detection.has_gpu():
         model = torch_models.resnet18()
-        with pytest.raises(RuntimeError):
+        with pytest.raises(AssertionError):
             _ = misc.model_to(on_gpu=True, model=model)
 
     # Test on CPU

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1219,7 +1219,7 @@ def test_model_to():
     # no GPU on Travis so this will crash
     if not utils.env_detection.has_gpu():
         model = torch_models.resnet18()
-        with pytest.raises(AssertionError):
+        with pytest.raises((AssertionError, RuntimeError)):
             _ = misc.model_to(on_gpu=True, model=model)
 
     # Test on CPU

--- a/tiatoolbox/utils/env_detection.py
+++ b/tiatoolbox/utils/env_detection.py
@@ -168,7 +168,7 @@ def running_on_ci() -> bool:
     """
     return any(
         (
-            os.environ.get("CI") == "true",
+            os.environ.get("CI", "").lower() == "true",
             running_on_travis(),
             running_on_github(),
             running_on_circleci(),


### PR DESCRIPTION
`model.to('cuda')` on my m1-based mac (mps backed) raises AssertionError, not Runtime one:
```            if not hasattr(torch._C, '_cuda_getDeviceCount'):
>               raise AssertionError("Torch not compiled with CUDA enabled")
E               AssertionError: Torch not compiled with CUDA enabled
```

Also, improved Ci-detection behaviour.