### PR TITLE
Add check for Phase correlation transform

### DIFF
--- a/tests/test_wsi_registration.py
+++ b/tests/test_wsi_registration.py
@@ -348,7 +348,7 @@ def test_register_output_with_initializer(
     pre_transform = np.array([[-1, 0, 337.8], [0, -1, 767.7], [0, 0, 1]])
 
     expected = np.array(
-        [[-0.98454, -0.00708, 397.95628], [-0.01024, -0.99752, 684.81131], [0, 0, 1]]
+        [[-0.98454, -0.00708, 336.9562], [-0.01024, -0.99751, 769.81131], [0, 0, 1]]
     )
 
     output = df.register(
@@ -373,7 +373,7 @@ def test_register_output_without_initializer(
 
     df = DFBRegister()
     expected = np.array(
-        [[-0.99863, 0.00189, 389.79039], [0.00691, -0.99810, 874.98081], [0, 0, 1]]
+        [[-0.99863, 0.00189, 336.79039], [0.00691, -0.99810, 765.98081], [0, 0, 1]]
     )
 
     output = df.register(
@@ -499,3 +499,6 @@ def test_affine_wsi_transformer(sample_ome_tiff):
         expected = cv2.rotate(expected, cv2.ROTATE_90_CLOCKWISE)
 
         assert np.sum(expected - output) == 0
+
+
+

--- a/tests/test_wsi_registration.py
+++ b/tests/test_wsi_registration.py
@@ -499,6 +499,3 @@ def test_affine_wsi_transformer(sample_ome_tiff):
         expected = cv2.rotate(expected, cv2.ROTATE_90_CLOCKWISE)
 
         assert np.sum(expected - output) == 0
-
-
-

--- a/tiatoolbox/tools/registration/wsi_registration.py
+++ b/tiatoolbox/tools/registration/wsi_registration.py
@@ -1111,7 +1111,7 @@ class DFBRegister:
             fixed_tissue_mask, moving_tissue_mask, translation_offset
         )
 
-        # Use the estimated phase cross correlation transform 
+        # Use the estimated phase cross correlation transform
         # only if it improves DICE overlap
         after_dice = dice(fixed_tissue_mask, transform_tissue_mask)
         if after_dice < before_dice:

--- a/tiatoolbox/tools/registration/wsi_registration.py
+++ b/tiatoolbox/tools/registration/wsi_registration.py
@@ -1107,7 +1107,9 @@ class DFBRegister:
             fixed_tissue_img, moving_tissue_img
         )
         translation_offset = np.array([[1, 0, shift[1]], [0, 1, shift[0]], [0, 0, 1]])
-        transform_tissue_mask = apply_affine_transformation(fixed_tissue_mask, moving_tissue_mask, translation_offset)
+        transform_tissue_mask = apply_affine_transformation(
+            fixed_tissue_mask, moving_tissue_mask, translation_offset
+        )
 
         # Use the estimated phase cross correlation transform only if it improves DICE overlap
         after_dice = dice(fixed_tissue_mask, transform_tissue_mask)

--- a/tiatoolbox/tools/registration/wsi_registration.py
+++ b/tiatoolbox/tools/registration/wsi_registration.py
@@ -1111,7 +1111,8 @@ class DFBRegister:
             fixed_tissue_mask, moving_tissue_mask, translation_offset
         )
 
-        # Use the estimated phase cross correlation transform only if it improves DICE overlap
+        # Use the estimated phase cross correlation transform 
+        # only if it improves DICE overlap
         after_dice = dice(fixed_tissue_mask, transform_tissue_mask)
         if after_dice < before_dice:
             translation_offset = np.eye(3, 3)

--- a/tiatoolbox/tools/registration/wsi_registration.py
+++ b/tiatoolbox/tools/registration/wsi_registration.py
@@ -1107,6 +1107,12 @@ class DFBRegister:
             fixed_tissue_img, moving_tissue_img
         )
         translation_offset = np.array([[1, 0, shift[1]], [0, 1, shift[0]], [0, 0, 1]])
+        transform_tissue_mask = apply_affine_transformation(fixed_tissue_mask, moving_tissue_mask, translation_offset)
+
+        # Use the estimated phase cross correlation transform only if it improves DICE overlap
+        after_dice = dice(fixed_tissue_mask, transform_tissue_mask)
+        if after_dice < before_dice:
+            translation_offset = np.eye(3, 3)
 
         # Combining tissue and block transform
         tissue_transform = translation_offset @ block_transform @ tissue_transform


### PR DESCRIPTION
Likewise other intermediate transform, Phase cross-correlation transform should only be applied if it improves the DICE overlap.