### PR TITLE
🐛 Fix `json_extract` Construction

### DIFF
--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -46,6 +46,7 @@ SAMPLE_PROPERTIES = {
     "neg": -1,
     "bool": True,
     "nesting": {"fib": [1, 1, 2, 3, 5], "foo": {"bar": "baz"}},
+    "dot.key": 3.14,
 }
 
 
@@ -571,3 +572,19 @@ class TestPredicate:
             eval_locals,
         )
         assert bool(check(result)) is True
+
+    @staticmethod
+    def test_key_with_period(
+        eval_globals: dict[str, object],
+        eval_locals: Mapping[str, object],
+        check: Callable,
+    ) -> None:
+        """Test key with period."""
+        query = "props['dot.key']"
+        result = eval(  # skipcq: PYL-W0123  # noqa: S307
+            query,
+            eval_globals,
+            eval_locals,
+        )
+
+        assert check(result) == 3.14

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -105,8 +105,8 @@ class TestSQLite:
             {},
         )
         assert str(query) == (
-            '((json_extract(properties, "$.int") == 2) OR '
-            '(json_extract(properties, "$.int") == 3))'
+            """((json_extract(properties, '$."int"') == 2) OR """
+            """(json_extract(properties, '$."int"') == 3))"""
         )
 
 

--- a/tiatoolbox/annotation/dsl.py
+++ b/tiatoolbox/annotation/dsl.py
@@ -265,14 +265,14 @@ class SQLJSONDictionary(SQLExpression):
 
     def __str__(self: SQLJSONDictionary) -> str:
         """Return a human-readable, or informal, string representation of an object."""
-        return f"json_extract(properties, {json.dumps(f'$.{self.acc}')})"
+        return f"json_extract(properties, '$.{self.acc}')"
 
     def __getitem__(self: SQLJSONDictionary, key: str) -> SQLJSONDictionary:
         """Get an item from the dataset."""
         key_str = f"[{key}]" if isinstance(key, (int,)) else str(key)
 
         joiner = "." if self.acc and not isinstance(key, int) else ""
-        return SQLJSONDictionary(acc=self.acc + joiner + f"{key_str}")
+        return SQLJSONDictionary(acc=self.acc + joiner + f'"{key_str}"')
 
     def get(
         self: SQLJSONDictionary,

--- a/tiatoolbox/annotation/dsl.py
+++ b/tiatoolbox/annotation/dsl.py
@@ -269,10 +269,10 @@ class SQLJSONDictionary(SQLExpression):
 
     def __getitem__(self: SQLJSONDictionary, key: str) -> SQLJSONDictionary:
         """Get an item from the dataset."""
-        key_str = f"[{key}]" if isinstance(key, (int,)) else str(key)
+        key_str = f"[{key}]" if isinstance(key, (int,)) else f'"{key}"'
 
         joiner = "." if self.acc and not isinstance(key, int) else ""
-        return SQLJSONDictionary(acc=self.acc + joiner + f'"{key_str}"')
+        return SQLJSONDictionary(acc=self.acc + joiner + key_str)
 
     def get(
         self: SQLJSONDictionary,


### PR DESCRIPTION
Restructures the way the dsl builds the SQL expression to access JSON properties so that properties with a . in are correctly treated as a single key

Adds a test to check for correct behaviour when accessing a property containing a .

Addresses issue #771 

Would like to check with John if removing json.dumps() is ok. I couldn't see a reason it was necessary and all tests pass/all the use-cases I tried worked fine, but maybe there is one I missed.