### PR TITLE
:bug: Fix `codecov` Reporting

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -63,11 +63,12 @@ jobs:
            --durations=10 --durations-min=1.0 \
            --maxfail=1
     - name: Report test coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
         files: coverage.xml
         fail_ci_if_error: false
         verbose: true
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Report test coverage to DeepSource
       uses: deepsourcelabs/test-coverage-action@master

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -64,11 +64,12 @@ jobs:
            --maxfail=1
     - name: Report test coverage to Codecov
       uses: codecov/codecov-action@v4
+      env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: coverage.xml
         fail_ci_if_error: false
         verbose: true
-        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Report test coverage to DeepSource
       uses: deepsourcelabs/test-coverage-action@master


### PR DESCRIPTION
- Fix `codecov` Reporting

Fixes the following error:

```
[2024-04-26T13:26:38.358Z] ['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
[2024-04-26T13:26:38.358Z] ['verbose'] The error stack is: Error: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
    at main (/snapshot/repo/dist/src/index.js)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
[2024-04-26T13:26:38.358Z] ['verbose'] End of uploader: 748 milliseconds
[2024-04-26T13:26:38.358Z] ['info'] Codecov will exit with status code 0. If you are expecting a non-zero exit code, please pass in the `-Z` flag
```