### PR TITLE
🐛 Parse JP2 Boxes By ID Not Position

### DIFF
--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -1432,7 +1432,7 @@ def test_wsireader_open(
 def test_jp2_missing_cod(sample_jp2, caplog):
     """Test for warning if JP2 is missing COD segment."""
     wsi = wsireader.OmnyxJP2WSIReader(sample_jp2)
-    wsi.glymur_wsi.codestream.segment = []
+    wsi.glymur_jp2.codestream.segment = []
     _ = wsi.info
     assert "missing COD" in caplog.text
 

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -900,6 +900,8 @@ def ppu2mpp(ppu: int, units: Union[str, int]) -> float:
 
     """
     microns_per_unit = {
+        "meter": 1e6,  # 1,000,000
+        "m": 1e6,  # 1,000,000
         "centimeter": 1e4,  # 10,000
         "cm": 1e4,  # 10,000
         "mm": 1e3,  # 1,000


### PR DESCRIPTION
Boxes can be in any order. Previously the order was being relied on.