### PR TITLE
🔖 Release 1.5.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: TissueImageAnalytics/tiatoolbox
   image: ghcr.io/tissueimageanalytics/tiatoolbox
-  TOOLBOX_VER: 1.4.1
+  TOOLBOX_VER: 1.5.0
 
 jobs:
   build-and-push-image:

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,15 +5,19 @@
 - TIA Centre led by Nasir Rajpoot <tia@dcs.warwick.ac.uk>
 - Shan E Ahmed Raza \<@shaneahmed>
 - John Pocock \<@John-P>
+- Mark Eastwood \<@measty>
 - Simon Graham \<@simongraham>
 - Dang Vu \<@vqdang>
 - Mostafa Jahanifar \<@mostafajahanifar>
 - David Epstein \<@DavidBAEpstein>
-- Mark Eastwood \<@measty>
-- Srijay Deshpande \<@Srijay-lab>
-- Ruqayya Awan \<@ruqayya>
 - Adam Shephard \<@adamshephard>
+- Ruqayya Awan \<@ruqayya>
+- Abdullah Alsalemi \<@Abdol>
+- Dmitrii Blaginin \<@blaginin>
+- Srijay Deshpande \<@Srijay-lab>
+- Jiaqi Lv\<@Jiaqi-Lv>
 - George Hadjigeorgiou \<@ghadjigeorghiou>
+- Abishekraj Vinayagar Gnanasambandam \<@AbishekRajVG>
 - Wenqi Lu \<@wenqi006>
 - Saad Bashir \<@rajasaad>
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,7 +44,7 @@ authors:
   given-names: "Shan E Ahmed"
   orcid: "https://orcid.org/0000-0002-1097-1738"
 title: "TIAToolbox as an end-to-end library for advanced tissue image analytics"
-version: 1.4.1  # TIAToolbox version
+version: 1.5.0  # TIAToolbox version
 doi: 10.5281/zenodo.5802442
 date-released: 2022-10-20
 url: "https://github.com/TissueImageAnalytics/tiatoolbox"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,50 @@
 # History
 
+## 1.5.0 (2023-12-15)
+
+### Major Updates and Feature Improvements
+
+- Adds the bokeh visualization tool. #684
+  - The tool allows a user to launch a server on their machine to visualise whole slide images, overlay the results of deep learning algorithms or to select a patch from whole slide image and run TIAToolbox deep learning engines.
+  - This tool powers the TIA demos server. For details please see https://tiademos.dcs.warwick.ac.uk/.
+- Extends Annotation to Support Init from WKB #639
+- Adds `IOConfig` for NuClick in `pretrained_model.yaml` #709
+- Adds functions to save the TIAToolbox Engine outputs to Zarr and AnnotationStore files. #724
+- Adds Support for QuPath Annotation Imports #721
+
+### Changes to API
+
+- Adds `model.to(device)` and `model.load_model_from_file()` functionality to make it compatible with PyTorch API. #733
+- Replaces `pretrained` with `weights` to make the engines compatible with the new PyTorch API. #621
+- Adds support for high-level imports for various utility functions and classes such as `WSIReader`, `PatchPredictor` and `imread` #606, #607,
+- Adds `tiatoolbox.typing` for type hints. #619
+- Fixes incorrect file size saved by `save_tiles`, issue with certain WSIs raised by @TomastpPereira
+- TissueMasker transform now returns mask instead of a list. #748
+  - Fixes #732
+
+### Bug Fixes and Other Changes
+
+- Fixes `pixman` incompability error on Colab #601
+- Removes `shapely.speedups`. The module no longer has any affect in Shapely >=2.0. #622
+- Fixes errors in the slidegraph example notebook #608
+- Fixes bugs in WSI Registration #645, #670, #693
+- Fixes the situation where PatchExtractor.get_coords() can return patch coords which lie fully outside the bounds of a slide. #712
+  - Fixes #710
+- Fixes #738 raised by @xiachenrui
+
+### Development related changes
+
+- Replaces `flake8` and `isort` with `ruff` #625, #666
+- Adds `mypy` checks to `root` and `utils` package. This will be rolled out in phases to other modules. #723
+- Adds a module to detect file types using magic number/signatures #616
+- Uses `poetry` for version updates instead of `bump2version`. #638
+- Removes `setup.cfg` and uses `pyproject.toml` for project configurations.
+- Reduces runtime for some unit tests e.g., #627, #630, #631, #629
+- Reuses models and datasets in tests on GitHub actions by utilising cache #641, #644
+- Set up parallel tests locally #671
+
+**Full Changelog:** https://github.com/TissueImageAnalytics/tiatoolbox/compare/v1.4.0...v1.5.0
+
 ## 1.4.1 (2023-07-25)
 
 ### Bug Fixes and Other Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@
 
 [tool.poetry]
 name = "TIA Centre"
-version = "1.4.0"
+version = "1.5.0"
 description = "test"
 authors = ["TIA Centre <tialab@dcs.warwick.ac.uk>"]
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/TissueImageAnalytics/tiatoolbox",
-    version="1.4.1",
+    version="1.5.0",
     zip_safe=False,
 )

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 __author__ = """TIA Centre"""
 __email__ = "tialab@dcs.warwick.ac.uk"
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 
 # This will set the tiatoolbox external data
 # default to be the user home folder, should work on both Window and Unix/Linux

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -2377,6 +2377,7 @@ class SQLiteStore(AnnotationStore):
         cx: float,
         cy: float,
     ) -> bytes:
+        """Unpack WKB data."""
         return (
             self._decompress_data(data)
             if data


### PR DESCRIPTION
## 1.5.0 (2023-12-15)

### Major Updates and Feature Improvements

- Adds the bokeh visualization tool. #684
  - The tool allows a user to launch a server on their machine to visualise whole slide images, overlay the results of deep learning algorithms or to select a patch from whole slide image and run TIAToolbox deep learning engines.
  - This tool powers the TIA demos server. For details please see https://tiademos.dcs.warwick.ac.uk/.
- Extends Annotation to Support Init from WKB #639
- Adds `IOConfig` for NuClick in `pretrained_model.yaml` #709
- Adds functions to save the TIAToolbox Engine outputs to Zarr and AnnotationStore files. #724
- Adds Support for QuPath Annotation Imports #721

### Changes to API

- Adds `model.to(device)` and `model.load_model_from_file()` functionality to make it compatible with PyTorch API. #733
- Replaces `pretrained` with `weights` to make the engines compatible with the new PyTorch API. #621
- Adds support for high-level imports for various utility functions and classes such as `WSIReader`, `PatchPredictor` and `imread` #606, #607,
- Adds `tiatoolbox.typing` for type hints. #619
- Fixes incorrect file size saved by `save_tiles`, issue with certain WSIs raised by @TomastpPereira
- TissueMasker transform now returns mask instead of a list. #748
  - Fixes #732

### Bug Fixes and Other Changes

- Fixes `pixman` incompability error on Colab #601
- Removes `shapely.speedups`. The module no longer has any affect in Shapely >=2.0. #622
- Fixes errors in the slidegraph example notebook #608
- Fixes bugs in WSI Registration #645, #670, #693
- Fixes the situation where PatchExtractor.get_coords() can return patch coords which lie fully outside the bounds of a slide. #712
  - Fixes #710
- Fixes #738 raised by @xiachenrui

### Development related changes

- Replaces `flake8` and `isort` with `ruff` #625, #666
- Adds `mypy` checks to `root` and `utils` package. This will be rolled out in phases to other modules. #723
- Adds a module to detect file types using magic number/signatures #616
- Uses `poetry` for version updates instead of `bump2version`. #638
- Removes `setup.cfg` and uses `pyproject.toml` for project configurations.
- Reduces runtime for some unit tests e.g., #627, #630, #631, #629
- Reuses models and datasets in tests on GitHub actions by utilising cache #641, #644
- Set up parallel tests locally #671

**Full Changelog:** https://github.com/TissueImageAnalytics/tiatoolbox/compare/v1.4.0...v1.5.0