### PR TITLE
:bug: Return `masks` Instead of `[mask]` in Tissue Masker

### DIFF
--- a/tiatoolbox/tools/tissuemask.py
+++ b/tiatoolbox/tools/tissuemask.py
@@ -164,7 +164,7 @@ class OtsuTissueMasker(TissueMasker):
             mask = (grey < self.threshold).astype(bool)
             masks.append(mask)
 
-        return [mask]
+        return masks
 
 
 class MorphologicalMasker(OtsuTissueMasker):


### PR DESCRIPTION
Fixes #732.
- masks should be returned instead of [mask].