### PR TITLE
♻️ Remove `POWER` from sqlite-dist Calculations

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -32,5 +32,5 @@ torch>=2.1.0
 torchvision>=0.15.0
 tqdm>=4.64.1
 umap-learn>=0.5.3
-wsidicom>=0.7.0
+wsidicom>=0.7.0, <0.18.0 # newly released version is causing tests to fail for now
 zarr>=2.13.3

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -2588,8 +2588,10 @@ class SQLiteStore(AnnotationStore):
             if geometry_predicate == "centers_within_k":
                 # Use rtree index to check distance between points
                 query_string += (
-                    "AND (((:min_x + :max_x)/2 - (min_x + max_x)/2)*((:min_x + :max_x)/2 - (min_x + max_x)/2) + "
-                    " ((:min_y + :max_y)/2 - (min_y + max_y)/2)*((:min_y + :max_y)/2 - (min_y+ max_y)/2)) < :distance2 "
+                    "AND (((:min_x + :max_x)/2 - (min_x + max_x)/2)*"
+                    "((:min_x + :max_x)/2 - (min_x + max_x)/2) + "
+                    " ((:min_y + :max_y)/2 - (min_y + max_y)/2)*"
+                    "((:min_y + :max_y)/2 - (min_y+ max_y)/2)) < :distance2 "
                 )
                 query_parameters["distance2"] = distance**2
             # Otherwise, perform a regular bounding box intersection

--- a/tiatoolbox/annotation/storage.py
+++ b/tiatoolbox/annotation/storage.py
@@ -2588,8 +2588,8 @@ class SQLiteStore(AnnotationStore):
             if geometry_predicate == "centers_within_k":
                 # Use rtree index to check distance between points
                 query_string += (
-                    "AND (POWER((:min_x + :max_x)/2 - (min_x + max_x)/2, 2) + "
-                    " POWER((:min_y + :max_y)/2 - (min_y + max_y)/2, 2)) < :distance2 "
+                    "AND (((:min_x + :max_x)/2 - (min_x + max_x)/2)*((:min_x + :max_x)/2 - (min_x + max_x)/2) + "
+                    " ((:min_y + :max_y)/2 - (min_y + max_y)/2)*((:min_y + :max_y)/2 - (min_y+ max_y)/2)) < :distance2 "
                 )
                 query_parameters["distance2"] = distance**2
             # Otherwise, perform a regular bounding box intersection


### PR DESCRIPTION
Removes the use of POWER from distance calculations to address issue #692

Replaces use of POWER with explicit multiplication.