### PR TITLE
:children_crossing: Refactor `cli.visualize` to Improve `cli` Response

### DIFF
--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -125,4 +125,5 @@ if __name__ == "__main__":
     tiatoolbox = _lazy_import("tiatoolbox", location)
     tools = _lazy_import("tools", location)
     utils = _lazy_import("utils", location)
+    visualization = _lazy_import("visualization", location)
     wsicore = _lazy_import("wsicore", location)

--- a/tiatoolbox/cli/visualize.py
+++ b/tiatoolbox/cli/visualize.py
@@ -12,9 +12,6 @@ import click
 from flask_cors import CORS
 
 from tiatoolbox.cli.common import tiatoolbox_cli
-from tiatoolbox.visualization.tileserver import TileServer
-
-BOKEH_PATH = importlib_resources.files("tiatoolbox.visualization.bokeh_app")
 
 
 def run_tileserver() -> None:
@@ -22,6 +19,8 @@ def run_tileserver() -> None:
 
     def run_app() -> None:
         """Run the tileserver app."""
+        from tiatoolbox.visualization.tileserver import TileServer
+
         app = TileServer(
             title="Tiatoolbox TileServer",
             layers={},
@@ -35,6 +34,7 @@ def run_tileserver() -> None:
 
 def run_bokeh(img_input: list[str], port: int, *, noshow: bool) -> None:
     """Start the bokeh server."""
+    bokeh_path = importlib_resources.files("tiatoolbox.visualization.bokeh_app")
     cmd = [
         "bokeh",
         "serve",
@@ -43,7 +43,7 @@ def run_bokeh(img_input: list[str], port: int, *, noshow: bool) -> None:
         cmd = [*cmd, "--show"]  # pragma: no cover
     cmd = [
         *cmd,
-        BOKEH_PATH,
+        bokeh_path,
         "--port",
         str(port),
         "--unused-session-lifetime",


### PR DESCRIPTION
- Refactor `cli.visualize` to Improve `cli` Response

Before applying fix `$ time python -m tiatoolbox -h`
real    0m18.525s
user    0m17.144s
sys     0m3.077s

After applying the fix `$ time python -m tiatoolbox -h`
real    0m1.053s
user    0m0.434s
sys     0m0.020s
