### PR TITLE
:construction: Add type checking using `mypy`

### DIFF
--- a/.github/workflows/mypy-type-check.yml
+++ b/.github/workflows/mypy-type-check.yml
@@ -1,0 +1,38 @@
+# This workflow will perform code type checking using mypy
+
+name: mypy type checking
+
+on:
+  push:
+    branches: [ develop, pre-release, master, main ]
+  pull_request:
+    branches: [ develop, pre-release, master, main ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Setup mypy
+      run: |
+        pip install mypy
+        mypy --install-types
+
+    - name: Perform type checking
+      run: |
+        mypy tiatoolbox/__init__.py

--- a/.github/workflows/mypy-type-check.yml
+++ b/.github/workflows/mypy-type-check.yml
@@ -31,8 +31,7 @@ jobs:
     - name: Setup mypy
       run: |
         pip install mypy
-        mypy --install-types
 
     - name: Perform type checking
       run: |
-        mypy tiatoolbox/__init__.py
+        mypy --install-types --non-interactive tiatoolbox/__init__.py

--- a/.github/workflows/mypy-type-check.yml
+++ b/.github/workflows/mypy-type-check.yml
@@ -34,4 +34,4 @@ jobs:
 
     - name: Perform type checking
       run: |
-        mypy --install-types --non-interactive tiatoolbox/__init__.py
+        mypy --install-types --non-interactive --follow-imports=skip tiatoolbox/__init__.py

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -139,3 +139,14 @@ def test_lazy_import() -> None:
     )
 
     assert "exceptions" in sys.modules
+
+
+def test_lazy_import_module_not_found() -> None:
+    """'Test lazy import for ModuleNotFoundError."""
+    from tiatoolbox import _lazy_import
+
+    with pytest.raises(ModuleNotFoundError):
+        _lazy_import(
+            "nonexistent_module",
+            Path(__file__).parent.parent / "tiatoolbox",
+        )

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING, Dict
 if sys.version_info >= (3, 9):  # pragma: no cover
     import importlib.resources as importlib_resources
 else:  # pragma: no cover
-    import importlib_resources  # type: ignore[import-not-found] To support Python 3.8
+    # To support Python 3.8
+    import importlib_resources  # type: ignore[import-not-found]
 
 import yaml
 

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Dict
 if sys.version_info >= (3, 9):  # pragma: no cover
     import importlib.resources as importlib_resources
 else:  # pragma: no cover
-    import importlib_resources  # To support Python 3.8
+    import importlib_resources  # type: ignore[import-not-found]  # To support Python 3.8
 
 import yaml
 

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
 
 if sys.version_info >= (3, 9):  # pragma: no cover
     import importlib.resources as importlib_resources

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -108,7 +108,7 @@ rcParam["pretrained_model_info"] = read_registry_files("data/pretrained_model.ya
 def _lazy_import(name: str, module_location: Path) -> dict[str, ModuleType]:
     spec = importlib.util.spec_from_file_location(name, module_location)
     if spec is None or spec.loader is None:
-        raise ModuleNotFoundError(name=name, path=module_location)
+        raise ModuleNotFoundError(name=name, path=str(module_location))
     loader = importlib.util.LazyLoader(spec.loader)
     spec.loader = loader
     module = importlib.util.module_from_spec(spec)

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Dict
 if sys.version_info >= (3, 9):  # pragma: no cover
     import importlib.resources as importlib_resources
 else:  # pragma: no cover
-    import importlib_resources  # type: ignore[import-not-found]  # To support Python 3.8
+    import importlib_resources  # type: ignore[import-not-found] To support Python 3.8
 
 import yaml
 

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -91,7 +91,7 @@ def read_registry_files(path_to_registry: str | Path) -> dict | str:
 
 
     """
-    path_to_registry = str(path_to_registry)   # To pass tests with Python 3.8
+    path_to_registry = str(path_to_registry)  # To pass tests with Python 3.8
     pretrained_files_registry_path = importlib_resources.as_file(
         importlib_resources.files("tiatoolbox") / path_to_registry,
     )

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -91,7 +91,7 @@ def read_registry_files(path_to_registry: str | Path) -> dict | str:
 
 
     """
-    path_to_registry = str(path_to_registry)
+    path_to_registry = str(path_to_registry)   # To pass tests with Python 3.8
     pretrained_files_registry_path = importlib_resources.as_file(
         importlib_resources.files("tiatoolbox") / path_to_registry,
     )

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -75,7 +75,7 @@ class DuplicateFilter(logging.Filter):
 # runtime context parameters
 rcParam: dict[str, str | Path | dict]  # noqa: N816
 rcParam = {  # noqa: N816
-    "TIATOOLBOX_HOME": Path.home() / Path(".tiatoolbox"),
+    "TIATOOLBOX_HOME": Path.home() / ".tiatoolbox",
 }
 
 
@@ -91,10 +91,9 @@ def read_registry_files(path_to_registry: str | Path) -> dict | str:
 
 
     """
-    if isinstance(path_to_registry, Path):
-        path_to_registry = str(path_to_registry)
+    path_to_registry = str(path_to_registry)
     pretrained_files_registry_path = importlib_resources.as_file(
-        importlib_resources.files("tiatoolbox").joinpath(path_to_registry),
+        importlib_resources.files("tiatoolbox") / path_to_registry,
     )
 
     with pretrained_files_registry_path as registry_file_path:
@@ -106,7 +105,7 @@ def read_registry_files(path_to_registry: str | Path) -> dict | str:
 rcParam["pretrained_model_info"] = read_registry_files("data/pretrained_model.yaml")
 
 
-def _lazy_import(name: str, module_location: Path) -> dict[str, ModuleType]:
+def _lazy_import(name: str, module_location: Path) -> ModuleType:
     spec = importlib.util.spec_from_file_location(name, module_location)
     if spec is None or spec.loader is None:
         raise ModuleNotFoundError(name=name, path=str(module_location))
@@ -115,7 +114,7 @@ def _lazy_import(name: str, module_location: Path) -> dict[str, ModuleType]:
     module = importlib.util.module_from_spec(spec)
     sys.modules[name] = module
     loader.exec_module(module)
-    return {name: module}
+    return module
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add type checking using `mypy`, a static type checker for Python.

This PR involves adding type hints and checking the correctness of existing type hints in the code base.
A GitHub action has been created to run `mypy` after push and pull requests.
Currently, only `tiatoolbox/__init__.py` has been checked to work without errors with `mypy`.