### PR TITLE
:white_check_mark: Add Test to Reset `logger` Filters.

### DIFF
--- a/tests/test_annotation_stores.py
+++ b/tests/test_annotation_stores.py
@@ -27,6 +27,7 @@ from shapely.geometry import (
     Polygon,
 )
 
+from tiatoolbox import logger
 from tiatoolbox.annotation import (
     Annotation,
     AnnotationStore,
@@ -51,6 +52,14 @@ sqlite3.enable_callback_tracebacks(True)  # noqa: FBT003
 GRID_SIZE = (10, 10)
 FILLED_LEN = 2 * (GRID_SIZE[0] * GRID_SIZE[1])
 RNG = np.random.default_rng(0)  # Numpy Random Generator
+
+# ----------------------------------------------------------------------
+# Resets
+# ----------------------------------------------------------------------
+
+# Reset filters in logger.
+for filter_ in logger.filters:
+    logger.removeFilter(filter_)
 
 # ----------------------------------------------------------------------
 # Helper Functions

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -109,6 +109,14 @@ def test_logger_output() -> None:
 
 def test_duplicate_filter(caplog: pytest.LogCaptureFixture) -> None:
     """Test DuplicateFilter for warnings."""
+    # Test logger reset after applying duplicate filter.
+    duplicate_filter = DuplicateFilter()
+    logger.addFilter(duplicate_filter)
+
+    # Reset filters in logger.
+    for filter_ in logger.filters:
+        logger.removeFilter(filter_)
+
     for _ in range(2):
         logger.warning("Test duplicate filter warnings.")
     assert "Test duplicate filter warnings." in caplog.text


### PR DESCRIPTION
- Logger filters need to be reset at the start of run. This is required if a failed test with logs is run in another pytest.
- This PR fixes [failed tests](https://github.com/TissueImageAnalytics/tiatoolbox/actions/runs/9414105193/job/25932262521) in #783. 