### PR TITLE
🐛 Fix `patch_coords`

### DIFF
--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -340,7 +340,16 @@ def test_get_coordinates() -> None:
         input_within_bound=True,
     )
     assert len(output) == 0
-
+    # test with stride allowing extra patch
+    output = PatchExtractor.get_coordinates(
+        image_shape=(9, 6),
+        patch_input_shape=(4, 6),
+        stride_shape=(2, 6),
+        input_within_bound=False,
+    )
+    assert len(output) == 5
+    # shouldnt give any patch with top-left corner out of bound
+    assert np.all(np.max(output[:, :2], axis=0) < np.array([9, 6]))
     # test error input form
     with pytest.raises(ValueError, match=r"Invalid.*shape.*"):
         PatchExtractor.get_coordinates(

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -452,13 +452,9 @@ class PatchExtractor(PatchExtractorABC):
             x, y = np.meshgrid(x, y)
             return np.stack([x.flatten(), y.flatten()], axis=-1)
 
-        output_x_end = (
-            np.ceil(image_shape[0] / patch_output_shape[0]) * patch_output_shape[0]
-        )
+        output_x_end = np.ceil(image_shape[0] / stride_shape[0]) * stride_shape[0]
         output_x_list = np.arange(0, int(output_x_end), stride_shape[0])
-        output_y_end = (
-            np.ceil(image_shape[1] / patch_output_shape[1]) * patch_output_shape[1]
-        )
+        output_y_end = np.ceil(image_shape[1] / stride_shape[1]) * stride_shape[1]
         output_y_list = np.arange(0, int(output_y_end), stride_shape[1])
         output_tl_list = flat_mesh_grid_coord(output_x_list, output_y_list)
         output_br_list = output_tl_list + patch_output_shape[None]


### PR DESCRIPTION
proposed fix for issue #710 

fixes situation where PatchExtractor.get_coords() can return patch coords which lie fully outside the bounds of a slide.

Also adds a test that would have flagged this situation.