### PR TITLE
🐛 Fix `AffineWSITransformer.read_rect()`

### DIFF
--- a/tiatoolbox/tools/registration/wsi_registration.py
+++ b/tiatoolbox/tools/registration/wsi_registration.py
@@ -1617,7 +1617,7 @@ class AffineWSITransformer:
         """
         (
             read_level,
-            level_location,
+            _level_location,
             level_size,
             post_read_scale,
             _baseline_read_size,


### PR DESCRIPTION
- Fix issues when extracting transformed patches using `mpp` and `power` units