### PR TITLE
🚨 Fix `flake8-annotation` Linter Errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ select = [
   "C90",   # mccabe
   "T10",   # flake8-debugger
   "T20",   # flake8-print
-  # "ANN",   # flake8-annotations
+  "ANN",   # flake8-annotations
   "ARG",   # flake8-unused-arguments
   "BLE",   # flake8-blind-except
   "COM",   # flake8-commas

--- a/tests/test_annotation_stores.py
+++ b/tests/test_annotation_stores.py
@@ -1561,7 +1561,7 @@ class TestStore:
 
     @staticmethod
     def test_append_invalid_geometry(
-        fill_store: callable,   # noqa: ARG004
+        fill_store: callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test that appending invalid geometry raises an exception."""

--- a/tests/test_annotation_stores.py
+++ b/tests/test_annotation_stores.py
@@ -187,7 +187,7 @@ def sample_triangle() -> Polygon:
 def fill_store(
     cell_grid: list[Polygon],
     points_grid: list[Point],
-) -> Callable[list[str], AnnotationStore]:
+) -> Callable[[list[str]], AnnotationStore]:
     """Factory fixture to fill stores with test data."""
 
     def _fill_store(
@@ -552,7 +552,7 @@ def test_sqlite_store_index_version_error(monkeypatch: object) -> None:
         store.create_index("foo", lambda _, p: "foo" in p)
 
 
-def test_sqlite_store_index_str(fill_store: callable, tmp_path: Path) -> None:
+def test_sqlite_store_index_str(fill_store: Callable, tmp_path: Path) -> None:
     """Test that adding an index improves performance."""
     _, store = fill_store(SQLiteStore, tmp_path / "polygon.db")
 
@@ -579,7 +579,7 @@ def test_sqlite_store_index_str(fill_store: callable, tmp_path: Path) -> None:
     assert t2 < t1
 
 
-def test_sqlite_create_index_no_analyze(fill_store: callable, tmp_path: Path) -> None:
+def test_sqlite_create_index_no_analyze(fill_store: Callable, tmp_path: Path) -> None:
     """Test that creating an index without ANALYZE."""
     _, store = fill_store(SQLiteStore, tmp_path / "polygon.db")
     properties_predicate = "props['class']"
@@ -588,7 +588,7 @@ def test_sqlite_create_index_no_analyze(fill_store: callable, tmp_path: Path) ->
 
 
 def test_sqlite_pquery_warn_no_index(
-    fill_store: callable,
+    fill_store: Callable,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that querying without an index warns."""
@@ -602,14 +602,14 @@ def test_sqlite_pquery_warn_no_index(
         assert len(record) == 0
 
 
-def test_sqlite_store_indexes(fill_store: callable, tmp_path: Path) -> None:
+def test_sqlite_store_indexes(fill_store: Callable, tmp_path: Path) -> None:
     """Test getting a list of index names."""
     _, store = fill_store(SQLiteStore, tmp_path / "polygon.db")
     store.create_index("test_index", "props['class']")
     assert "test_index" in store.indexes()
 
 
-def test_sqlite_drop_index_error(fill_store: callable, tmp_path: Path) -> None:
+def test_sqlite_drop_index_error(fill_store: Callable, tmp_path: Path) -> None:
     """Test dropping an index that does not exist."""
     _, store = fill_store(SQLiteStore, tmp_path / "polygon.db")
     with pytest.raises(sqlite3.OperationalError, match="no such index"):
@@ -623,7 +623,7 @@ def test_sqlite_store_unsupported_compression(sample_triangle: Polygon) -> None:
         _ = store.serialise_geometry(sample_triangle)
 
 
-def test_sqlite_optimize(fill_store: callable, tmp_path: Path) -> None:
+def test_sqlite_optimize(fill_store: Callable, tmp_path: Path) -> None:
     """Test optimizing the database."""
     _, store = fill_store(SQLiteStore, tmp_path / "polygon.db")
     store.optimize()
@@ -726,7 +726,7 @@ def test_sqlite_drop_index_fail() -> None:
         store.drop_index("foo")
 
 
-def test_sqlite_optimize_no_vacuum(fill_store: callable, tmp_path: Path) -> None:
+def test_sqlite_optimize_no_vacuum(fill_store: Callable, tmp_path: Path) -> None:
     """Test running the optimize function on an SQLiteStore without VACUUM."""
     _, store = fill_store(SQLiteStore, tmp_path / "polygon.db")
     store.optimize(limit=0, vacuum=False)
@@ -806,7 +806,7 @@ def test_query_min_area_no_area_column(fill_store: callable) -> None:
         store.query((0, 0, 1000, 1000), min_area=1)
 
 
-def test_auto_commit(fill_store: callable, tmp_path: Path) -> None:
+def test_auto_commit(fill_store: Callable, tmp_path: Path) -> None:
     """Test auto commit.
 
     Check that if auto-commit is False, the changes are not committed until
@@ -854,7 +854,7 @@ class TestStore:
 
     @staticmethod
     def test_open_close(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -915,7 +915,7 @@ class TestStore:
 
     @staticmethod
     def test_query_bbox(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -926,7 +926,7 @@ class TestStore:
 
     @staticmethod
     def test_iquery_bbox(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -938,7 +938,7 @@ class TestStore:
 
     @staticmethod
     def test_query_polygon(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -950,7 +950,7 @@ class TestStore:
 
     @staticmethod
     def test_iquery_polygon(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -962,7 +962,7 @@ class TestStore:
 
     @staticmethod
     def test_patch(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -982,7 +982,7 @@ class TestStore:
 
     @staticmethod
     def test_patch_append(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -994,7 +994,7 @@ class TestStore:
 
     @staticmethod
     def test_patch_many(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1016,7 +1016,7 @@ class TestStore:
 
     @staticmethod
     def test_patch_many_no_properies(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1031,7 +1031,7 @@ class TestStore:
 
     @staticmethod
     def test_patch_many_no_geometry(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1048,7 +1048,7 @@ class TestStore:
 
     @staticmethod
     def test_patch_many_no_geometry_no_properties(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1059,7 +1059,7 @@ class TestStore:
 
     @staticmethod
     def test_patch_many_append(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1072,7 +1072,7 @@ class TestStore:
 
     @staticmethod
     def test_patch_many_len_mismatch(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1084,7 +1084,7 @@ class TestStore:
 
     @staticmethod
     def test_keys(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1096,7 +1096,7 @@ class TestStore:
 
     @staticmethod
     def test_remove(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1108,7 +1108,7 @@ class TestStore:
 
     @staticmethod
     def test_delitem(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1120,7 +1120,7 @@ class TestStore:
 
     @staticmethod
     def test_remove_many(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1131,7 +1131,7 @@ class TestStore:
 
     @staticmethod
     def test_len(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1141,7 +1141,7 @@ class TestStore:
 
     @staticmethod
     def test_contains(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1152,7 +1152,7 @@ class TestStore:
 
     @staticmethod
     def test_iter(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1163,7 +1163,7 @@ class TestStore:
 
     @staticmethod
     def test_getitem(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         sample_triangle: Polygon,
         store_cls: type[AnnotationStore],
@@ -1177,7 +1177,7 @@ class TestStore:
 
     @staticmethod
     def test_setitem(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         sample_triangle: Polygon,
         store_cls: type[AnnotationStore],
@@ -1192,7 +1192,7 @@ class TestStore:
 
     @staticmethod
     def test_getitem_setitem_cycle(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         sample_triangle: Polygon,
         store_cls: type[AnnotationStore],
@@ -1226,7 +1226,7 @@ class TestStore:
 
     @staticmethod
     def test_to_dataframe(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1241,7 +1241,7 @@ class TestStore:
 
     @staticmethod
     def test_features(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1258,7 +1258,7 @@ class TestStore:
 
     @staticmethod
     def test_to_geodict(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1273,7 +1273,7 @@ class TestStore:
 
     @staticmethod
     def test_from_geojson_str(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1285,7 +1285,7 @@ class TestStore:
 
     @staticmethod
     def test_from_geojson_file(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1298,7 +1298,7 @@ class TestStore:
 
     @staticmethod
     def test_from_geojson_path(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1310,7 +1310,7 @@ class TestStore:
 
     @staticmethod
     def test_from_geojson_path_transform(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1331,7 +1331,7 @@ class TestStore:
 
     @staticmethod
     def test_transform(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1350,7 +1350,7 @@ class TestStore:
 
     @staticmethod
     def test_to_geojson_str(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1366,7 +1366,7 @@ class TestStore:
 
     @staticmethod
     def test_to_geojson_file(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1384,7 +1384,7 @@ class TestStore:
 
     @staticmethod
     def test_to_geojson_path(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1401,7 +1401,7 @@ class TestStore:
 
     @staticmethod
     def test_to_ndjson_str(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1417,7 +1417,7 @@ class TestStore:
 
     @staticmethod
     def test_to_ndjson_file(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1436,7 +1436,7 @@ class TestStore:
 
     @staticmethod
     def test_to_ndjson_path(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1454,7 +1454,7 @@ class TestStore:
 
     @staticmethod
     def test_dump(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1465,7 +1465,7 @@ class TestStore:
 
     @staticmethod
     def test_dump_file_handle(
-        fill_store: callable,
+        fill_store: Callable,
         tmp_path: Path,
         store_cls: type[AnnotationStore],
     ) -> None:
@@ -1476,7 +1476,7 @@ class TestStore:
         assert (tmp_path / "dump_test.db").stat().st_size > 0
 
     @staticmethod
-    def test_dumps(fill_store: callable, store_cls: type[AnnotationStore]) -> None:
+    def test_dumps(fill_store: Callable, store_cls: type[AnnotationStore]) -> None:
         """Test dumping by returning a string."""
         _, store = fill_store(store_cls, ":memory:")
         string = store.dumps()
@@ -1484,7 +1484,7 @@ class TestStore:
 
     @staticmethod
     def test_iquery_predicate_str(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test iquering with a predicate string."""
@@ -1496,7 +1496,7 @@ class TestStore:
 
     @staticmethod
     def test_iquery_predicate_callable(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test iquering with a predicate function."""
@@ -1511,7 +1511,7 @@ class TestStore:
 
     @staticmethod
     def test_iquery_predicate_pickle(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test iquering with a pickled predicate function."""
@@ -1523,7 +1523,7 @@ class TestStore:
 
     @staticmethod
     def test_query_predicate_str(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test quering with a predicate string."""
@@ -1534,7 +1534,7 @@ class TestStore:
 
     @staticmethod
     def test_query_predicate_callable(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test quering with a predicate function."""
@@ -1549,7 +1549,7 @@ class TestStore:
 
     @staticmethod
     def test_query_predicate_pickle(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test quering with a pickled predicate function."""
@@ -1561,7 +1561,7 @@ class TestStore:
 
     @staticmethod
     def test_append_invalid_geometry(
-        fill_store: callable,  # noqa: ARG004
+        fill_store: Callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test that appending invalid geometry raises an exception."""
@@ -1571,7 +1571,7 @@ class TestStore:
 
     @staticmethod
     def test_update_invalid_geometry(
-        fill_store: callable,  # noqa: ARG004
+        fill_store: Callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test that updating  a new key and None geometry raises an exception."""
@@ -1581,7 +1581,7 @@ class TestStore:
             store.patch(key, geometry=None, properties={"class": 123})
 
     @staticmethod
-    def test_pop_key(fill_store: callable, store_cls: type[AnnotationStore]) -> None:
+    def test_pop_key(fill_store: Callable, store_cls: type[AnnotationStore]) -> None:
         """Test popping an annotation by key."""
         keys, store = fill_store(store_cls, ":memory:")
         assert keys[0] in store
@@ -1591,7 +1591,7 @@ class TestStore:
 
     @staticmethod
     def test_pop_key_error(
-        fill_store: callable,  # noqa: ARG004
+        fill_store: Callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test that popping a key that is not in the store raises an exception."""
@@ -1600,7 +1600,7 @@ class TestStore:
             store.pop("foo")
 
     @staticmethod
-    def test_popitem(fill_store: callable, store_cls: type[AnnotationStore]) -> None:
+    def test_popitem(fill_store: Callable, store_cls: type[AnnotationStore]) -> None:
         """Test popping a key and annotation by key."""
         keys, store = fill_store(store_cls, ":memory:")
         key, annotation = store.popitem()
@@ -1610,7 +1610,7 @@ class TestStore:
 
     @staticmethod
     def test_popitem_empty_error(
-        fill_store: callable,  # noqa: ARG004
+        fill_store: Callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test that popping an empty store raises an exception."""
@@ -1620,7 +1620,7 @@ class TestStore:
 
     @staticmethod
     def test_setdefault(
-        fill_store: callable,  # noqa: ARG004
+        fill_store: Callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
         sample_triangle: list[Polygon],
     ) -> None:
@@ -1634,7 +1634,7 @@ class TestStore:
 
     @staticmethod
     def test_setdefault_error(
-        fill_store: callable,  # noqa: ARG004
+        fill_store: Callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
         sample_triangle: Polygon,  # noqa: ARG004
     ) -> None:
@@ -1644,7 +1644,7 @@ class TestStore:
             store.setdefault("foo", {})
 
     @staticmethod
-    def test_get(fill_store: callable, store_cls: type[AnnotationStore]) -> None:
+    def test_get(fill_store: Callable, store_cls: type[AnnotationStore]) -> None:
         """Test getting an annotation by key."""
         keys, store = fill_store(store_cls, ":memory:")
         assert keys[0] in store
@@ -1652,7 +1652,7 @@ class TestStore:
 
     @staticmethod
     def test_get_default(
-        fill_store: callable,  # noqa: ARG004
+        fill_store: Callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test getting a default value for a key."""
@@ -1662,7 +1662,7 @@ class TestStore:
 
     @staticmethod
     def test_eq(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test comparing two stores for equality."""
@@ -1679,7 +1679,7 @@ class TestStore:
 
     @staticmethod
     def test_ne(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test comparing two stores for inequality."""
@@ -1688,7 +1688,7 @@ class TestStore:
         assert store1 != store2
 
     @staticmethod
-    def test_clear(fill_store: callable, store_cls: type[AnnotationStore]) -> None:
+    def test_clear(fill_store: Callable, store_cls: type[AnnotationStore]) -> None:
         """Test clearing a store."""
         keys, store = fill_store(store_cls, ":memory:")
         store.clear()
@@ -1698,7 +1698,7 @@ class TestStore:
 
     @staticmethod
     def test_update(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
         sample_triangle: Polygon,
     ) -> None:
@@ -1713,7 +1713,7 @@ class TestStore:
         assert store["foo"] == annotations["foo"]
 
     @staticmethod
-    def test_cast_dict(fill_store: callable, store_cls: type[AnnotationStore]) -> None:
+    def test_cast_dict(fill_store: Callable, store_cls: type[AnnotationStore]) -> None:
         """Test casting a store to a dictionary."""
         keys, store = fill_store(store_cls, ":memory:")
         store_dict = dict(store)
@@ -1722,7 +1722,7 @@ class TestStore:
 
     @staticmethod
     def test_query_invalid_geometry_predicate(
-        fill_store: callable,  # noqa: ARG004
+        fill_store: Callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test that invalid geometry predicate raises an exception."""
@@ -1732,7 +1732,7 @@ class TestStore:
 
     @staticmethod
     def test_query_no_geometry_or_where(
-        fill_store: callable,  # noqa: ARG004
+        fill_store: Callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test that query raises exception when no geometry or predicate given."""
@@ -1742,7 +1742,7 @@ class TestStore:
 
     @staticmethod
     def test_iquery_invalid_geometry_predicate(
-        fill_store: callable,  # noqa: ARG004
+        fill_store: Callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test that invalid geometry predicate raises an exception."""
@@ -1752,7 +1752,7 @@ class TestStore:
 
     @staticmethod
     def test_serialise_deseialise_geometry(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test that geometry can be serialised and deserialised."""
@@ -1768,7 +1768,7 @@ class TestStore:
 
     @staticmethod
     def test_commit(
-        fill_store: callable,  # noqa: ARG004
+        fill_store: Callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
         tmp_path: Path,
     ) -> None:
@@ -1785,7 +1785,7 @@ class TestStore:
 
     @staticmethod
     def test_load_cases_error(
-        fill_store: callable,  # noqa: ARG004
+        fill_store: Callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test that loading a store with an invalid file handle raises an exception."""
@@ -1795,7 +1795,7 @@ class TestStore:
 
     @staticmethod
     def test_py38_init(
-        fill_store: callable,  # noqa: ARG004
+        fill_store: Callable,  # noqa: ARG004
         store_cls: type[AnnotationStore],
         monkeypatch: object,
     ) -> None:
@@ -1809,7 +1809,7 @@ class TestStore:
                 self: Connection,
                 name: str,
                 num_params: int,
-                func: Any,  # noqa: ARG002, ANN401
+                func: object,  # noqa: ARG002
             ) -> None:
                 """Mock create_function without `deterministic` kwarg."""
                 return self.create_function(self, name, num_params)
@@ -1820,7 +1820,7 @@ class TestStore:
 
     @staticmethod
     def test_bquery(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying a store with a bounding box."""
@@ -1831,7 +1831,7 @@ class TestStore:
 
     @staticmethod
     def test_bquery_polygon(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying a store with a polygon."""
@@ -1842,7 +1842,7 @@ class TestStore:
 
     @staticmethod
     def test_bquery_callable(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying a store with a bounding box and a callable where."""
@@ -1857,7 +1857,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_all(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for all properties."""
@@ -1869,7 +1869,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_all_unique_exception(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for all properties."""
@@ -1879,7 +1879,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_unique(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties."""
@@ -1890,7 +1890,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_unique_with_geometry(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties with a geometry intersection."""
@@ -1904,7 +1904,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_unique_with_where(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties with a where predicate."""
@@ -1918,7 +1918,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_unique_with_geometry_and_where(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties with a geometry and where predicate."""
@@ -1933,7 +1933,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_callable_unique(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties with a callable select and where."""
@@ -1948,7 +1948,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_callable_unique_no_squeeze(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties with a callable select and where."""
@@ -1964,7 +1964,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_callable_unique_multi_select(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying unique properties with a callable select and where."""
@@ -1979,7 +1979,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_callable(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties with a callable select and where."""
@@ -1994,7 +1994,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_callable_no_where(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties with callable select, no where."""
@@ -2009,7 +2009,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_pickled(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties with a pickled select and where."""
@@ -2024,7 +2024,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_pickled_no_squeeze(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties with a pickled select and where."""
@@ -2040,7 +2040,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_pickled_multi_select(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties with a pickled select and where."""
@@ -2055,7 +2055,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_invalid_expression_type(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties with an invalid expression type."""
@@ -2065,7 +2065,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_non_matching_type(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying with a non-matching type for select and where."""
@@ -2075,7 +2075,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_dict(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties."""
@@ -2087,7 +2087,7 @@ class TestStore:
 
     @staticmethod
     def test_pquery_dict_with_geometry(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying for properties with a geometry intersection."""
@@ -2269,7 +2269,7 @@ class TestStore:
 
     @staticmethod
     def test_bquery_bounds(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying a store with a bounding box iterable."""
@@ -2816,7 +2816,7 @@ class TestStore:
 
     @staticmethod
     def test_query_min_area(
-        fill_store: callable,
+        fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
         """Test querying with a minimum area."""

--- a/tests/test_annotation_stores.py
+++ b/tests/test_annotation_stores.py
@@ -8,7 +8,7 @@ import sys
 from itertools import repeat, zip_longest
 from pathlib import Path
 from timeit import timeit
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generator
+from typing import TYPE_CHECKING, Callable, ClassVar, Generator
 
 import numpy as np
 import pandas as pd
@@ -109,7 +109,7 @@ def cell_polygon(
     return affinity.rotate(polygon, angle, origin="centroid")
 
 
-def sample_where_1(props: dict[str, Any]) -> bool:
+def sample_where_1(props: dict[str, object]) -> bool:
     """Simple example predicate function for tests.
 
     Checks for a class = 1.
@@ -118,7 +118,7 @@ def sample_where_1(props: dict[str, Any]) -> bool:
     return props.get("class") == 1
 
 
-def sample_where_123(props: dict[str, Any]) -> bool:
+def sample_where_123(props: dict[str, object]) -> bool:
     """Simple example predicate function for tests.
 
     Checks for a class = 123.
@@ -127,7 +127,7 @@ def sample_where_123(props: dict[str, Any]) -> bool:
     return props.get("class") == 123
 
 
-def sample_select(props: dict[str, Any]) -> tuple[Any]:
+def sample_select(props: dict[str, object]) -> tuple[object]:
     """Simple example select expression for tests.
 
     Gets the class value.
@@ -136,7 +136,7 @@ def sample_select(props: dict[str, Any]) -> tuple[Any]:
     return props.get("class")
 
 
-def sample_multi_select(props: dict[str, Any]) -> tuple[Any]:
+def sample_multi_select(props: dict[str, object]) -> tuple[object]:
     """Simple example select expression for tests.
 
     Gets the class value and the class mod 2.
@@ -732,7 +732,7 @@ def test_sqlite_optimize_no_vacuum(fill_store: Callable, tmp_path: Path) -> None
     store.optimize(limit=0, vacuum=False)
 
 
-def test_sqlite_wkb(fill_store: callable) -> None:
+def test_sqlite_wkb(fill_store: Callable) -> None:
     """Test that SQLiteStore returns annotations with WKB geometry."""
     _, store = fill_store(SQLiteStore, ":memory:")
     results = store.query((0, 0, 30, 30))
@@ -752,7 +752,7 @@ def test_annotation_to_geojson() -> None:
     assert geojson["properties"] == {"foo": "bar", "baz": "qux"}
 
 
-def test_remove_area_column(fill_store: callable) -> None:
+def test_remove_area_column(fill_store: Callable) -> None:
     """Test removing an area column."""
     _, store = fill_store(SQLiteStore, ":memory:")
     store.remove_area_column()
@@ -767,7 +767,7 @@ def test_remove_area_column(fill_store: callable) -> None:
     assert "area" not in store.indexes()
 
 
-def test_remove_area_column_indexed(fill_store: callable) -> None:
+def test_remove_area_column_indexed(fill_store: Callable) -> None:
     """Test removing an area column if there's an index on it."""
     _, store = fill_store(SQLiteStore, ":memory:")
     store.create_index("area", '"area"')
@@ -777,7 +777,7 @@ def test_remove_area_column_indexed(fill_store: callable) -> None:
     assert len(result) == 200
 
 
-def test_add_area_column(fill_store: callable) -> None:
+def test_add_area_column(fill_store: Callable) -> None:
     """Test adding an area column."""
     _, store = fill_store(SQLiteStore, ":memory:")
     store.remove_area_column()
@@ -798,7 +798,7 @@ def test_add_area_column(fill_store: callable) -> None:
     assert "area" not in store.indexes()
 
 
-def test_query_min_area_no_area_column(fill_store: callable) -> None:
+def test_query_min_area_no_area_column(fill_store: Callable) -> None:
     """Test querying with a minimum area when there is no area column."""
     _, store = fill_store(SQLiteStore, ":memory:")
     store.remove_area_column()
@@ -1845,7 +1845,7 @@ class TestStore:
         fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
-        """Test querying a store with a bounding box and a callable where."""
+        """Test querying a store with a bounding box and a Callable where."""
         keys, store = fill_store(store_cls, ":memory:")
         store.patch(keys[0], properties={"class": 123})
         dictionary = store.bquery(
@@ -1936,7 +1936,7 @@ class TestStore:
         fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
-        """Test querying for properties with a callable select and where."""
+        """Test querying for properties with a Callable select and where."""
         _, store = fill_store(store_cls, ":memory:")
         result_set = store.pquery(
             select=lambda props: (props.get("class"),),
@@ -1951,7 +1951,7 @@ class TestStore:
         fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
-        """Test querying for properties with a callable select and where."""
+        """Test querying for properties with a Callable select and where."""
         _, store = fill_store(store_cls, ":memory:")
         result_set = store.pquery(
             select=sample_select,
@@ -1967,7 +1967,7 @@ class TestStore:
         fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
-        """Test querying unique properties with a callable select and where."""
+        """Test querying unique properties with a Callable select and where."""
         _, store = fill_store(store_cls, ":memory:")
         result_set = store.pquery(
             select=sample_multi_select,
@@ -1982,7 +1982,7 @@ class TestStore:
         fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
-        """Test querying for properties with a callable select and where."""
+        """Test querying for properties with a Callable select and where."""
         _, store = fill_store(store_cls, ":memory:")
         result_set = store.pquery(
             select=lambda props: props.get("class"),
@@ -1997,7 +1997,7 @@ class TestStore:
         fill_store: Callable,
         store_cls: type[AnnotationStore],
     ) -> None:
-        """Test querying for properties with callable select, no where."""
+        """Test querying for properties with Callable select, no where."""
         _, store = fill_store(store_cls, ":memory:")
         result_set = store.pquery(
             select=lambda props: props.get("class"),

--- a/tests/test_annotation_tilerendering.py
+++ b/tests/test_annotation_tilerendering.py
@@ -46,7 +46,7 @@ def points_grid(spacing: float = 60) -> list[Point]:
 def fill_store(
     cell_grid: list[Polygon],
     points_grid: list[Point],
-    ) -> Callable[list[str], AnnotationStore]:
+) -> Callable[list[str], AnnotationStore]:
     """Factory fixture to fill stores with test data."""
 
     def _fill_store(
@@ -161,8 +161,9 @@ def test_filter_by_expression(fill_store: callable, tmp_path: Path) -> None:
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
     _, store = fill_store(SQLiteStore, tmp_path / "test.db")
     renderer = AnnotationRenderer(
-        where='props["type"] == "cell"', edge_thickness=0,
-        )
+        where='props["type"] == "cell"',
+        edge_thickness=0,
+    )
     tg = AnnotationTileGenerator(wsi.info, store, renderer, tile_size=256)
     thumb = tg.get_thumb_tile()
     _, num = label(np.array(thumb)[:, :, 1])
@@ -248,10 +249,10 @@ def test_sub_tile_levels(fill_store: callable, tmp_path: Path) -> None:
         """Mock generator with specific subtile_level."""
 
         def tile_path(
-                self: MockTileGenerator,
-                level: int,
-                x: int,
-                y: int,
+            self: MockTileGenerator,
+            level: int,
+            x: int,
+            y: int,
         ) -> Path:  # skipcq: PYL-R0201
             """Tile path."""
             return Path(level, x, y)

--- a/tests/test_annotation_tilerendering.py
+++ b/tests/test_annotation_tilerendering.py
@@ -46,13 +46,13 @@ def points_grid(spacing: float = 60) -> list[Point]:
 def fill_store(
     cell_grid: list[Polygon],
     points_grid: list[Point],
-) -> Callable[list[str], AnnotationStore]:
+) -> Callable[[list[str]], AnnotationStore]:
     """Factory fixture to fill stores with test data."""
 
     def _fill_store(
         store_class: AnnotationStore,
         path: str | Path,
-    ) -> Callable[list[str], AnnotationStore]:
+    ) -> tuple[list[str], AnnotationStore]:
         """Fills store with random variety of annotations."""
         store = store_class(path)
 
@@ -84,7 +84,7 @@ def fill_store(
     return _fill_store
 
 
-def test_tile_generator_len(fill_store: callable, tmp_path: Path) -> None:
+def test_tile_generator_len(fill_store: Callable, tmp_path: Path) -> None:
     """Test __len__ for AnnotationTileGenerator."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -93,7 +93,7 @@ def test_tile_generator_len(fill_store: callable, tmp_path: Path) -> None:
     assert len(tg) == (4 * 4) + (2 * 2) + 1
 
 
-def test_tile_generator_iter(fill_store: callable, tmp_path: Path) -> None:
+def test_tile_generator_iter(fill_store: Callable, tmp_path: Path) -> None:
     """Test __iter__ for AnnotationTileGenerator."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -105,7 +105,7 @@ def test_tile_generator_iter(fill_store: callable, tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(running_on_travis(), reason="no display on travis.")
-def test_show_generator_iter(fill_store: callable, tmp_path: Path) -> None:
+def test_show_generator_iter(fill_store: Callable, tmp_path: Path) -> None:
     """Show tiles with example annotations (if not travis)."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -121,7 +121,7 @@ def test_show_generator_iter(fill_store: callable, tmp_path: Path) -> None:
         plt.show(block=False)
 
 
-def test_correct_number_rendered(fill_store: callable, tmp_path: Path) -> None:
+def test_correct_number_rendered(fill_store: Callable, tmp_path: Path) -> None:
     """Test that the expected number of annotations are rendered."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -134,7 +134,7 @@ def test_correct_number_rendered(fill_store: callable, tmp_path: Path) -> None:
     assert num == 75  # expect 75 rendered objects
 
 
-def test_correct_colour_rendered(fill_store: callable, tmp_path: Path) -> None:
+def test_correct_colour_rendered(fill_store: Callable, tmp_path: Path) -> None:
     """Test colour mapping."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -155,7 +155,7 @@ def test_correct_colour_rendered(fill_store: callable, tmp_path: Path) -> None:
     assert num == 1  # expect 1 blue objects
 
 
-def test_filter_by_expression(fill_store: callable, tmp_path: Path) -> None:
+def test_filter_by_expression(fill_store: Callable, tmp_path: Path) -> None:
     """Test filtering using a where expression."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -170,7 +170,7 @@ def test_filter_by_expression(fill_store: callable, tmp_path: Path) -> None:
     assert num == 25  # expect 25 cell objects, as the added one is too small
 
 
-def test_zoomed_out_rendering(fill_store: callable, tmp_path: Path) -> None:
+def test_zoomed_out_rendering(fill_store: Callable, tmp_path: Path) -> None:
     """Test that the expected number of annotations are rendered."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -192,7 +192,7 @@ def test_zoomed_out_rendering(fill_store: callable, tmp_path: Path) -> None:
     assert num == 25  # expect 25 cells in top left quadrant
 
 
-def test_decimation(fill_store: callable, tmp_path: Path) -> None:
+def test_decimation(fill_store: Callable, tmp_path: Path) -> None:
     """Test decimation."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -207,7 +207,7 @@ def test_decimation(fill_store: callable, tmp_path: Path) -> None:
     assert num == 17  # expect 17 pts in bottom right quadrant
 
 
-def test_get_tile_negative_level(fill_store: callable, tmp_path: Path) -> None:
+def test_get_tile_negative_level(fill_store: Callable, tmp_path: Path) -> None:
     """Test for IndexError on negative levels."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array)
@@ -218,7 +218,7 @@ def test_get_tile_negative_level(fill_store: callable, tmp_path: Path) -> None:
         tg.get_tile(-1, 0, 0)
 
 
-def test_get_tile_large_level(fill_store: callable, tmp_path: Path) -> None:
+def test_get_tile_large_level(fill_store: Callable, tmp_path: Path) -> None:
     """Test for IndexError on too large a level."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array)
@@ -229,7 +229,7 @@ def test_get_tile_large_level(fill_store: callable, tmp_path: Path) -> None:
         tg.get_tile(100, 0, 0)
 
 
-def test_get_tile_large_xy(fill_store: callable, tmp_path: Path) -> None:
+def test_get_tile_large_xy(fill_store: Callable, tmp_path: Path) -> None:
     """Test for IndexError on too large an xy index."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array)
@@ -240,7 +240,7 @@ def test_get_tile_large_xy(fill_store: callable, tmp_path: Path) -> None:
         tg.get_tile(0, 100, 100)
 
 
-def test_sub_tile_levels(fill_store: callable, tmp_path: Path) -> None:
+def test_sub_tile_levels(fill_store: Callable, tmp_path: Path) -> None:
     """Test sub-tile level generation."""
     array = data.camera()
     wsi = wsireader.VirtualWSIReader(array)
@@ -269,7 +269,7 @@ def test_sub_tile_levels(fill_store: callable, tmp_path: Path) -> None:
 
 
 def test_unknown_geometry(
-    fill_store: callable,  # noqa: ARG001
+    fill_store: Callable,  # noqa: ARG001
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test warning when unknown geometries cannot be rendered."""
@@ -284,7 +284,7 @@ def test_unknown_geometry(
 
 
 def test_interp_pad_warning(
-    fill_store: callable,
+    fill_store: Callable,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -297,7 +297,7 @@ def test_interp_pad_warning(
     assert "interpolation, pad_mode are unused" in caplog.text
 
 
-def test_user_provided_cm(fill_store: callable, tmp_path: Path) -> None:
+def test_user_provided_cm(fill_store: Callable, tmp_path: Path) -> None:
     """Test correct color mapping for user-provided cm name."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -331,7 +331,7 @@ def test_random_mapper() -> None:
             assert 0 <= val <= 1
 
 
-def test_categorical_mapper(fill_store: callable, tmp_path: Path) -> None:
+def test_categorical_mapper(fill_store: Callable, tmp_path: Path) -> None:
     """Test categorical mapper option to ease cli usage."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -348,7 +348,7 @@ def test_categorical_mapper(fill_store: callable, tmp_path: Path) -> None:
 
 
 def test_colour_prop_warnings(
-    fill_store: callable,
+    fill_store: Callable,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -372,7 +372,7 @@ def test_colour_prop_warnings(
     assert "property value type incompatable" in caplog.text
 
 
-def test_blur(fill_store: callable, tmp_path: Path) -> None:
+def test_blur(fill_store: Callable, tmp_path: Path) -> None:
     """Test blur."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -388,7 +388,7 @@ def test_blur(fill_store: callable, tmp_path: Path) -> None:
     assert np.allclose(tile_blurred, tile.filter(blur_filter), atol=1)
 
 
-def test_direct_color(fill_store: callable, tmp_path: Path) -> None:
+def test_direct_color(fill_store: Callable, tmp_path: Path) -> None:
     """Test direct color."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -404,7 +404,7 @@ def test_direct_color(fill_store: callable, tmp_path: Path) -> None:
     assert num == 1  # expect 1 blue objects
 
 
-def test_secondary_cmap(fill_store: callable, tmp_path: Path) -> None:
+def test_secondary_cmap(fill_store: Callable, tmp_path: Path) -> None:
     """Test secondary cmap."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -425,7 +425,7 @@ def test_secondary_cmap(fill_store: callable, tmp_path: Path) -> None:
     )  # expect rendered color to be viridis(0.75)
 
 
-def test_unfilled_polys(fill_store: callable, tmp_path: Path) -> None:
+def test_unfilled_polys(fill_store: Callable, tmp_path: Path) -> None:
     """Test unfilled polygons."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -453,7 +453,7 @@ def test_multipolygon_render(cell_grid: list[Polygon]) -> None:
     assert num == 25  # expect 25 red objects
 
 
-def test_function_mapper(fill_store: callable, tmp_path: Path) -> None:
+def test_function_mapper(fill_store: Callable, tmp_path: Path) -> None:
     """Test function mapper."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))

--- a/tests/test_annotation_tilerendering.py
+++ b/tests/test_annotation_tilerendering.py
@@ -6,6 +6,7 @@ Test for annotation rendering using AnnotationRenderer and AnnotationTileGenerat
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Callable
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -36,19 +37,22 @@ def cell_grid() -> list[Polygon]:
 
 
 @pytest.fixture(scope="session")
-def points_grid(spacing=60) -> list[Point]:
+def points_grid(spacing: float = 60) -> list[Point]:
     """Generate a grid of fake point annotations."""
     return [Point((600 + i * spacing, 600 + j * spacing)) for i, j in np.ndindex(7, 7)]
 
 
 @pytest.fixture(scope="session")
-def fill_store(cell_grid, points_grid):
+def fill_store(
+    cell_grid: list[Polygon],
+    points_grid: list[Point],
+    ) -> Callable[list[str], AnnotationStore]:
     """Factory fixture to fill stores with test data."""
 
     def _fill_store(
         store_class: AnnotationStore,
         path: str | Path,
-    ):
+    ) -> Callable[list[str], AnnotationStore]:
         """Fills store with random variety of annotations."""
         store = store_class(path)
 
@@ -80,7 +84,7 @@ def fill_store(cell_grid, points_grid):
     return _fill_store
 
 
-def test_tile_generator_len(fill_store, tmp_path: Path) -> None:
+def test_tile_generator_len(fill_store: callable, tmp_path: Path) -> None:
     """Test __len__ for AnnotationTileGenerator."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -89,7 +93,7 @@ def test_tile_generator_len(fill_store, tmp_path: Path) -> None:
     assert len(tg) == (4 * 4) + (2 * 2) + 1
 
 
-def test_tile_generator_iter(fill_store, tmp_path: Path) -> None:
+def test_tile_generator_iter(fill_store: callable, tmp_path: Path) -> None:
     """Test __iter__ for AnnotationTileGenerator."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -101,7 +105,7 @@ def test_tile_generator_iter(fill_store, tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(running_on_travis(), reason="no display on travis.")
-def test_show_generator_iter(fill_store, tmp_path: Path) -> None:
+def test_show_generator_iter(fill_store: callable, tmp_path: Path) -> None:
     """Show tiles with example annotations (if not travis)."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -117,7 +121,7 @@ def test_show_generator_iter(fill_store, tmp_path: Path) -> None:
         plt.show(block=False)
 
 
-def test_correct_number_rendered(fill_store, tmp_path: Path) -> None:
+def test_correct_number_rendered(fill_store: callable, tmp_path: Path) -> None:
     """Test that the expected number of annotations are rendered."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -130,7 +134,7 @@ def test_correct_number_rendered(fill_store, tmp_path: Path) -> None:
     assert num == 75  # expect 75 rendered objects
 
 
-def test_correct_colour_rendered(fill_store, tmp_path: Path) -> None:
+def test_correct_colour_rendered(fill_store: callable, tmp_path: Path) -> None:
     """Test colour mapping."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -151,19 +155,21 @@ def test_correct_colour_rendered(fill_store, tmp_path: Path) -> None:
     assert num == 1  # expect 1 blue objects
 
 
-def test_filter_by_expression(fill_store, tmp_path: Path) -> None:
+def test_filter_by_expression(fill_store: callable, tmp_path: Path) -> None:
     """Test filtering using a where expression."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
     _, store = fill_store(SQLiteStore, tmp_path / "test.db")
-    renderer = AnnotationRenderer(where='props["type"] == "cell"', edge_thickness=0)
+    renderer = AnnotationRenderer(
+        where='props["type"] == "cell"', edge_thickness=0,
+        )
     tg = AnnotationTileGenerator(wsi.info, store, renderer, tile_size=256)
     thumb = tg.get_thumb_tile()
     _, num = label(np.array(thumb)[:, :, 1])
     assert num == 25  # expect 25 cell objects, as the added one is too small
 
 
-def test_zoomed_out_rendering(fill_store, tmp_path: Path) -> None:
+def test_zoomed_out_rendering(fill_store: callable, tmp_path: Path) -> None:
     """Test that the expected number of annotations are rendered."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -185,7 +191,7 @@ def test_zoomed_out_rendering(fill_store, tmp_path: Path) -> None:
     assert num == 25  # expect 25 cells in top left quadrant
 
 
-def test_decimation(fill_store, tmp_path: Path) -> None:
+def test_decimation(fill_store: callable, tmp_path: Path) -> None:
     """Test decimation."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -200,7 +206,7 @@ def test_decimation(fill_store, tmp_path: Path) -> None:
     assert num == 17  # expect 17 pts in bottom right quadrant
 
 
-def test_get_tile_negative_level(fill_store, tmp_path: Path) -> None:
+def test_get_tile_negative_level(fill_store: callable, tmp_path: Path) -> None:
     """Test for IndexError on negative levels."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array)
@@ -211,7 +217,7 @@ def test_get_tile_negative_level(fill_store, tmp_path: Path) -> None:
         tg.get_tile(-1, 0, 0)
 
 
-def test_get_tile_large_level(fill_store, tmp_path: Path) -> None:
+def test_get_tile_large_level(fill_store: callable, tmp_path: Path) -> None:
     """Test for IndexError on too large a level."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array)
@@ -222,7 +228,7 @@ def test_get_tile_large_level(fill_store, tmp_path: Path) -> None:
         tg.get_tile(100, 0, 0)
 
 
-def test_get_tile_large_xy(fill_store, tmp_path: Path) -> None:
+def test_get_tile_large_xy(fill_store: callable, tmp_path: Path) -> None:
     """Test for IndexError on too large an xy index."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array)
@@ -233,7 +239,7 @@ def test_get_tile_large_xy(fill_store, tmp_path: Path) -> None:
         tg.get_tile(0, 100, 100)
 
 
-def test_sub_tile_levels(fill_store, tmp_path: Path) -> None:
+def test_sub_tile_levels(fill_store: callable, tmp_path: Path) -> None:
     """Test sub-tile level generation."""
     array = data.camera()
     wsi = wsireader.VirtualWSIReader(array)
@@ -241,12 +247,17 @@ def test_sub_tile_levels(fill_store, tmp_path: Path) -> None:
     class MockTileGenerator(AnnotationTileGenerator):
         """Mock generator with specific subtile_level."""
 
-        def tile_path(self, level: int, x: int, y: int) -> Path:  # skipcq: PYL-R0201
+        def tile_path(
+                self: MockTileGenerator,
+                level: int,
+                x: int,
+                y: int,
+        ) -> Path:  # skipcq: PYL-R0201
             """Tile path."""
             return Path(level, x, y)
 
         @property
-        def sub_tile_level_count(self):
+        def sub_tile_level_count(self: MockTileGenerator) -> int:
             return 1
 
     _, store = fill_store(SQLiteStore, tmp_path / "test.db")
@@ -257,7 +268,7 @@ def test_sub_tile_levels(fill_store, tmp_path: Path) -> None:
 
 
 def test_unknown_geometry(
-    fill_store,  # noqa: ARG001
+    fill_store: callable,  # noqa: ARG001
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test warning when unknown geometries cannot be rendered."""
@@ -272,7 +283,7 @@ def test_unknown_geometry(
 
 
 def test_interp_pad_warning(
-    fill_store,
+    fill_store: callable,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -285,7 +296,7 @@ def test_interp_pad_warning(
     assert "interpolation, pad_mode are unused" in caplog.text
 
 
-def test_user_provided_cm(fill_store, tmp_path: Path) -> None:
+def test_user_provided_cm(fill_store: callable, tmp_path: Path) -> None:
     """Test correct color mapping for user-provided cm name."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -319,7 +330,7 @@ def test_random_mapper() -> None:
             assert 0 <= val <= 1
 
 
-def test_categorical_mapper(fill_store, tmp_path: Path) -> None:
+def test_categorical_mapper(fill_store: callable, tmp_path: Path) -> None:
     """Test categorical mapper option to ease cli usage."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -336,7 +347,7 @@ def test_categorical_mapper(fill_store, tmp_path: Path) -> None:
 
 
 def test_colour_prop_warnings(
-    fill_store,
+    fill_store: callable,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -360,7 +371,7 @@ def test_colour_prop_warnings(
     assert "property value type incompatable" in caplog.text
 
 
-def test_blur(fill_store, tmp_path: Path) -> None:
+def test_blur(fill_store: callable, tmp_path: Path) -> None:
     """Test blur."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -376,7 +387,7 @@ def test_blur(fill_store, tmp_path: Path) -> None:
     assert np.allclose(tile_blurred, tile.filter(blur_filter), atol=1)
 
 
-def test_direct_color(fill_store, tmp_path: Path) -> None:
+def test_direct_color(fill_store: callable, tmp_path: Path) -> None:
     """Test direct color."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -392,7 +403,7 @@ def test_direct_color(fill_store, tmp_path: Path) -> None:
     assert num == 1  # expect 1 blue objects
 
 
-def test_secondary_cmap(fill_store, tmp_path: Path) -> None:
+def test_secondary_cmap(fill_store: callable, tmp_path: Path) -> None:
     """Test secondary cmap."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -413,7 +424,7 @@ def test_secondary_cmap(fill_store, tmp_path: Path) -> None:
     )  # expect rendered color to be viridis(0.75)
 
 
-def test_unfilled_polys(fill_store, tmp_path: Path) -> None:
+def test_unfilled_polys(fill_store: callable, tmp_path: Path) -> None:
     """Test unfilled polygons."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
@@ -427,7 +438,7 @@ def test_unfilled_polys(fill_store, tmp_path: Path) -> None:
     assert np.sum(tile_filled) > 2 * np.sum(tile_outline)
 
 
-def test_multipolygon_render(cell_grid) -> None:
+def test_multipolygon_render(cell_grid: list[Polygon]) -> None:
     """Test multipolygon rendering."""
     renderer = AnnotationRenderer(score_prop="color", edge_thickness=0)
     tile = np.zeros((1024, 1024, 3), dtype=np.uint8)
@@ -441,13 +452,13 @@ def test_multipolygon_render(cell_grid) -> None:
     assert num == 25  # expect 25 red objects
 
 
-def test_function_mapper(fill_store, tmp_path: Path) -> None:
+def test_function_mapper(fill_store: callable, tmp_path: Path) -> None:
     """Test function mapper."""
     array = np.ones((1024, 1024))
     wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
     _, store = fill_store(SQLiteStore, tmp_path / "test.db")
 
-    def color_fn(props):
+    def color_fn(props: dict[str, str]) -> tuple[int, int, int]:
         # simple test function that returns red for cells, otherwise green.
         if props["type"] == "cell":
             return 1, 0, 0

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from numbers import Number
-from typing import ClassVar, Mapping
+from typing import Callable, ClassVar, Mapping
 
 import pytest
 
@@ -134,9 +134,9 @@ class TestPredicate:
 
     @staticmethod
     def test_number_binary_operations(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Check that binary operations between ints does not error."""
         for op in BINARY_OP_STRINGS:
@@ -150,9 +150,9 @@ class TestPredicate:
 
     @staticmethod
     def test_property_binary_operations(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Check that binary operations between properties does not error."""
         for op in BINARY_OP_STRINGS:
@@ -166,9 +166,9 @@ class TestPredicate:
 
     @staticmethod
     def test_r_binary_operations(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test right hand binary operations between numbers and properties."""
         for op in BINARY_OP_STRINGS:
@@ -182,9 +182,9 @@ class TestPredicate:
 
     @staticmethod
     def test_number_prefix_operations(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test prefix operations on numbers."""
         for op in PREFIX_OP_STRINGS:
@@ -198,9 +198,9 @@ class TestPredicate:
 
     @staticmethod
     def test_property_prefix_operations(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test prefix operations on properties."""
         for op in PREFIX_OP_STRINGS:
@@ -214,9 +214,9 @@ class TestPredicate:
 
     @staticmethod
     def test_regex_nested_props(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test regex on nested properties."""
         query = "props['nesting']['fib'][4]"
@@ -229,9 +229,9 @@ class TestPredicate:
 
     @staticmethod
     def test_regex_str_props(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test regex on string properties."""
         query = "regexp('Hello', props['string'])"
@@ -244,9 +244,9 @@ class TestPredicate:
 
     @staticmethod
     def test_regex_str_str(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test regex on string and string."""
         query = "regexp('Hello', 'Hello world!')"
@@ -259,9 +259,9 @@ class TestPredicate:
 
     @staticmethod
     def test_regex_props_str(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test regex on property and string."""
         query = "regexp(props['string'], 'Hello world!')"
@@ -274,9 +274,9 @@ class TestPredicate:
 
     @staticmethod
     def test_regex_ignore_case(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test regex with ignorecase flag."""
         query = "regexp('hello', props['string'], re.IGNORECASE)"
@@ -289,9 +289,9 @@ class TestPredicate:
 
     @staticmethod
     def test_regex_no_match(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test regex with no match."""
         query = "regexp('Yello', props['string'])"
@@ -304,9 +304,9 @@ class TestPredicate:
 
     @staticmethod
     def test_has_key(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test has_key function."""
         query = "has_key(props, 'foo')"
@@ -319,9 +319,9 @@ class TestPredicate:
 
     @staticmethod
     def test_is_none(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test is_none function."""
         query = "is_none(props['null'])"
@@ -334,9 +334,9 @@ class TestPredicate:
 
     @staticmethod
     def test_is_not_none(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test is_not_none function."""
         query = "is_not_none(props['int'])"
@@ -349,9 +349,9 @@ class TestPredicate:
 
     @staticmethod
     def test_nested_has_key(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test nested has_key function."""
         query = "has_key(props['dict'], 'a')"
@@ -364,9 +364,9 @@ class TestPredicate:
 
     @staticmethod
     def test_list_sum(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test sum function on a list."""
         query = "sum(props['list'])"
@@ -379,9 +379,9 @@ class TestPredicate:
 
     @staticmethod
     def test_abs(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test abs function."""
         query = "abs(props['neg'])"
@@ -394,9 +394,9 @@ class TestPredicate:
 
     @staticmethod
     def test_not(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test not operator."""
         query = "not props['bool']"
@@ -409,9 +409,9 @@ class TestPredicate:
 
     @staticmethod
     def test_props_int_keys(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test props with int keys."""
         query = "props['list'][1]"
@@ -424,9 +424,9 @@ class TestPredicate:
 
     @staticmethod
     def test_props_get(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test props.get function."""
         query = "is_none(props.get('foo'))"
@@ -439,9 +439,9 @@ class TestPredicate:
 
     @staticmethod
     def test_props_get_default(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test props.get function with default."""
         query = "props.get('foo', 42)"
@@ -454,9 +454,9 @@ class TestPredicate:
 
     @staticmethod
     def test_in_list(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test in operator for list."""
         query = "1 in props.get('list')"
@@ -469,9 +469,9 @@ class TestPredicate:
 
     @staticmethod
     def test_has_key_exception(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,  # noqa: ARG004
+        check: Callable,  # noqa: ARG004
     ) -> None:
         """Test has_key function with exception."""
         query = "has_key(1, 'a')"
@@ -484,9 +484,9 @@ class TestPredicate:
 
     @staticmethod
     def test_logical_and(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test logical and operator."""
         query = "props['bool'] & is_none(props['null'])"
@@ -499,9 +499,9 @@ class TestPredicate:
 
     @staticmethod
     def test_logical_or(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test logical or operator."""
         query = "props['bool'] | (props['int'] < 2)"
@@ -514,9 +514,9 @@ class TestPredicate:
 
     @staticmethod
     def test_nested_logic(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test nested logical operators."""
         query = "(props['bool'] | (props['int'] < 2)) & abs(props['neg'])"
@@ -529,9 +529,9 @@ class TestPredicate:
 
     @staticmethod
     def test_contains_list(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test contains operator for list."""
         query = "1 in props['list']"
@@ -544,9 +544,9 @@ class TestPredicate:
 
     @staticmethod
     def test_contains_dict(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test contains operator for dict."""
         query = "'a' in props['dict']"
@@ -559,9 +559,9 @@ class TestPredicate:
 
     @staticmethod
     def test_contains_str(
-        eval_globals: dict[str, Any],  # noqa: F821
+        eval_globals: dict[str, object],
         eval_locals: Mapping[str, object],
-        check: callable,
+        check: Callable,
     ) -> None:
         """Test contains operator for str."""
         query = "'Hello' in props['string']"

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from numbers import Number
-from typing import ClassVar
+from typing import ClassVar, Mapping
 
 import pytest
 
@@ -63,7 +63,7 @@ def test_json_contains() -> None:
     assert not json_contains(properties, "foo")
 
 
-def sqlite_eval(query: str | Number):
+def sqlite_eval(query: str | Number) -> bool:
     """Evaluate an SQL predicate on dummy data and return the result.
 
     Args:
@@ -133,7 +133,11 @@ class TestPredicate:
     ]
 
     @staticmethod
-    def test_number_binary_operations(eval_globals, eval_locals, check) -> None:
+    def test_number_binary_operations(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Check that binary operations between ints does not error."""
         for op in BINARY_OP_STRINGS:
             query = f"2 {op} 2"
@@ -145,7 +149,11 @@ class TestPredicate:
             assert isinstance(check(result), Number)
 
     @staticmethod
-    def test_property_binary_operations(eval_globals, eval_locals, check) -> None:
+    def test_property_binary_operations(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Check that binary operations between properties does not error."""
         for op in BINARY_OP_STRINGS:
             query = f"props['int'] {op} props['int']"
@@ -157,7 +165,11 @@ class TestPredicate:
             assert isinstance(check(result), Number)
 
     @staticmethod
-    def test_r_binary_operations(eval_globals, eval_locals, check) -> None:
+    def test_r_binary_operations(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test right hand binary operations between numbers and properties."""
         for op in BINARY_OP_STRINGS:
             query = f"2 {op} props['int']"
@@ -169,7 +181,11 @@ class TestPredicate:
             assert isinstance(check(result), Number)
 
     @staticmethod
-    def test_number_prefix_operations(eval_globals, eval_locals, check) -> None:
+    def test_number_prefix_operations(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test prefix operations on numbers."""
         for op in PREFIX_OP_STRINGS:
             query = f"{op}1"
@@ -181,7 +197,11 @@ class TestPredicate:
             assert isinstance(check(result), Number)
 
     @staticmethod
-    def test_property_prefix_operations(eval_globals, eval_locals, check) -> None:
+    def test_property_prefix_operations(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test prefix operations on properties."""
         for op in PREFIX_OP_STRINGS:
             query = f"{op}props['int']"
@@ -193,7 +213,11 @@ class TestPredicate:
             assert isinstance(check(result), Number)
 
     @staticmethod
-    def test_regex_nested_props(eval_globals, eval_locals, check):
+    def test_regex_nested_props(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test regex on nested properties."""
         query = "props['nesting']['fib'][4]"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -204,7 +228,11 @@ class TestPredicate:
         assert check(result) == 5
 
     @staticmethod
-    def test_regex_str_props(eval_globals, eval_locals, check):
+    def test_regex_str_props(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test regex on string properties."""
         query = "regexp('Hello', props['string'])"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -215,7 +243,11 @@ class TestPredicate:
         assert check(result) == "Hello"
 
     @staticmethod
-    def test_regex_str_str(eval_globals, eval_locals, check):
+    def test_regex_str_str(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test regex on string and string."""
         query = "regexp('Hello', 'Hello world!')"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -226,7 +258,11 @@ class TestPredicate:
         assert check(result) == "Hello"
 
     @staticmethod
-    def test_regex_props_str(eval_globals, eval_locals, check):
+    def test_regex_props_str(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test regex on property and string."""
         query = "regexp(props['string'], 'Hello world!')"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -237,7 +273,11 @@ class TestPredicate:
         assert check(result) == "Hello world!"
 
     @staticmethod
-    def test_regex_ignore_case(eval_globals, eval_locals, check):
+    def test_regex_ignore_case(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test regex with ignorecase flag."""
         query = "regexp('hello', props['string'], re.IGNORECASE)"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -248,7 +288,11 @@ class TestPredicate:
         assert check(result) == "Hello"
 
     @staticmethod
-    def test_regex_no_match(eval_globals, eval_locals, check):
+    def test_regex_no_match(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test regex with no match."""
         query = "regexp('Yello', props['string'])"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -259,7 +303,11 @@ class TestPredicate:
         assert check(result) is None
 
     @staticmethod
-    def test_has_key(eval_globals, eval_locals, check):
+    def test_has_key(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test has_key function."""
         query = "has_key(props, 'foo')"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -270,7 +318,11 @@ class TestPredicate:
         assert bool(check(result)) is False
 
     @staticmethod
-    def test_is_none(eval_globals, eval_locals, check):
+    def test_is_none(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test is_none function."""
         query = "is_none(props['null'])"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -281,7 +333,11 @@ class TestPredicate:
         assert bool(check(result)) is True
 
     @staticmethod
-    def test_is_not_none(eval_globals, eval_locals, check):
+    def test_is_not_none(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test is_not_none function."""
         query = "is_not_none(props['int'])"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -292,7 +348,11 @@ class TestPredicate:
         assert bool(check(result)) is True
 
     @staticmethod
-    def test_nested_has_key(eval_globals, eval_locals, check):
+    def test_nested_has_key(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test nested has_key function."""
         query = "has_key(props['dict'], 'a')"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -303,7 +363,11 @@ class TestPredicate:
         assert bool(check(result)) is True
 
     @staticmethod
-    def test_list_sum(eval_globals, eval_locals, check):
+    def test_list_sum(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test sum function on a list."""
         query = "sum(props['list'])"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -314,7 +378,11 @@ class TestPredicate:
         assert check(result) == sum(SAMPLE_PROPERTIES["list"])
 
     @staticmethod
-    def test_abs(eval_globals, eval_locals, check):
+    def test_abs(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test abs function."""
         query = "abs(props['neg'])"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -325,7 +393,11 @@ class TestPredicate:
         assert check(result) == 1
 
     @staticmethod
-    def test_not(eval_globals, eval_locals, check):
+    def test_not(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test not operator."""
         query = "not props['bool']"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -336,7 +408,11 @@ class TestPredicate:
         assert bool(check(result)) is False
 
     @staticmethod
-    def test_props_int_keys(eval_globals, eval_locals, check):
+    def test_props_int_keys(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test props with int keys."""
         query = "props['list'][1]"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -347,7 +423,11 @@ class TestPredicate:
         assert check(result) == 1
 
     @staticmethod
-    def test_props_get(eval_globals, eval_locals, check):
+    def test_props_get(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test props.get function."""
         query = "is_none(props.get('foo'))"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -358,7 +438,11 @@ class TestPredicate:
         assert bool(check(result)) is True
 
     @staticmethod
-    def test_props_get_default(eval_globals, eval_locals, check):
+    def test_props_get_default(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test props.get function with default."""
         query = "props.get('foo', 42)"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -369,7 +453,11 @@ class TestPredicate:
         assert check(result) == 42
 
     @staticmethod
-    def test_in_list(eval_globals, eval_locals, check):
+    def test_in_list(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test in operator for list."""
         query = "1 in props.get('list')"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -381,10 +469,10 @@ class TestPredicate:
 
     @staticmethod
     def test_has_key_exception(
-        eval_globals,
-        eval_locals,
-        check,  # noqa: ARG004
-    ):
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,  # noqa: ARG004
+    ) -> None:
         """Test has_key function with exception."""
         query = "has_key(1, 'a')"
         with pytest.raises(TypeError, match="(not iterable)|(Unsupported type)"):
@@ -395,7 +483,11 @@ class TestPredicate:
             )
 
     @staticmethod
-    def test_logical_and(eval_globals, eval_locals, check):
+    def test_logical_and(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test logical and operator."""
         query = "props['bool'] & is_none(props['null'])"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -406,7 +498,11 @@ class TestPredicate:
         assert bool(check(result)) is True
 
     @staticmethod
-    def test_logical_or(eval_globals, eval_locals, check):
+    def test_logical_or(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test logical or operator."""
         query = "props['bool'] | (props['int'] < 2)"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -417,7 +513,11 @@ class TestPredicate:
         assert bool(check(result)) is True
 
     @staticmethod
-    def test_nested_logic(eval_globals, eval_locals, check):
+    def test_nested_logic(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test nested logical operators."""
         query = "(props['bool'] | (props['int'] < 2)) & abs(props['neg'])"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -428,7 +528,11 @@ class TestPredicate:
         assert bool(check(result)) is True
 
     @staticmethod
-    def test_contains_list(eval_globals, eval_locals, check):
+    def test_contains_list(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test contains operator for list."""
         query = "1 in props['list']"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -439,7 +543,11 @@ class TestPredicate:
         assert bool(check(result)) is True
 
     @staticmethod
-    def test_contains_dict(eval_globals, eval_locals, check):
+    def test_contains_dict(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test contains operator for dict."""
         query = "'a' in props['dict']"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307
@@ -450,7 +558,11 @@ class TestPredicate:
         assert bool(check(result)) is True
 
     @staticmethod
-    def test_contains_str(eval_globals, eval_locals, check):
+    def test_contains_str(
+        eval_globals: dict[str, Any],  # noqa: F821
+        eval_locals: Mapping[str, object],
+        check: callable,
+    ) -> None:
         """Test contains operator for str."""
         query = "'Hello' in props['string']"
         result = eval(  # skipcq: PYL-W0123  # noqa: S307

--- a/tiatoolbox/annotation/dsl.py
+++ b/tiatoolbox/annotation/dsl.py
@@ -321,7 +321,7 @@ def py_is_none(x: Any) -> bool:  # noqa: ANN401
     return x is None
 
 
-def py_is_not_none(x: Any) -> bool: # noqa: ANN401
+def py_is_not_none(x: Any) -> bool:  # noqa: ANN401
     """Check if x is not None."""
     return x is not None
 

--- a/tiatoolbox/annotation/dsl.py
+++ b/tiatoolbox/annotation/dsl.py
@@ -69,11 +69,11 @@ from typing import Any, Callable
 class SQLNone:
     """Sentinel object for SQL NULL within expressions."""
 
-    def __str__(self) -> str:
+    def __str__(self: SQLNone) -> str:
         """Return a human-readable, or informal, string representation of an object."""
         return "NULL"
 
-    def __repr__(self) -> str:
+    def __repr__(self: SQLNone) -> str:
         """Return a string representation of the object."""
         return str(self)  # pragma: no cover
 
@@ -83,115 +83,115 @@ class SQLExpression:
 
     __hash__ = None
 
-    def __repr__(self) -> str:
+    def __repr__(self: SQLExpression) -> str:
         """Return a string representation of the object."""
         return str(self)  # pragma: no cover
 
-    def __add__(self, other):
+    def __add__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Adds two objects and returns a new object as a resultant object."""
         return SQLTriplet(self, operator.add, other)
 
-    def __radd__(self, other):
+    def __radd__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Adds two objects if the left operand does not support the operation."""
         return SQLTriplet(other, operator.add, self)
 
-    def __mul__(self, other):
+    def __mul__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Implements the arithmetic multiplication operation."""
         return SQLTriplet(self, operator.mul, other)
 
-    def __rmul__(self, other):
+    def __rmul__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Multiplies two objects if the left operand does not support the operation."""
         return SQLTriplet(other, operator.mul, self)
 
-    def __sub__(self, other):
+    def __sub__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Return the difference of two objects."""
         return SQLTriplet(other, operator.sub, self)
 
-    def __rsub__(self, other):
+    def __rsub__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Implements the reverse subtraction operation."""
         return SQLTriplet(self, operator.sub, other)
 
-    def __truediv__(self, other):
+    def __truediv__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Implements normal division operation."""
         return SQLTriplet(self, operator.truediv, other)
 
-    def __rtruediv__(self, other):
+    def __rtruediv__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Implements reverse normal division."""
         return SQLTriplet(other, operator.truediv, self)
 
-    def __floordiv__(self, other):
+    def __floordiv__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Implements integer division operation."""
         return SQLTriplet(self, operator.floordiv, other)
 
-    def __rfloordiv__(self, other):
+    def __rfloordiv__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Implements reverse integer division operation."""
         return SQLTriplet(other, operator.floordiv, self)
 
-    def __mod__(self, other):
+    def __mod__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Implements Modulo (%) operator."""
         return SQLTriplet(self, operator.mod, other)
 
-    def __rmod__(self, other):
+    def __rmod__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Implements reverse Modulo (%) operator."""
         return SQLTriplet(other, operator.mod, self)
 
-    def __gt__(self, other):
+    def __gt__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Return a value when comparing two objects (x>y)."""
         return SQLTriplet(self, operator.gt, other)
 
-    def __ge__(self, other):
+    def __ge__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Return a value when comparing two objects (x>=y)."""
         return SQLTriplet(self, operator.ge, other)
 
-    def __lt__(self, other):
+    def __lt__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Return a value when comparing two objects (x<y)."""
         return SQLTriplet(self, operator.lt, other)
 
-    def __le__(self, other):
+    def __le__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Return a value when comparing two objects (x<=y)."""
         return SQLTriplet(self, operator.le, other)
 
-    def __abs__(self):
+    def __abs__(self: SQLExpression) -> SQLTriplet:
         """Return the absolute value of the object."""
         return SQLTriplet(self, operator.abs)
 
-    def __eq__(self, other):
+    def __eq__(self: SQLExpression, other: SQLExpression) -> SQLTriplet:
         """Define how the object is compared for equality."""
         return SQLTriplet(self, operator.eq, other)
 
-    def __ne__(self, other: object):
+    def __ne__(self: SQLExpression, other: object) -> SQLTriplet:
         """Define how the object is compared for equality (not equal to)."""
         return SQLTriplet(self, operator.ne, other)
 
-    def __neg__(self):
+    def __neg__(self: SQLExpression) -> SQLTriplet:
         """Define how the object is compared for negation (not equal to)."""
         return SQLTriplet(self, operator.neg)
 
-    def __contains__(self, other) -> bool:
+    def __contains__(self: SQLExpression, other: object) -> bool:
         """Test whether the object contains the specified object or not."""
         return SQLTriplet(self, "contains", other)
 
-    def __pow__(self, x):
+    def __pow__(self: SQLExpression, x: SQLTriplet | str) -> SQLTriplet:
         """Implements exponentiation operation."""
         return SQLTriplet(self, operator.pow, x)
 
-    def __rpow__(self, x):
+    def __rpow__(self: SQLExpression, x: SQLTriplet | str) -> SQLTriplet:
         """Implements reverse exponentiation operation."""
         return SQLTriplet(x, operator.pow, self)
 
-    def __and__(self, other):
+    def __and__(self: SQLExpression, other: object) -> SQLTriplet:
         """Implements logical AND operation."""
         return SQLTriplet(self, operator.and_, other)
 
-    def __rand__(self, other):
+    def __rand__(self: SQLExpression, other: object) -> SQLTriplet:
         """Implements reverse logical AND operation."""
         return SQLTriplet(other, operator.and_, self)
 
-    def __or__(self, other):
+    def __or__(self: SQLExpression, other: object) -> SQLTriplet:
         """Implements logical OR operation."""
         return SQLTriplet(self, operator.or_, other)
 
-    def __ror__(self, other):
+    def __ror__(self: SQLExpression, other: object) -> SQLTriplet:
         """Implements reverse logical OR operation."""
         return SQLTriplet(other, operator.or_, self)
 
@@ -207,7 +207,7 @@ class SQLTriplet(SQLExpression):
     """
 
     def __init__(
-        self,
+        self: SQLExpression,
         lhs: SQLTriplet | str,
         op: Callable | str | None = None,
         rhs: SQLTriplet | str | None = None,
@@ -243,7 +243,7 @@ class SQLTriplet(SQLExpression):
             "bool": lambda x, _: f"({x} != 0)",
         }
 
-    def __str__(self) -> str:
+    def __str__(self: SQLExpression) -> str:
         """Return a human-readable, or informal, string representation of an object."""
         lhs = self.lhs
         rhs = self.rhs
@@ -259,22 +259,26 @@ class SQLTriplet(SQLExpression):
 class SQLJSONDictionary(SQLExpression):
     """Representation of an SQL expression to access JSON properties."""
 
-    def __init__(self, acc: str | None = None) -> None:
+    def __init__(self: SQLJSONDictionary, acc: str | None = None) -> None:
         """Initialize :class:`SQLJSONDictionary`."""
         self.acc = acc or ""
 
-    def __str__(self) -> str:
+    def __str__(self: SQLJSONDictionary) -> str:
         """Return a human-readable, or informal, string representation of an object."""
         return f"json_extract(properties, {json.dumps(f'$.{self.acc}')})"
 
-    def __getitem__(self, key: str) -> SQLJSONDictionary:
+    def __getitem__(self: SQLJSONDictionary, key: str) -> SQLJSONDictionary:
         """Get an item from the dataset."""
         key_str = f"[{key}]" if isinstance(key, (int,)) else str(key)
 
         joiner = "." if self.acc and not isinstance(key, int) else ""
         return SQLJSONDictionary(acc=self.acc + joiner + f"{key_str}")
 
-    def get(self, key, default=None):
+    def get(
+        self: SQLJSONDictionary,
+        key: str,
+        default: str | None = None,
+    ) -> SQLTriplet:
         """Return SQLTriplet specified by key."""
         return SQLTriplet(self[key], "if_null", default or SQLNone())
 
@@ -282,13 +286,13 @@ class SQLJSONDictionary(SQLExpression):
 class SQLRegex(SQLExpression):
     """Representation of an SQL expression to match a string against a regex."""
 
-    def __init__(self, pattern: str, string: str, flags: int = 0) -> None:
+    def __init__(self: SQLRegex, pattern: str, string: str, flags: int = 0) -> None:
         """Initialize :class:`SQLRegex`."""
         self.pattern = pattern
         self.string = string
         self.flags = flags
 
-    def __str__(self) -> str:
+    def __str__(self: SQLRegex) -> str:
         """Return a human-readable, or informal, string representation of an object."""
         string = self.string
         pattern = self.pattern
@@ -302,17 +306,22 @@ class SQLRegex(SQLExpression):
         return f"({string} REGEXP {pattern})"
 
     @classmethod
-    def search(cls, pattern: str, string: str, flags: int = 0) -> SQLRegex:
+    def search(
+        cls: type[SQLRegex],
+        pattern: str,
+        string: str,
+        flags: int = 0,
+    ) -> SQLRegex:
         """Return an SQL expression to match a string against a pattern."""
         return SQLRegex(pattern, string, int(flags))
 
 
-def py_is_none(x: Any) -> bool:
+def py_is_none(x: Any) -> bool:  # noqa: ANN401
     """Check if x is None."""
     return x is None
 
 
-def py_is_not_none(x: Any) -> bool:
+def py_is_not_none(x: Any) -> bool: # noqa: ANN401
     """Check if x is not None."""
     return x is not None
 

--- a/tiatoolbox/annotation/dsl.py
+++ b/tiatoolbox/annotation/dsl.py
@@ -62,7 +62,7 @@ import operator
 import re
 from dataclasses import dataclass
 from numbers import Number
-from typing import Any, Callable
+from typing import Callable
 
 
 @dataclass
@@ -316,12 +316,12 @@ class SQLRegex(SQLExpression):
         return SQLRegex(pattern, string, int(flags))
 
 
-def py_is_none(x: Any) -> bool:  # noqa: ANN401
+def py_is_none(x: object) -> bool:
     """Check if x is None."""
     return x is None
 
 
-def py_is_not_none(x: Any) -> bool:  # noqa: ANN401
+def py_is_not_none(x: object) -> bool:
     """Check if x is not None."""
     return x is not None
 

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -45,7 +45,6 @@ from pathlib import Path
 from typing import (
     IO,
     TYPE_CHECKING,
-    Any,
     Callable,
     ClassVar,
     Generator,
@@ -281,7 +280,7 @@ class Annotation:
         """Compare this annotation to another.
 
         Args:
-            other (Any):
+            other (object):
                 The object to compare to.
 
         Returns:
@@ -737,7 +736,7 @@ class AnnotationStore(ABC, MutableMapping):
         self: AnnotationStore,
         key: str,
         geometry: Geometry | None = None,
-        properties: dict[str, Any] | None = None,
+        properties: dict[str, object] | None = None,
     ) -> None:
         """Patch an annotation at given key.
 
@@ -897,14 +896,14 @@ class AnnotationStore(ABC, MutableMapping):
     @staticmethod
     def _eval_where(
         predicate: Predicate | None,
-        properties: dict[str, Any],
+        properties: dict[str, object],
     ) -> bool:
         """Evaluate properties predicate against properties.
 
         Args:
             predicate (str or bytes or Callable):
                 The predicate to evaluate on properties. The predicate may be a
-                string, pickled bytes, or a callable (e.g. a function).
+                string, pickled bytes, or a Callable (e.g. a function).
             properties (dict):
                 A dictionary of JSON serializable
                 properties on which to evaluate the predicate.
@@ -947,7 +946,7 @@ class AnnotationStore(ABC, MutableMapping):
                 A statement which should evaluate to a boolean value.
                 Only annotations for which this predicate is true will
                 be returned. Defaults to None (assume always true). This
-                may be a string, callable, or pickled function as bytes.
+                may be a string, Callable, or pickled function as bytes.
                 Callables are called to filter each result returned
                 from the annotation store backend in python before being
                 returned to the user. A pickle object is, where
@@ -1099,7 +1098,7 @@ class AnnotationStore(ABC, MutableMapping):
                 A statement which should evaluate to a boolean value.
                 Only annotations for which this predicate is true will
                 be returned. Defaults to None (assume always true). This
-                may be a string, callable, or pickled function as bytes.
+                may be a string, Callable, or pickled function as bytes.
                 Callables are called to filter each result returned
                 from the annotation store backend in python before being
                 returned to the user. A pickle object is, where
@@ -1188,7 +1187,7 @@ class AnnotationStore(ABC, MutableMapping):
                 A statement which should evaluate to a boolean value.
                 Only annotations for which this predicate is true will
                 be returned. Defaults to None (assume always true). This
-                may be a string, callable, or pickled function as bytes.
+                may be a string, Callable, or pickled function as bytes.
                 Callables are called to filter each result returned
                 from the annotation store backend in python before being
                 returned to the user. A pickle object is, where
@@ -1253,7 +1252,7 @@ class AnnotationStore(ABC, MutableMapping):
         *,
         unique: bool = True,
         squeeze: bool = True,
-    ) -> dict[str, Any] | set[Any]:
+    ) -> dict[str, object] | set[object]:
         """Query the store for annotation properties.
 
         Acts similarly to `AnnotationStore.query` but returns only the
@@ -1275,7 +1274,7 @@ class AnnotationStore(ABC, MutableMapping):
                 A statement which should evaluate to a boolean value.
                 Only annotations for which this predicate is true will
                 be returned. Defaults to None (assume always true). This
-                may be a string, callable, or pickled function as bytes.
+                may be a string, Callable, or pickled function as bytes.
                 Callables are called to filter each result returned the
                 from annotation store backend in python before being
                 returned to the user. A pickle object is, where
@@ -1333,8 +1332,8 @@ class AnnotationStore(ABC, MutableMapping):
         if where is not None and type(select) is not type(where):
             msg = "select and where must be of the same type"
             raise TypeError(msg)
-        if not isinstance(select, (str, bytes)) and not callable(select):
-            msg = f"select must be str, bytes, or callable, not {type(select)}"
+        if not isinstance(select, (str, bytes)) and not Callable(select):
+            msg = f"select must be str, bytes, or Callable, not {type(select)}"
             raise TypeError(
                 msg,
             )
@@ -1345,7 +1344,7 @@ class AnnotationStore(ABC, MutableMapping):
         def select_values(
             select: Select,
             annotation: Annotation,
-        ) -> Properties | Any | tuple[Any, ...]:  # noqa: ANN401
+        ) -> Properties | object | tuple[object, ...]:
             """Get the value(s) to return from an annotation via a select.
 
             Args:
@@ -1362,7 +1361,7 @@ class AnnotationStore(ABC, MutableMapping):
                     If arguments have incompatible values.
 
             Returns:
-                Union[Properties, Any, Tuple[Any, ...]]:
+                Union[Properties, object, Tuple[object, ...]]:
                     The value(s) to return from the annotation. This
                     will be a dictionary if unique is False. Otherwise,
                     it will be a list of sets. If squeeze and unique are
@@ -1420,7 +1419,7 @@ class AnnotationStore(ABC, MutableMapping):
                 A statement which should evaluate to a boolean value.
                 Only annotations for which this predicate is true will be
                 returned. Defaults to None (assume always true). This may
-                be a string, callable, or pickled function as bytes.
+                be a string, Callable, or pickled function as bytes.
                 Callables are called to filter each result returned the
                 annotation store backend in python before being returned
                 to the user. A pickle object is, where possible, hooked
@@ -1597,12 +1596,12 @@ class AnnotationStore(ABC, MutableMapping):
         items: Generator[tuple[str, Properties], None, None],
         get_values: Callable[
             [Select, Annotation],
-            Properties | Any | tuple[Any, ...],
+            Properties | object | tuple[object, ...],
         ],
         *,
         unique: bool,
         squeeze: bool,
-    ) -> dict[str, Any] | dict:
+    ) -> dict[str, object] | dict:
         """Package the results of a pquery into the right output format.
 
         Args:
@@ -1646,7 +1645,7 @@ class AnnotationStore(ABC, MutableMapping):
             result = result[0]
         return result  # CCR001
 
-    def features(self: AnnotationStore) -> Generator[dict[str, Any], None, None]:
+    def features(self: AnnotationStore) -> Generator[dict[str, object], None, None]:
         """Return annotations as a list of geoJSON features.
 
         Returns:
@@ -1657,7 +1656,7 @@ class AnnotationStore(ABC, MutableMapping):
         for a in self.values():
             yield a.to_feature()
 
-    def to_geodict(self: AnnotationStore) -> dict[str, Any]:
+    def to_geodict(self: AnnotationStore) -> dict[str, object]:
         """Return annotations as a dictionary in geoJSON format.
 
         Returns:
@@ -1687,7 +1686,7 @@ class AnnotationStore(ABC, MutableMapping):
                 The function to call when fp is None.
 
         Returns:
-            Any:
+            str | bytes | None:
                 The result of dump. Depends on the provided functions.
 
         """
@@ -1704,9 +1703,9 @@ class AnnotationStore(ABC, MutableMapping):
     @staticmethod
     def _load_cases(
         fp: IO | str | Path,
-        string_fn: Callable[[str | bytes], Any],
-        file_fn: Callable[[IO], Any],
-    ) -> Any:  # noqa: ANN401
+        string_fn: Callable[[str | bytes], object],
+        file_fn: Callable[[IO], object],
+    ) -> object:
         """Loads cases for an input file handle or path."""
         with contextlib.suppress(OSError):
             if isinstance(fp, (Path, str)) and Path(fp).exists():
@@ -1975,7 +1974,7 @@ class AnnotationStore(ABC, MutableMapping):
         patch/tile/core space, or to a different resolution, for example.
 
         Args:
-            transform (callable[Geometry, Geometry]):
+            transform (Callable[Geometry, Geometry]):
                 A function that takes a geometry and returns a new
                 transformed geometry.
 
@@ -2499,12 +2498,12 @@ class SQLiteStore(AnnotationStore):
     @staticmethod
     def _initialize_query_string_parameters(
         query_geometry: Geometry | None,
-        query_parameters: dict[str, Any],
+        query_parameters: dict[str, object],
         geometry_predicate: str | None,
         columns: str,
         where: bytes | str,
         distance: float = 0,
-    ) -> tuple[str, dict[str, Any]]:
+    ) -> tuple[str, dict[str, object]]:
         """Initialises the query string and parameters."""
         query_string = (
             "SELECT "  # skipcq: BAN-B608  # noqa: S608
@@ -2604,7 +2603,7 @@ class SQLiteStore(AnnotationStore):
             geometry(tuple or Geometry):
                 The geometry being queried against.
             callable_columns(str):
-                The columns to select when a callable is given to
+                The columns to select when a Callable is given to
                 `where`.
             geometry_predicate(str):
                 A string which define which binary geometry predicate to
@@ -2728,7 +2727,7 @@ class SQLiteStore(AnnotationStore):
                 A statement which should evaluate to a boolean value.
                 Only annotations for which this predicate is true will
                 be returned. Defaults to None (assume always true). This
-                may be a string, callable, or pickled function as bytes.
+                may be a string, Callable, or pickled function as bytes.
                 Callables are called to filter each result returned
                 from the annotation store backend in python before being
                 returned to the user. A pickle object is, where
@@ -2848,7 +2847,7 @@ class SQLiteStore(AnnotationStore):
                 A statement which should evaluate to a boolean value.
                 Only annotations for which this predicate is true will
                 be returned. Defaults to None (assume always true). This
-                may be a string, callable, or pickled function as bytes.
+                may be a string, Callable, or pickled function as bytes.
                 Callables are called to filter each result returned
                 from the annotation store backend in python before being
                 returned to the user. A pickle object is, where
@@ -2915,14 +2914,14 @@ class SQLiteStore(AnnotationStore):
     ) -> dict[str, set[Properties]] | dict[str, Properties]:
         """Package the results of a pquery into the right output format.
 
-        This variant is used when select and where are callable or
+        This variant is used when select and where are Callable or
         pickle objects.
 
         Args:
             select (Union[str, bytes, Callable]):
-                A callable to select the properties to return.
+                A Callable to select the properties to return.
             where (CallablePredicate):
-                A callable predicate to filter the rows with. Maybe
+                A Callable predicate to filter the rows with. Maybe
                 None for no-op (no filtering).
             cur (sqlite3.Cursor):
                 The cursor for the query.
@@ -2939,14 +2938,14 @@ class SQLiteStore(AnnotationStore):
 
         def add_props_to_result(
             result: defaultdict[str, set],
-            properties: dict[str, Any],
+            properties: dict[str, object],
         ) -> None:
             """Add the properties to the appropriate set in result.
 
             Args:
                 result (DefaultDict[str, set]):
                     The result dictionary to add the properties to.
-                properties (Dict[str, Any]):
+                properties (Dict[str, object]):
                     The properties to add to the result.
 
             """
@@ -3026,13 +3025,13 @@ class SQLiteStore(AnnotationStore):
         """Determine boolean flags for the kind of pquery this is.
 
         If either one of `select` or `where` is a str, bytes, or
-        callable, then is_callable_query, is_pickle_query, and
+        Callable, then is_callable_query, is_pickle_query, and
         is_str_query respectively will be set to True.
 
         Returns:
             tuple:
                 A tuple of bools:
-                - True if select or where are callable (functions).
+                - True if select or where are Callable (functions).
                 - True if select or where are bytes (pickle expressions).
                 - True if select or where are str (SQL expressions).
 
@@ -3051,19 +3050,19 @@ class SQLiteStore(AnnotationStore):
         """Validate that select and where are valid types.
 
         1. Check that select and where are the same type if where is given.
-        2. Check that select is in (str, bytes, callable).
+        2. Check that select is in (str, bytes, Callable).
 
         Raises:
             TypeError:
                 If select and where are not the same type or not in
-                (str, bytes, callable).
+                (str, bytes, Callable).
 
         """
         if where is not None and type(select) is not type(where):
             msg = "select and where must be of the same type"
             raise TypeError(msg)
-        if not isinstance(select, (str, bytes)) and not callable(select):
-            msg = f"select must be str, bytes, or callable, not {type(select)}"
+        if not isinstance(select, (str, bytes)) and not Callable(select):
+            msg = f"select must be str, bytes, or Callable, not {type(select)}"
             raise TypeError(
                 msg,
             )
@@ -3077,7 +3076,7 @@ class SQLiteStore(AnnotationStore):
         *,
         unique: bool = True,
         squeeze: bool = True,
-    ) -> dict[str, Any] | set[Any]:
+    ) -> dict[str, object] | set[object]:
         """Query the store for annotation properties.
 
         Acts similarly to `AnnotationStore.query` but returns only the
@@ -3099,7 +3098,7 @@ class SQLiteStore(AnnotationStore):
                 A statement which should evaluate to a boolean value.
                 Only annotations for which this predicate is true will
                 be returned. Defaults to None (assume always true). This
-                may be a string, callable, or pickled function as bytes.
+                may be a string, Callable, or pickled function as bytes.
                 Callables are called to filter each result returned the
                 from annotation store backend in python before being
                 returned to the user. A pickle object is, where
@@ -3202,7 +3201,7 @@ class SQLiteStore(AnnotationStore):
 
         if is_pickle_query or is_callable_query:
             # Where to apply after database query
-            # only done for callable where.
+            # only done for Callable where.
             post_where = where if is_callable_query else None
             result = self._handle_pickle_callable_pquery(
                 select,
@@ -3510,7 +3509,7 @@ class SQLiteStore(AnnotationStore):
         store_to_df = pd.concat([store_to_df, pd.json_normalize(df_rows)])
         return store_to_df.set_index("key")
 
-    def features(self: SQLiteStore) -> Generator[dict[str, Any], None, None]:
+    def features(self: SQLiteStore) -> Generator[dict[str, object], None, None]:
         """Return annotations as a list of geoJSON features.
 
         Returns:
@@ -3702,7 +3701,7 @@ class DictionaryStore(AnnotationStore):
         self: DictionaryStore,
         key: str,
         geometry: Geometry | None = None,
-        properties: dict[str, Any] | None = None,
+        properties: dict[str, object] | None = None,
     ) -> None:
         """Patch an annotation at given key.
 

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -3756,10 +3756,10 @@ class DictionaryStore(AnnotationStore):
         """Return the length of the instance attributes."""
         return len(self._rows)
 
+    # flake8: noqa: A003
     @classmethod
-    def open(
-        cls: type[DictionaryStore], fp: Path | str | IO,
-    ) -> DictionaryStore:
+    def open(cls: type[DictionaryStore],
+             fp: Path | str | IO) -> AnnotationStore:
         """Opens :class:`DictionaryStore` from file pointer or path."""
         return cls.from_ndjson(fp)
 
@@ -3772,7 +3772,7 @@ class DictionaryStore(AnnotationStore):
             self.path.touch()
         self.dump(self.connection)
 
-    def dump(self: DictionaryStore, fp: Path | str | IO) -> None:
+    def dump(self: DictionaryStore, fp: Path | str | IO) -> str:
         """Serialise a copy of the whole store to a file-like object.
 
         Args:

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -1332,7 +1332,7 @@ class AnnotationStore(ABC, MutableMapping):
         if where is not None and type(select) is not type(where):
             msg = "select and where must be of the same type"
             raise TypeError(msg)
-        if not isinstance(select, (str, bytes)) and not Callable(select):
+        if not isinstance(select, (str, bytes)) and not callable(select):
             msg = f"select must be str, bytes, or Callable, not {type(select)}"
             raise TypeError(
                 msg,
@@ -3061,7 +3061,7 @@ class SQLiteStore(AnnotationStore):
         if where is not None and type(select) is not type(where):
             msg = "select and where must be of the same type"
             raise TypeError(msg)
-        if not isinstance(select, (str, bytes)) and not Callable(select):
+        if not isinstance(select, (str, bytes)) and not callable(select):
             msg = f"select must be str, bytes, or Callable, not {type(select)}"
             raise TypeError(
                 msg,

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -597,7 +597,7 @@ class AnnotationStore(ABC, MutableMapping):
 
     @classmethod
     @abstractmethod
-    def open(cls: type[AnnotationStore], fp: Path | str | IO) -> ABC:  # noqa: A003
+    def open(cls: type[AnnotationStore], fp: Path | str | IO) -> ABC:
         """Load a store object from a path or file-like object.
 
         Args:
@@ -824,7 +824,9 @@ class AnnotationStore(ABC, MutableMapping):
             self.remove(key)
 
     def setdefault(
-        self: AnnotationStore, key: str, default: Annotation | None = None,
+        self: AnnotationStore,
+        key: str,
+        default: Annotation | None = None,
     ) -> Annotation:
         """Return the value of the annotation with the given key.
 
@@ -1802,7 +1804,8 @@ class AnnotationStore(ABC, MutableMapping):
         self.append_many(annotations)
 
     def to_geojson(
-        self: AnnotationStore, fp: IO | str | Path | None = None,
+        self: AnnotationStore,
+        fp: IO | str | Path | None = None,
     ) -> str | None:
         """Serialise the store to geoJSON.
 
@@ -1964,7 +1967,8 @@ class AnnotationStore(ABC, MutableMapping):
         return pd.json_normalize(features).set_index("key")
 
     def transform(
-        self: AnnotationStore, transform: Callable[[Geometry], Geometry],
+        self: AnnotationStore,
+        transform: Callable[[Geometry], Geometry],
     ) -> None:
         """Transform all annotations in the store using provided function.
 
@@ -2026,7 +2030,9 @@ class SQLiteMetadata(MutableMapping):
         return cursor.fetchone() is not None
 
     def __setitem__(
-        self: SQLiteMetadata, key: str, value: dict | list | float | str,
+        self: SQLiteMetadata,
+        key: str,
+        value: dict | list | float | str,
     ) -> None:
         """Set a metadata value."""
         value = json.dumps(value)
@@ -2076,7 +2082,7 @@ class SQLiteStore(AnnotationStore):
     """
 
     @classmethod
-    def open(cls: type[SQLiteStore], fp: Path | str) -> SQLiteStore:  # noqa: A003
+    def open(cls: type[SQLiteStore], fp: Path | str) -> SQLiteStore:
         """Opens :class:`SQLiteStore` from file pointer or path."""
         return SQLiteStore(fp)
 
@@ -2450,7 +2456,10 @@ class SQLiteStore(AnnotationStore):
         return result
 
     def _append(
-        self: SQLiteStore, key: str, annotation: Annotation, cur: sqlite3.Cursor,
+        self: SQLiteStore,
+        key: str,
+        annotation: Annotation,
+        cur: sqlite3.Cursor,
     ) -> None:
         """Append without starting a transaction.
 
@@ -3643,7 +3652,8 @@ class DictionaryStore(AnnotationStore):
     """Pure python dictionary backed annotation store."""
 
     def __init__(
-        self: DictionaryStore, connection: Path | str | IO = ":memory:",
+        self: DictionaryStore,
+        connection: Path | str | IO = ":memory:",
     ) -> None:
         """Initialize :class:`DictionaryStore`."""
         super().__init__()
@@ -3758,8 +3768,7 @@ class DictionaryStore(AnnotationStore):
 
     # flake8: noqa: A003
     @classmethod
-    def open(cls: type[DictionaryStore],
-             fp: Path | str | IO) -> AnnotationStore:
+    def open(cls: type[DictionaryStore], fp: Path | str | IO) -> AnnotationStore:
         """Opens :class:`DictionaryStore` from file pointer or path."""
         return cls.from_ndjson(fp)
 

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -56,7 +56,6 @@ from typing import (
 import numpy as np
 import pandas as pd
 import shapely
-from shapely import BaseGeometry
 from shapely import wkb as shapely_wkb
 from shapely import wkt as shapely_wkt
 from shapely.affinity import scale, translate
@@ -1770,7 +1769,7 @@ class AnnotationStore(ABC, MutableMapping):
 
         """
 
-        def transform_geometry(geom: BaseGeometry) -> BaseGeometry:
+        def transform_geometry(geom: Geometry) -> Geometry:
             """Helper function to transform a geometry if needed."""
             if origin != (0, 0):
                 # transform coords to be relative to given origin.

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -463,11 +463,14 @@ class AnnotationStore(ABC, MutableMapping):
         """
         return np.dot(np.subtract(a, b), np.subtract(b, c)) == 0
 
-    def _is_rectangle(self: ABC,
-                      a: list[float],
-                      b: list[float],
-                      c: list[float],
-                      d: list[float], *args: str) -> bool:
+    def _is_rectangle(
+        self: ABC,
+        a: list[float],
+        b: list[float],
+        c: list[float],
+        d: list[float],
+        *args: str,
+    ) -> bool:
         """Determine if a set of coordinates form a rectangle.
 
         Used for optimising queries. If more than five points are given,
@@ -594,8 +597,7 @@ class AnnotationStore(ABC, MutableMapping):
 
     @classmethod
     @abstractmethod
-    def open(cls: type[AnnotationStore], # noqa: A003
-             fp: Path | str | IO) -> ABC:
+    def open(cls: type[AnnotationStore], fp: Path | str | IO) -> ABC:  # noqa: A003
         """Load a store object from a path or file-like object.
 
         Args:
@@ -821,9 +823,9 @@ class AnnotationStore(ABC, MutableMapping):
         for key in keys:
             self.remove(key)
 
-    def setdefault(self: AnnotationStore,
-                   key: str,
-                   default: Annotation | None = None) -> Annotation:
+    def setdefault(
+        self: AnnotationStore, key: str, default: Annotation | None = None,
+    ) -> Annotation:
         """Return the value of the annotation with the given key.
 
         If the key does not exist, insert the default value and return
@@ -1799,8 +1801,9 @@ class AnnotationStore(ABC, MutableMapping):
         logger.info("Adding %d annotations.", len(annotations))
         self.append_many(annotations)
 
-    def to_geojson(self: AnnotationStore,
-                   fp: IO | str | Path | None = None) -> str | None:
+    def to_geojson(
+        self: AnnotationStore, fp: IO | str | Path | None = None,
+    ) -> str | None:
         """Serialise the store to geoJSON.
 
         For more information on the geoJSON format see:
@@ -1960,8 +1963,9 @@ class AnnotationStore(ABC, MutableMapping):
         )
         return pd.json_normalize(features).set_index("key")
 
-    def transform(self: AnnotationStore,
-                  transform: Callable[[Geometry], Geometry]) -> None:
+    def transform(
+        self: AnnotationStore, transform: Callable[[Geometry], Geometry],
+    ) -> None:
         """Transform all annotations in the store using provided function.
 
         Useful for transforming coordinates from slide space into
@@ -2021,9 +2025,9 @@ class SQLiteMetadata(MutableMapping):
         cursor = self.con.execute("SELECT 1 FROM metadata WHERE [key] = ?", (key,))
         return cursor.fetchone() is not None
 
-    def __setitem__(self: SQLiteMetadata,
-                    key: str,
-                    value: dict | list | float | str) -> None:
+    def __setitem__(
+        self: SQLiteMetadata, key: str, value: dict | list | float | str,
+    ) -> None:
         """Set a metadata value."""
         value = json.dumps(value)
         self.con.execute(
@@ -2445,9 +2449,9 @@ class SQLiteStore(AnnotationStore):
             self.con.commit()
         return result
 
-    def _append(self: SQLiteStore,
-                key: str, annotation: Annotation,
-                cur: sqlite3.Cursor) -> None:
+    def _append(
+        self: SQLiteStore, key: str, annotation: Annotation, cur: sqlite3.Cursor,
+    ) -> None:
         """Append without starting a transaction.
 
         Args:
@@ -3638,8 +3642,9 @@ class SQLiteStore(AnnotationStore):
 class DictionaryStore(AnnotationStore):
     """Pure python dictionary backed annotation store."""
 
-    def __init__(self: DictionaryStore,
-                 connection: Path | str | IO = ":memory:") -> None:
+    def __init__(
+        self: DictionaryStore, connection: Path | str | IO = ":memory:",
+    ) -> None:
         """Initialize :class:`DictionaryStore`."""
         super().__init__()
         self._rows = {}
@@ -3752,8 +3757,9 @@ class DictionaryStore(AnnotationStore):
         return len(self._rows)
 
     @classmethod
-    def open(cls: type[DictionaryStore],  # noqa: A003
-             fp: Path | str | IO) -> DictionaryStore:
+    def open(
+        cls: type[DictionaryStore], fp: Path | str | IO,
+    ) -> DictionaryStore:
         """Opens :class:`DictionaryStore` from file pointer or path."""
         return cls.from_ndjson(fp)
 

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -56,6 +56,7 @@ from typing import (
 import numpy as np
 import pandas as pd
 import shapely
+from shapely import BaseGeometry
 from shapely import wkb as shapely_wkb
 from shapely import wkt as shapely_wkt
 from shapely.affinity import scale, translate
@@ -115,7 +116,7 @@ class Annotation:
     _wkb: bytes | None = field(default=None, hash=False)
 
     @property
-    def geometry(self) -> Geometry:
+    def geometry(self: Annotation) -> Geometry:
         """Return the shapely geometry of the annotation."""
         if self._geometry is None:
             # Lazy creation of Shapely object when first requested. This
@@ -127,14 +128,14 @@ class Annotation:
         return self._geometry
 
     @property
-    def wkb(self) -> bytes:
+    def wkb(self: Annotation) -> bytes:
         """Return the WKB representation of the annotation."""
         if self._wkb is None:
             object.__setattr__(self, "_wkb", self.geometry.wkb)
         return self._wkb
 
     @property
-    def geometry_type(self) -> GeometryType:
+    def geometry_type(self: Annotation) -> GeometryType:
         """Return the geometry type of the annotation."""
         if self._geometry:
             return GeometryType(self.geometry.type)
@@ -147,7 +148,7 @@ class Annotation:
 
     @property
     def coords(  # noqa: PLR0911 - 7 > 6 returns
-        self,
+        self: Annotation,
     ) -> np.array | list[np.array] | list[list[np.array]]:
         """The annotation geometry as a flat array of 2D coordinates.
 
@@ -182,7 +183,7 @@ class Annotation:
         msg = f"Unknown geometry type: {self.geometry_type}"
         raise ValueError(msg)
 
-    def to_feature(self) -> dict:
+    def to_feature(self: Annotation) -> dict:
         """Return a feature representation of this annotation.
 
         A feature representation is a Python dictionary with the
@@ -198,7 +199,7 @@ class Annotation:
             "properties": self.properties,
         }
 
-    def to_geojson(self) -> str:
+    def to_geojson(self: Annotation) -> str:
         """Return a GeoJSON string representation of this annotation.
 
         Returns:
@@ -208,7 +209,7 @@ class Annotation:
         """
         return json.dumps(self.to_feature())
 
-    def to_wkb(self) -> bytes:
+    def to_wkb(self: Annotation) -> bytes:
         """Returns the geometry as Well-Known Binary (WKB).
 
         Returns:
@@ -218,7 +219,7 @@ class Annotation:
         """
         return copy.copy(self.wkb)
 
-    def to_wkt(self) -> str:
+    def to_wkt(self: Annotation) -> str:
         """Returns the geometry as Well-Know Text (WKT).
 
         Returns:
@@ -229,7 +230,7 @@ class Annotation:
         return self.geometry.wkt
 
     def __init__(
-        self,
+        self: Annotation,
         geometry: Geometry | int | str | None = None,
         properties: Properties | None = None,
         wkb: bytes | None = None,
@@ -263,11 +264,11 @@ class Annotation:
             object.__setattr__(self, "_geometry", geometry)
         object.__setattr__(self, "properties", properties or {})
 
-    def __repr__(self) -> str:
+    def __repr__(self: Annotation) -> str:
         """Return a string representation of the object."""
         return f"Annotation({self.geometry}, {self.properties})"
 
-    def __hash__(self) -> int:
+    def __hash__(self: Annotation) -> int:
         """Compute the hash value of the object.
 
         Returns:
@@ -277,7 +278,7 @@ class Annotation:
         """
         return hash((self.geometry, json.dumps(self.properties, sort_keys=True)))
 
-    def __eq__(self, other: object) -> bool:
+    def __eq__(self: Annotation, other: object) -> bool:
         """Compare this annotation to another.
 
         Args:
@@ -429,11 +430,11 @@ class Annotation:
 class AnnotationStore(ABC, MutableMapping):
     """Annotation store abstract base class."""
 
-    def __new__(cls, *args, **kwargs):  # noqa: ARG003
+    def __new__(cls: ABC, *args: str, **kwargs: int) -> ABC:  # noqa: ARG003
         """Return an instance of a subclass of AnnotationStore."""
         if cls is AnnotationStore:
             msg = (
-                "AnnotationStore is an abstract class and cannot be instantiated. "
+                "AnnotationStore is an abstract class and cannot be instantiated."
                 "Use a subclass such as DictionaryStore or SQLiteStore instead."
             )
             raise TypeError(
@@ -442,7 +443,7 @@ class AnnotationStore(ABC, MutableMapping):
         return super().__new__(cls)
 
     @staticmethod
-    def _is_right_angle(a, b, c) -> bool:
+    def _is_right_angle(a: list[float], b: list[float], c: list[float]) -> bool:
         """Return True if three points make a right angle.
 
         Used for optimising queries.
@@ -462,7 +463,11 @@ class AnnotationStore(ABC, MutableMapping):
         """
         return np.dot(np.subtract(a, b), np.subtract(b, c)) == 0
 
-    def _is_rectangle(self, a, b, c, d, *args) -> bool:
+    def _is_rectangle(self: ABC,
+                      a: list[float],
+                      b: list[float],
+                      c: list[float],
+                      d: list[float], *args: str) -> bool:
         """Determine if a set of coordinates form a rectangle.
 
         Used for optimising queries. If more than five points are given,
@@ -538,7 +543,7 @@ class AnnotationStore(ABC, MutableMapping):
         return Path(connection)
 
     @staticmethod
-    def _validate_equal_lengths(*args):
+    def _validate_equal_lengths(*args: str) -> None:
         """Validate that all given args are either None or have the same length."""
         lengths = [len(v) for v in args if v is not None]
         if lengths and any(length != lengths[0] for length in lengths):
@@ -589,7 +594,8 @@ class AnnotationStore(ABC, MutableMapping):
 
     @classmethod
     @abstractmethod
-    def open(cls, fp: Path | str | IO) -> AnnotationStore:  # noqa: A003
+    def open(cls: type[AnnotationStore], # noqa: A003
+             fp: Path | str | IO) -> ABC:
         """Load a store object from a path or file-like object.
 
         Args:
@@ -643,11 +649,11 @@ class AnnotationStore(ABC, MutableMapping):
         )
 
     @abstractmethod
-    def commit(self) -> None:
+    def commit(self: AnnotationStore) -> None:
         """Commit any in-memory changes to disk."""
 
     @abstractmethod
-    def dump(self, fp: Path | str | IO) -> None:
+    def dump(self: AnnotationStore, fp: Path | str | IO) -> None:
         """Serialise a copy of the whole store to a file-like object.
 
         Args:
@@ -657,7 +663,7 @@ class AnnotationStore(ABC, MutableMapping):
         """
 
     @abstractmethod
-    def dumps(self) -> str | bytes:
+    def dumps(self: AnnotationStore) -> str | bytes:
         """Serialise and return a copy of store as a string or bytes.
 
         Returns:
@@ -667,10 +673,10 @@ class AnnotationStore(ABC, MutableMapping):
         """
 
     def append(
-        self,
+        self: AnnotationStore,
         annotation: Annotation,
         key: str | None = None,
-    ) -> int:
+    ) -> str:
         """Insert a new annotation, returning the key.
 
         Args:
@@ -693,7 +699,7 @@ class AnnotationStore(ABC, MutableMapping):
         return self.append_many([annotation], keys)[0]
 
     def append_many(
-        self,
+        self: AnnotationStore,
         annotations: Iterable[Annotation],
         keys: Iterable[str] | None = None,
     ) -> list[str]:
@@ -727,7 +733,7 @@ class AnnotationStore(ABC, MutableMapping):
         return result
 
     def patch(
-        self,
+        self: AnnotationStore,
         key: str,
         geometry: Geometry | None = None,
         properties: dict[str, Any] | None = None,
@@ -758,7 +764,7 @@ class AnnotationStore(ABC, MutableMapping):
         self.patch_many([key], geometry, properties)
 
     def patch_many(
-        self,
+        self: AnnotationStore,
         keys: Iterable[int],
         geometries: Iterable[Geometry] | None = None,
         properties_iter: Iterable[Properties] | None = None,
@@ -794,7 +800,7 @@ class AnnotationStore(ABC, MutableMapping):
             properties_ = copy.deepcopy(properties)
             self.patch(key, geometry, properties_)
 
-    def remove(self, key: str) -> None:
+    def remove(self: AnnotationStore, key: str) -> None:
         """Remove annotation from the store with its unique key.
 
         Args:
@@ -804,7 +810,7 @@ class AnnotationStore(ABC, MutableMapping):
         """
         self.remove_many([key])
 
-    def remove_many(self, keys: Iterable[str]) -> None:
+    def remove_many(self: AnnotationStore, keys: Iterable[str]) -> None:
         """Bulk removal of annotations by keys.
 
         Args:
@@ -815,7 +821,9 @@ class AnnotationStore(ABC, MutableMapping):
         for key in keys:
             self.remove(key)
 
-    def setdefault(self, key: str, default: Annotation | None = None) -> Annotation:
+    def setdefault(self: AnnotationStore,
+                   key: str,
+                   default: Annotation | None = None) -> Annotation:
         """Return the value of the annotation with the given key.
 
         If the key does not exist, insert the default value and return
@@ -837,7 +845,7 @@ class AnnotationStore(ABC, MutableMapping):
             raise TypeError(msg)
         return super().setdefault(key, default)
 
-    def __delitem__(self, key: str) -> None:
+    def __delitem__(self: AnnotationStore, key: str) -> None:
         """Delete an annotation by key.
 
         An alias of `remove`.
@@ -849,7 +857,7 @@ class AnnotationStore(ABC, MutableMapping):
         """
         self.remove(key)
 
-    def keys(self) -> Iterable[str]:
+    def keys(self: AnnotationStore) -> Iterable[str]:
         """Return an iterable (usually generator) of all keys in the store.
 
         Returns:
@@ -860,7 +868,7 @@ class AnnotationStore(ABC, MutableMapping):
         for key, _ in self.items():  # noqa: PERF102
             yield key
 
-    def values(self) -> Iterable[Annotation]:
+    def values(self: AnnotationStore) -> Iterable[Annotation]:
         """Return an iterable of all annotation in the store.
 
         Returns:
@@ -871,7 +879,7 @@ class AnnotationStore(ABC, MutableMapping):
         for _, annotation in self.items():  # noqa: PERF102
             yield annotation
 
-    def __iter__(self) -> Iterator[str]:
+    def __iter__(self: AnnotationStore) -> Iterator[str]:
         """Return an iterable of keys in the store.
 
         An alias of `keys`.
@@ -918,7 +926,7 @@ class AnnotationStore(ABC, MutableMapping):
         return bool(predicate(properties))
 
     def query(
-        self,
+        self: AnnotationStore,
         geometry: QueryGeometry | None = None,
         where: Predicate | None = None,
         geometry_predicate: str = "intersects",
@@ -1069,7 +1077,7 @@ class AnnotationStore(ABC, MutableMapping):
         }
 
     def iquery(
-        self,
+        self: AnnotationStore,
         geometry: QueryGeometry,
         where: Predicate | None = None,
         geometry_predicate: str = "intersects",
@@ -1149,7 +1157,7 @@ class AnnotationStore(ABC, MutableMapping):
         ]
 
     def bquery(
-        self,
+        self: AnnotationStore,
         geometry: QueryGeometry | None = None,
         where: Predicate | None = None,
     ) -> dict[str, tuple[float, float, float, float]]:
@@ -1235,7 +1243,7 @@ class AnnotationStore(ABC, MutableMapping):
         }
 
     def pquery(
-        self,
+        self: AnnotationStore,
         select: Select,
         geometry: QueryGeometry | None = None,
         where: Predicate | None = None,
@@ -1334,7 +1342,7 @@ class AnnotationStore(ABC, MutableMapping):
         def select_values(
             select: Select,
             annotation: Annotation,
-        ) -> Properties | Any | tuple[Any, ...]:
+        ) -> Properties | Any | tuple[Any, ...]:  # noqa: ANN401
             """Get the value(s) to return from an annotation via a select.
 
             Args:
@@ -1389,7 +1397,7 @@ class AnnotationStore(ABC, MutableMapping):
         )
 
     def nquery(
-        self,
+        self: AnnotationStore,
         geometry: Geometry | None = None,
         where: Predicate | None = None,
         n_where: Predicate | None = None,
@@ -1591,7 +1599,7 @@ class AnnotationStore(ABC, MutableMapping):
         *,
         unique: bool,
         squeeze: bool,
-    ):
+    ) -> dict[str, Any] | dict:
         """Package the results of a pquery into the right output format.
 
         Args:
@@ -1635,7 +1643,7 @@ class AnnotationStore(ABC, MutableMapping):
             result = result[0]
         return result  # CCR001
 
-    def features(self) -> Generator[dict[str, Any], None, None]:
+    def features(self: AnnotationStore) -> Generator[dict[str, Any], None, None]:
         """Return annotations as a list of geoJSON features.
 
         Returns:
@@ -1646,7 +1654,7 @@ class AnnotationStore(ABC, MutableMapping):
         for a in self.values():
             yield a.to_feature()
 
-    def to_geodict(self) -> dict[str, Any]:
+    def to_geodict(self: AnnotationStore) -> dict[str, Any]:
         """Return annotations as a dictionary in geoJSON format.
 
         Returns:
@@ -1695,7 +1703,7 @@ class AnnotationStore(ABC, MutableMapping):
         fp: IO | str | Path,
         string_fn: Callable[[str | bytes], Any],
         file_fn: Callable[[IO], Any],
-    ) -> Any:
+    ) -> Any:  # noqa: ANN401
         """Loads cases for an input file handle or path."""
         with contextlib.suppress(OSError):
             if isinstance(fp, (Path, str)) and Path(fp).exists():
@@ -1710,7 +1718,7 @@ class AnnotationStore(ABC, MutableMapping):
 
     @classmethod
     def from_geojson(
-        cls,
+        cls: type[AnnotationStore],
         fp: IO | str,
         scale_factor: tuple[float, float] = (1, 1),
         origin: tuple[float, float] = (0, 0),
@@ -1737,7 +1745,7 @@ class AnnotationStore(ABC, MutableMapping):
         return store
 
     def add_from_geojson(
-        self,
+        self: AnnotationStore,
         fp: IO | str,
         scale_factor: tuple[float, float] = (1, 1),
         origin: tuple[float, float] = (0, 0),
@@ -1758,7 +1766,7 @@ class AnnotationStore(ABC, MutableMapping):
 
         """
 
-        def transform_geometry(geom):
+        def transform_geometry(geom: BaseGeometry) -> BaseGeometry:
             """Helper function to transform a geometry if needed."""
             if origin != (0, 0):
                 # transform coords to be relative to given origin.
@@ -1791,7 +1799,8 @@ class AnnotationStore(ABC, MutableMapping):
         logger.info("Adding %d annotations.", len(annotations))
         self.append_many(annotations)
 
-    def to_geojson(self, fp: IO | str | Path | None = None) -> str | None:
+    def to_geojson(self: AnnotationStore,
+                   fp: IO | str | Path | None = None) -> str | None:
         """Serialise the store to geoJSON.
 
         For more information on the geoJSON format see:
@@ -1810,7 +1819,7 @@ class AnnotationStore(ABC, MutableMapping):
 
         """
 
-        def write_geojson_to_file_handle(file_handle: IO):
+        def write_geojson_to_file_handle(file_handle: IO) -> str / bytes / None:
             """Write the store to a GeoJson file give a handle.
 
             This replaces the naive method which uses a lot of memory::
@@ -1836,7 +1845,7 @@ class AnnotationStore(ABC, MutableMapping):
             none_fn=lambda: json.dumps(self.to_geodict()),
         )
 
-    def to_ndjson(self, fp: IO | None = None) -> str | None:
+    def to_ndjson(self: AnnotationStore, fp: IO | None = None) -> str | None:
         """Serialise to New Line Delimited JSON.
 
         Each line contains a JSON object with the following format:
@@ -1886,7 +1895,7 @@ class AnnotationStore(ABC, MutableMapping):
         )
 
     @classmethod
-    def from_ndjson(cls, fp: IO | str) -> AnnotationStore:
+    def from_ndjson(cls: type[AnnotationStore], fp: IO | str) -> AnnotationStore:
         """Load annotations from NDJSON.
 
         Expects each line to be a JSON object with the following format:
@@ -1930,7 +1939,7 @@ class AnnotationStore(ABC, MutableMapping):
         return store
 
     @classmethod
-    def from_dataframe(cls, df: pd.DataFrame) -> AnnotationStore:
+    def from_dataframe(cls: type[AnnotationStore], df: pd.DataFrame) -> AnnotationStore:
         """Converts to AnnotationStore from :class:`pandas.DataFrame`."""
         store = cls()
         for key, row in df.iterrows():
@@ -1939,7 +1948,7 @@ class AnnotationStore(ABC, MutableMapping):
             store.append(Annotation(geometry, properties), str(key))
         return store
 
-    def to_dataframe(self) -> pd.DataFrame:
+    def to_dataframe(self: AnnotationStore) -> pd.DataFrame:
         """Converts AnnotationStore to :class:`pandas.DataFrame`."""
         features = (
             {
@@ -1951,7 +1960,8 @@ class AnnotationStore(ABC, MutableMapping):
         )
         return pd.json_normalize(features).set_index("key")
 
-    def transform(self, transform: Callable[[Geometry], Geometry]) -> None:
+    def transform(self: AnnotationStore,
+                  transform: Callable[[Geometry], Geometry]) -> None:
         """Transform all annotations in the store using provided function.
 
         Useful for transforming coordinates from slide space into
@@ -1968,7 +1978,7 @@ class AnnotationStore(ABC, MutableMapping):
         }
         self.patch_many(transformed_geoms.keys(), transformed_geoms.values())
 
-    def __del__(self) -> None:
+    def __del__(self: AnnotationStore) -> None:
         """Implements destructor method.
 
         This should be called when all references to the object have been deleted
@@ -1977,7 +1987,7 @@ class AnnotationStore(ABC, MutableMapping):
         """
         self.close()
 
-    def clear(self) -> None:
+    def clear(self: AnnotationStore) -> None:
         """Remove all annotations from the store.
 
         This is a naive implementation, it simply iterates over all annotations
@@ -1998,7 +2008,7 @@ class SQLiteMetadata(MutableMapping):
 
     """
 
-    def __init__(self, con: sqlite3.Connection) -> None:
+    def __init__(self: SQLiteMetadata, con: sqlite3.Connection) -> None:
         """Initialize :class:`SQLiteMetadata`."""
         self.con = con
         self.con.execute(
@@ -2006,12 +2016,14 @@ class SQLiteMetadata(MutableMapping):
         )
         self.con.commit()
 
-    def __contains__(self, key: str) -> bool:
+    def __contains__(self: SQLiteMetadata, key: str) -> bool:
         """Test whether the object contains the specified object or not."""
         cursor = self.con.execute("SELECT 1 FROM metadata WHERE [key] = ?", (key,))
         return cursor.fetchone() is not None
 
-    def __setitem__(self, key: str, value: dict | list | float | str) -> None:
+    def __setitem__(self: SQLiteMetadata,
+                    key: str,
+                    value: dict | list | float | str) -> None:
         """Set a metadata value."""
         value = json.dumps(value)
         self.con.execute(
@@ -2020,7 +2032,7 @@ class SQLiteMetadata(MutableMapping):
         )
         self.con.commit()
 
-    def __getitem__(self, key: str) -> dict | list | int | float | str:
+    def __getitem__(self: SQLiteMetadata, key: str) -> dict | list | int | float | str:
         """Get a metadata value."""
         cursor = self.con.execute("SELECT value FROM metadata WHERE [key] = ?", (key,))
         result = cursor.fetchone()
@@ -2028,19 +2040,19 @@ class SQLiteMetadata(MutableMapping):
             raise KeyError(key)
         return json.loads(result[0])
 
-    def __delitem__(self, key: str) -> None:
+    def __delitem__(self: SQLiteMetadata, key: str) -> None:
         """Delete a metadata value."""
         if key not in self:
             raise KeyError(key)
         self.con.execute("DELETE FROM metadata WHERE [key] = ?", (key,))
 
-    def __iter__(self) -> Iterator[str]:
+    def __iter__(self: SQLiteMetadata) -> Iterator[str]:
         """Iterate over all keys."""
         cursor = self.con.execute("SELECT [key] FROM metadata")
         for row in cursor:
             yield row[0]
 
-    def __len__(self) -> int:
+    def __len__(self: SQLiteMetadata) -> int:
         """Return the number of metadata entries."""
         cursor = self.con.execute("SELECT COUNT(*) FROM metadata")
         return cursor.fetchone()[0]
@@ -2060,12 +2072,12 @@ class SQLiteStore(AnnotationStore):
     """
 
     @classmethod
-    def open(cls, fp: Path | str) -> SQLiteStore:  # noqa: A003
+    def open(cls: type[SQLiteStore], fp: Path | str) -> SQLiteStore:  # noqa: A003
         """Opens :class:`SQLiteStore` from file pointer or path."""
         return SQLiteStore(fp)
 
     def __init__(  # noqa: PLR0915
-        self,
+        self: SQLiteStore,
         connection: Path | str | IO = ":memory:",
         compression: str = "zlib",
         compression_level: int = 9,
@@ -2237,7 +2249,7 @@ class SQLiteStore(AnnotationStore):
         self.table_columns = self._get_table_columns()
 
     def serialise_geometry(  # skipcq: PYL-W0221
-        self,
+        self: SQLiteStore,
         geometry: Geometry,
     ) -> str | bytes:
         """Serialise a geometry to WKB with optional compression.
@@ -2263,7 +2275,7 @@ class SQLiteStore(AnnotationStore):
         raise ValueError(msg)
 
     def _unpack_geometry(
-        self,
+        self: SQLiteStore,
         data: str | bytes,
         cx: float,
         cy: float,
@@ -2291,7 +2303,7 @@ class SQLiteStore(AnnotationStore):
         return Point(cx, cy) if data is None else self.deserialize_geometry(data)
 
     def _unpack_wkb(
-        self,
+        self: SQLiteStore,
         data: bytes,
         cx: float,
         cy: float,
@@ -2303,7 +2315,7 @@ class SQLiteStore(AnnotationStore):
         )
 
     def deserialize_geometry(  # skipcq: PYL-W0221
-        self,
+        self: SQLiteStore,
         data: str | bytes,
     ) -> Geometry:
         """Deserialize a geometry from a string or bytes.
@@ -2322,7 +2334,7 @@ class SQLiteStore(AnnotationStore):
             return shapely_wkt.loads(data)
         return shapely_wkb.loads(data)
 
-    def _decompress_data(self, data: bytes) -> bytes:
+    def _decompress_data(self: SQLiteStore, data: bytes) -> bytes:
         """Decompresses geometry data.
 
         Args:
@@ -2384,14 +2396,14 @@ class SQLiteStore(AnnotationStore):
             options = conn.execute("pragma compile_options").fetchall()
         return [opt for opt, in options]
 
-    def close(self) -> None:
+    def close(self: SQLiteStore) -> None:
         """Closes :class:`SQLiteStore` from file pointer or path."""
         if self.auto_commit:
             self.con.commit()
         self.optimize(vacuum=False, limit=1000)
         self.con.close()
 
-    def _make_token(self, annotation: Annotation, key: str | None) -> dict:
+    def _make_token(self: SQLiteStore, annotation: Annotation, key: str | None) -> dict:
         """Create token data dict for tokenized SQL transaction."""
         key = key or str(uuid.uuid4())
         geometry = annotation.geometry
@@ -2414,7 +2426,7 @@ class SQLiteStore(AnnotationStore):
         }
 
     def append_many(
-        self,
+        self: SQLiteStore,
         annotations: Iterable[Annotation],
         keys: Iterable[str] | None = None,
     ) -> list[str]:
@@ -2433,7 +2445,9 @@ class SQLiteStore(AnnotationStore):
             self.con.commit()
         return result
 
-    def _append(self, key: str, annotation: Annotation, cur: sqlite3.Cursor) -> None:
+    def _append(self: SQLiteStore,
+                key: str, annotation: Annotation,
+                cur: sqlite3.Cursor) -> None:
         """Append without starting a transaction.
 
         Args:
@@ -2557,11 +2571,11 @@ class SQLiteStore(AnnotationStore):
         return query_string, query_parameters
 
     def _query(  # noqa: PLR0913
-        self,
+        self: SQLiteStore,
         columns: str,
         geometry: Geometry | None = None,
         callable_columns: str | None = None,
-        geometry_predicate="intersects",
+        geometry_predicate: str = "intersects",
         where: Predicate | None = None,
         min_area: float | None = None,
         distance: float = 0,
@@ -2682,10 +2696,10 @@ class SQLiteStore(AnnotationStore):
         return cur
 
     def iquery(
-        self,
+        self: SQLiteStore,
         geometry: QueryGeometry | None = None,
         where: Predicate | None = None,
-        geometry_predicate="intersects",
+        geometry_predicate: str = "intersects",
         distance: float = 0,
     ) -> list[str]:
         """Query the store for annotation keys.
@@ -2759,11 +2773,11 @@ class SQLiteStore(AnnotationStore):
         return [key for key, in cur.fetchall()]
 
     def query(
-        self,
+        self: SQLiteStore,
         geometry: QueryGeometry | None = None,
         where: Predicate | None = None,
         geometry_predicate: str = "intersects",
-        min_area=None,
+        min_area: float / None = None,
         distance: float = 0,
     ) -> dict[str, Annotation]:
         """Runs Query."""
@@ -2794,7 +2808,7 @@ class SQLiteStore(AnnotationStore):
         }
 
     def bquery(
-        self,
+        self: SQLiteStore,
         geometry: QueryGeometry | None = None,
         where: Predicate | None = None,
     ) -> dict[str, tuple[float, float, float, float]]:
@@ -3043,7 +3057,7 @@ class SQLiteStore(AnnotationStore):
             )
 
     def pquery(
-        self,
+        self: SQLiteStore,
         select: Select,
         geometry: QueryGeometry | None = None,
         where: Predicate | None = None,
@@ -3195,20 +3209,20 @@ class SQLiteStore(AnnotationStore):
             return result[0]
         return result
 
-    def __len__(self) -> int:
+    def __len__(self: SQLiteStore) -> int:
         """Return number of annotations in the store."""
         cur = self.con.cursor()
         cur.execute("SELECT COUNT(*) FROM annotations")
         (count,) = cur.fetchone()
         return count
 
-    def __contains__(self, key: str) -> bool:
+    def __contains__(self: SQLiteStore, key: str) -> bool:
         """Test whether the object contains the specified object or not."""
         cur = self.con.cursor()
         cur.execute("SELECT EXISTS(SELECT 1 FROM annotations WHERE [key] = ?)", (key,))
         return cur.fetchone()[0] == 1
 
-    def __getitem__(self, key: str) -> Annotation:
+    def __getitem__(self: SQLiteStore, key: str) -> Annotation:
         """Get an item from the store."""
         cur = self.con.cursor()
         cur.execute(
@@ -3229,7 +3243,7 @@ class SQLiteStore(AnnotationStore):
             wkb=self._unpack_wkb(serialised_geometry, cx, cy),
         )
 
-    def keys(self) -> Iterable[int]:
+    def keys(self: SQLiteStore) -> Iterable[int]:
         """Return an iterable (usually generator) of all keys in the store.
 
         Returns:
@@ -3239,7 +3253,7 @@ class SQLiteStore(AnnotationStore):
         """
         yield from self
 
-    def __iter__(self) -> Iterator[int]:
+    def __iter__(self: SQLiteStore) -> Iterator[int]:
         """Return an iterator for the given object."""
         cur = self.con.cursor()
         cur.execute(
@@ -3254,7 +3268,7 @@ class SQLiteStore(AnnotationStore):
                 break
             yield row[0]  # The key
 
-    def values(self) -> Iterable[tuple[int, Annotation]]:
+    def values(self: SQLiteStore) -> Iterable[tuple[int, Annotation]]:
         """Return an iterable of all annotation in the store.
 
         Returns:
@@ -3265,7 +3279,7 @@ class SQLiteStore(AnnotationStore):
         for _, value in self.items():  # noqa: PERF102
             yield value
 
-    def items(self) -> Iterable[tuple[int, Annotation]]:
+    def items(self: SQLiteStore) -> Iterable[tuple[int, Annotation]]:
         """Return iterable (generator) over key and annotations."""
         cur = self.con.cursor()
         cur.execute(
@@ -3287,7 +3301,7 @@ class SQLiteStore(AnnotationStore):
             yield key, Annotation(geometry, properties)
 
     def patch_many(
-        self,
+        self: SQLiteStore,
         keys: Iterable[int],
         geometries: Iterable[Geometry] | None = None,
         properties_iter: Iterable[Properties] | None = None,
@@ -3347,7 +3361,7 @@ class SQLiteStore(AnnotationStore):
             self.con.commit()
 
     def _patch_geometry(
-        self,
+        self: SQLiteStore,
         key: str,
         geometry: Geometry,
         cur: sqlite3.Cursor,
@@ -3393,7 +3407,7 @@ class SQLiteStore(AnnotationStore):
             query_parameters,
         )
 
-    def remove_many(self, keys: Iterable[str]) -> None:
+    def remove_many(self: SQLiteStore, keys: Iterable[str]) -> None:
         """Bulk removal of annotations by keys.
 
         Args:
@@ -3424,19 +3438,19 @@ class SQLiteStore(AnnotationStore):
         if self.auto_commit:
             self.con.commit()
 
-    def __setitem__(self, key: str, annotation: Annotation) -> None:
+    def __setitem__(self: SQLiteStore, key: str, annotation: Annotation) -> None:
         """Implements a method to assign a value to an item."""
         if key in self:
             self.patch(key, annotation.geometry, annotation.properties)
             return
         self.append(annotation, key)
 
-    def _get_table_columns(self):
+    def _get_table_columns(self: SQLiteStore) -> list[str]:
         """Get a list of columns in the annotations table."""
         cur = self.con.execute("PRAGMA table_info(annotations)")
         return [row[1] for row in cur.fetchall()]
 
-    def add_area_column(self, *, mk_index=True):
+    def add_area_column(self: SQLiteStore, *, mk_index: bool = True) -> None:
         """Add a column to store the area of the geometry."""
         cur = self.con.cursor()
         cur.execute(
@@ -3456,7 +3470,7 @@ class SQLiteStore(AnnotationStore):
         self.con.commit()
         self.table_columns.append("area")
 
-    def remove_area_column(self):
+    def remove_area_column(self: SQLiteStore) -> None:
         """Remove the area column from the store."""
         if "area" in self.indexes():
             self.drop_index("area")
@@ -3470,7 +3484,7 @@ class SQLiteStore(AnnotationStore):
         self.con.commit()
         self.table_columns.remove("area")
 
-    def to_dataframe(self) -> pd.DataFrame:
+    def to_dataframe(self: SQLiteStore) -> pd.DataFrame:
         """Converts AnnotationStore to :class:`pandas.DataFrame`."""
         store_to_df = pd.DataFrame()
         df_rows = (
@@ -3484,7 +3498,7 @@ class SQLiteStore(AnnotationStore):
         store_to_df = pd.concat([store_to_df, pd.json_normalize(df_rows)])
         return store_to_df.set_index("key")
 
-    def features(self) -> Generator[dict[str, Any], None, None]:
+    def features(self: SQLiteStore) -> Generator[dict[str, Any], None, None]:
         """Return annotations as a list of geoJSON features.
 
         Returns:
@@ -3501,11 +3515,11 @@ class SQLiteStore(AnnotationStore):
             for annotation in self.values()
         )
 
-    def commit(self) -> None:
+    def commit(self: SQLiteStore) -> None:
         """Commit any in-memory changes to disk."""
         self.con.commit()
 
-    def dump(self, fp: Path | str | IO) -> None:
+    def dump(self: SQLiteStore, fp: Path | str | IO) -> None:
         """Serialise a copy of the whole store to a file-like object.
 
         Args:
@@ -3518,7 +3532,7 @@ class SQLiteStore(AnnotationStore):
         target = sqlite3.connect(fp)
         self.con.backup(target)
 
-    def dumps(self) -> str:
+    def dumps(self: SQLiteStore) -> str:
         """Serialise and return a copy of store as a string or bytes.
 
         Returns:
@@ -3528,7 +3542,7 @@ class SQLiteStore(AnnotationStore):
         """
         return "\n".join(self.con.iterdump())
 
-    def clear(self) -> None:
+    def clear(self: SQLiteStore) -> None:
         """Remove all annotations from the store."""
         cur = self.con.cursor()
         cur.execute("DELETE FROM rtree")
@@ -3537,7 +3551,7 @@ class SQLiteStore(AnnotationStore):
             self.con.commit()
 
     def create_index(
-        self,
+        self: SQLiteStore,
         name: str,
         where: str | bytes,
         *,
@@ -3578,7 +3592,7 @@ class SQLiteStore(AnnotationStore):
         if analyze:
             cur.execute(f"ANALYZE {name}")
 
-    def indexes(self) -> list[str]:
+    def indexes(self: SQLiteStore) -> list[str]:
         """Return a list of the names of all indexes in the store.
 
         Returns:
@@ -3590,7 +3604,7 @@ class SQLiteStore(AnnotationStore):
         cur.execute("SELECT name FROM sqlite_master WHERE TYPE = 'index'")
         return [row[0] for row in cur.fetchall()]
 
-    def drop_index(self, name: str) -> None:
+    def drop_index(self: SQLiteStore, name: str) -> None:
         """Drop an index from the store.
 
         Args:
@@ -3601,7 +3615,7 @@ class SQLiteStore(AnnotationStore):
         cur = self.con.cursor()
         cur.execute(f"DROP INDEX {name}")
 
-    def optimize(self, limit: int = 1000, *, vacuum: bool = True) -> None:
+    def optimize(self: SQLiteStore, limit: int = 1000, *, vacuum: bool = True) -> None:
         """Optimize the database with VACUUM and ANALYZE.
 
         Args:
@@ -3624,7 +3638,8 @@ class SQLiteStore(AnnotationStore):
 class DictionaryStore(AnnotationStore):
     """Pure python dictionary backed annotation store."""
 
-    def __init__(self, connection: Path | str | IO = ":memory:") -> None:
+    def __init__(self: DictionaryStore,
+                 connection: Path | str | IO = ":memory:") -> None:
         """Initialize :class:`DictionaryStore`."""
         super().__init__()
         self._rows = {}
@@ -3643,7 +3658,7 @@ class DictionaryStore(AnnotationStore):
                 self.append(Annotation(geometry, properties), key=key)
 
     def append(
-        self,
+        self: DictionaryStore,
         annotation: Annotation,
         key: str | None = None,
     ) -> str:
@@ -3670,7 +3685,7 @@ class DictionaryStore(AnnotationStore):
         return key
 
     def patch(
-        self,
+        self: DictionaryStore,
         key: str,
         geometry: Geometry | None = None,
         properties: dict[str, Any] | None = None,
@@ -3703,7 +3718,7 @@ class DictionaryStore(AnnotationStore):
         new_properties.update(properties)
         self[key] = Annotation(geometry, new_properties)
 
-    def remove(self, key: str) -> None:
+    def remove(self: DictionaryStore, key: str) -> None:
         """Remove annotation from the store with its unique key.
 
         Args:
@@ -3713,35 +3728,36 @@ class DictionaryStore(AnnotationStore):
         """
         del self._rows[key]
 
-    def __getitem__(self, key: str) -> Annotation:
+    def __getitem__(self: DictionaryStore, key: str) -> Annotation:
         """Get an item from the store."""
         return self._rows[key]["annotation"]
 
-    def __setitem__(self, key: str, annotation: Annotation) -> None:
+    def __setitem__(self: DictionaryStore, key: str, annotation: Annotation) -> None:
         """Implements a method to assign a value to an item."""
         if key in self._rows:
             self._rows[key]["annotation"] = annotation
         self._rows[key] = {"annotation": annotation}
 
-    def __contains__(self, key: str) -> bool:
+    def __contains__(self: DictionaryStore, key: str) -> bool:
         """Test whether the object contains the specified object or not."""
         return key in self._rows
 
-    def items(self) -> Generator[tuple[str, Annotation], None, None]:
+    def items(self: DictionaryStore) -> Generator[tuple[str, Annotation], None, None]:
         """Return iterable (generator) over key and annotations."""
         for key, row in self._rows.items():
             yield key, row["annotation"]
 
-    def __len__(self) -> int:
+    def __len__(self: DictionaryStore) -> int:
         """Return the length of the instance attributes."""
         return len(self._rows)
 
     @classmethod
-    def open(cls, fp: Path | str | IO) -> DictionaryStore:  # noqa: A003
+    def open(cls: type[DictionaryStore],  # noqa: A003
+             fp: Path | str | IO) -> DictionaryStore:
         """Opens :class:`DictionaryStore` from file pointer or path."""
         return cls.from_ndjson(fp)
 
-    def commit(self) -> None:
+    def commit(self: DictionaryStore) -> None:
         """Commit any in-memory changes to disk."""
         if str(self.connection) == ":memory:":
             logger.warning("In-memory store. Nothing to commit.", stacklevel=2)
@@ -3750,7 +3766,7 @@ class DictionaryStore(AnnotationStore):
             self.path.touch()
         self.dump(self.connection)
 
-    def dump(self, fp: Path | str | IO) -> None:
+    def dump(self: DictionaryStore, fp: Path | str | IO) -> None:
         """Serialise a copy of the whole store to a file-like object.
 
         Args:
@@ -3760,7 +3776,7 @@ class DictionaryStore(AnnotationStore):
         """
         return self.to_ndjson(fp)
 
-    def dumps(self) -> str:
+    def dumps(self: DictionaryStore) -> str:
         """Serialise and return a copy of store as a string or bytes.
 
         Returns:
@@ -3770,7 +3786,7 @@ class DictionaryStore(AnnotationStore):
         """
         return self.to_ndjson()
 
-    def close(self) -> None:
+    def close(self: DictionaryStore) -> None:
         """Closes :class:`DictionaryStore` from file pointer or path."""
         duplicate_filter = DuplicateFilter()
         logger.addFilter(duplicate_filter)


### PR DESCRIPTION
- Fix flake8-annotation errors in tests and annotation.

To review:
- Please review `AnnotationStore` type hints for `*args` `**kwargs`
- Please review where Ruff errors are ignored for `Any` datatype (ANN401, F821)
- Please review where Ruff errors are ignored for unused arguments (ARG001)