### PR TITLE
➖ Remove `isort` and Use `ruff` for sorting imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,10 +62,6 @@ repos:
       - id: rst-backticks           # Detect common mistake of using single backticks when writing rst.
       - id: rst-directive-colons    # Detect mistake of rst directive not ending with double colon.
       - id: rst-inline-touching-normal # Detect mistake of inline code touching normal text in rst.
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
   - repo: https://github.com/psf/black
     rev: 23.7.0 # Replace with any tag/version: https://github.com/psf/black/tags
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,13 +38,6 @@
   ignore_errors = true
   omit = ['tests/*', 'tiatoolbox/__main__.py', '*/utils/env_detection.py', 'tiatoolbox/typing.py']
 
-[tool.isort]
-  profile = "black"
-  multi_line_output = 3
-  line_length = 88
-  filter_files = "True"
-  skip = [".gitignore", "benchmarks/*"]
-
 [build-system]
   requires = ["setuptools"]
   build-backend = "setuptools.build_meta"
@@ -86,6 +79,7 @@ select = [
   "E",     # pycodestyle - Error
   "F",     # pyflakes
   "G",     # flake8-logging-format
+  "I",     # Isort
   "N",     # pep8-naming
   # "S",     # flake8-bandit
   "W",     # pycodestyle - Warning

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -3,7 +3,6 @@
 black>=23.3.0
 coverage>=7.0.0
 docutils>=0.18.1
-isort==5.12.0
 jinja2>=3.0.3, <3.1.0
 pip>=22.3
 poetry-bumpversion>=0.3.1

--- a/tests/models/test_dataset.py
+++ b/tests/models/test_dataset.py
@@ -8,9 +8,8 @@ import pytest
 
 from tiatoolbox import rcParam
 from tiatoolbox.models.dataset import DatasetInfoABC, KatherPatchDataset, PatchDataset
-from tiatoolbox.utils import download_data
+from tiatoolbox.utils import download_data, unzip_data
 from tiatoolbox.utils import env_detection as toolbox_env
-from tiatoolbox.utils import unzip_data
 
 
 class Proto1(DatasetInfoABC):

--- a/tests/models/test_patch_predictor.py
+++ b/tests/models/test_patch_predictor.py
@@ -19,9 +19,8 @@ from tiatoolbox.models.dataset import (
     WSIPatchDataset,
     predefined_preproc_func,
 )
-from tiatoolbox.utils import download_data
+from tiatoolbox.utils import download_data, imread, imwrite
 from tiatoolbox.utils import env_detection as toolbox_env
-from tiatoolbox.utils import imread, imwrite
 from tiatoolbox.wsicore.wsireader import WSIReader
 
 ON_GPU = toolbox_env.has_gpu()


### PR DESCRIPTION
- Remove `isort` 
- Use `ruff` for sorting imports