### PR TITLE
:bug: Fix `test_dsl` for `pytest`>=8.3.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
         sudo apt update
         sudo apt-get install -y libopenslide-dev openslide-tools libopenjp2-7 libopenjp2-tools
         python -m pip install --upgrade pip
-        python -m pip install ruff==0.5.7 "pytest<8.3.0" pytest-cov pytest-runner
+        python -m pip install ruff==0.5.7 pytest pytest-cov pytest-runner
         pip install -r requirements/requirements.txt
     - name: Cache tiatoolbox static assets
       uses: actions/cache@v3

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -7,7 +7,7 @@ mypy>=1.6.1
 pip>=22.3
 poetry-bumpversion>=0.3.1
 pre-commit>=2.20.0
-pytest>=7.2.0, <8.3.0
+pytest>=7.2.0
 pytest-cov>=4.0.0
 pytest-runner>=6.0
 pytest-xdist[psutil]

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -112,19 +112,19 @@ class TestSQLite:
         )
 
 
-py_variables = {
+py_variables: dict = {
     "eval_globals": PY_GLOBALS,
     "eval_locals": {"props": SAMPLE_PROPERTIES},
     "check": lambda x: x,
 }
 
-sqlite_variables = {
+sqlite_variables: dict = {
     "eval_globals": SQL_GLOBALS,
     "eval_locals": {"props": SQLJSONDictionary()},
     "check": sqlite_eval,
 }
 
-scenario_python = (
+scenario_python: tuple = (
     "Python",
     {"scenario_variables": py_variables},
 )
@@ -142,7 +142,6 @@ def extract_variables(scenario_variables: dict) -> tuple[dict, dict, Callable]:
     return eval_globals, eval_locals, check
 
 
-# for scenario in (scenario_python, scenario_sqlite):
 class TestPredicate:
     """Test predicate statements with various backends."""
 

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from numbers import Number
-from typing import TYPE_CHECKING, Callable, ClassVar
+from typing import Callable, ClassVar
 
 import pytest
 
@@ -18,9 +18,6 @@ from tiatoolbox.annotation.dsl import (
     json_list_sum,
     py_regexp,
 )
-
-if TYPE_CHECKING:  # pragma: no cover
-    from collections.abc import Mapping
 
 BINARY_OP_STRINGS = [
     "+",
@@ -115,35 +112,48 @@ class TestSQLite:
         )
 
 
-class TestPredicate:
-    """Test predicate statments with various backends."""
+py_variables = {
+    "eval_globals": PY_GLOBALS,
+    "eval_locals": {"props": SAMPLE_PROPERTIES},
+    "check": lambda x: x,
+}
 
-    scenarios: ClassVar[list[str, dict]] = [
-        (
-            "Python",
-            {
-                "eval_globals": PY_GLOBALS,
-                "eval_locals": {"props": SAMPLE_PROPERTIES},
-                "check": lambda x: x,
-            },
-        ),
-        (
-            "SQLite",
-            {
-                "eval_globals": SQL_GLOBALS,
-                "eval_locals": {"props": SQLJSONDictionary()},
-                "check": sqlite_eval,
-            },
-        ),
-    ]
+sqlite_variables = {
+    "eval_globals": SQL_GLOBALS,
+    "eval_locals": {"props": SQLJSONDictionary()},
+    "check": sqlite_eval,
+}
+
+scenario_python = (
+    "Python",
+    {"scenario_variables": py_variables},
+)
+scenario_sqlite = (
+    "SQLite",
+    {"scenario_variables": sqlite_variables},
+)
+
+
+def extract_variables(scenario_variables: dict) -> tuple[dict, dict, Callable]:
+    """Extract variables from scenario variables."""
+    eval_globals = scenario_variables["eval_globals"]
+    eval_locals = scenario_variables["eval_locals"]
+    check = scenario_variables["check"]
+    return eval_globals, eval_locals, check
+
+
+# for scenario in (scenario_python, scenario_sqlite):
+class TestPredicate:
+    """Test predicate statements with various backends."""
+
+    scenarios: ClassVar[list[str, dict]] = [scenario_python, scenario_sqlite]
 
     @staticmethod
     def test_number_binary_operations(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Check that binary operations between ints does not error."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         for op in BINARY_OP_STRINGS:
             query = f"2 {op} 2"
             result = eval(  # skipcq: PYL-W0123
@@ -155,11 +165,10 @@ class TestPredicate:
 
     @staticmethod
     def test_property_binary_operations(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Check that binary operations between properties does not error."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         for op in BINARY_OP_STRINGS:
             query = f"props['int'] {op} props['int']"
             result = eval(  # skipcq: PYL-W0123
@@ -171,11 +180,10 @@ class TestPredicate:
 
     @staticmethod
     def test_r_binary_operations(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test right hand binary operations between numbers and properties."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         for op in BINARY_OP_STRINGS:
             query = f"2 {op} props['int']"
             result = eval(  # skipcq: PYL-W0123
@@ -187,11 +195,10 @@ class TestPredicate:
 
     @staticmethod
     def test_number_prefix_operations(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test prefix operations on numbers."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         for op in PREFIX_OP_STRINGS:
             query = f"{op}1"
             result = eval(  # skipcq: PYL-W0123
@@ -203,11 +210,10 @@ class TestPredicate:
 
     @staticmethod
     def test_property_prefix_operations(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test prefix operations on properties."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         for op in PREFIX_OP_STRINGS:
             query = f"{op}props['int']"
             result = eval(  # skipcq: PYL-W0123
@@ -219,11 +225,10 @@ class TestPredicate:
 
     @staticmethod
     def test_regex_nested_props(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test regex on nested properties."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "props['nesting']['fib'][4]"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -234,11 +239,10 @@ class TestPredicate:
 
     @staticmethod
     def test_regex_str_props(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test regex on string properties."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "regexp('Hello', props['string'])"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -249,11 +253,10 @@ class TestPredicate:
 
     @staticmethod
     def test_regex_str_str(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test regex on string and string."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "regexp('Hello', 'Hello world!')"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -264,11 +267,10 @@ class TestPredicate:
 
     @staticmethod
     def test_regex_props_str(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test regex on property and string."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "regexp(props['string'], 'Hello world!')"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -279,11 +281,10 @@ class TestPredicate:
 
     @staticmethod
     def test_regex_ignore_case(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test regex with ignorecase flag."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "regexp('hello', props['string'], re.IGNORECASE)"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -294,11 +295,10 @@ class TestPredicate:
 
     @staticmethod
     def test_regex_no_match(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test regex with no match."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "regexp('Yello', props['string'])"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -309,11 +309,10 @@ class TestPredicate:
 
     @staticmethod
     def test_has_key(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test has_key function."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "has_key(props, 'foo')"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -324,11 +323,10 @@ class TestPredicate:
 
     @staticmethod
     def test_is_none(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test is_none function."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "is_none(props['null'])"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -339,11 +337,10 @@ class TestPredicate:
 
     @staticmethod
     def test_is_not_none(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test is_not_none function."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "is_not_none(props['int'])"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -354,11 +351,10 @@ class TestPredicate:
 
     @staticmethod
     def test_nested_has_key(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test nested has_key function."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "has_key(props['dict'], 'a')"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -369,11 +365,10 @@ class TestPredicate:
 
     @staticmethod
     def test_list_sum(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test sum function on a list."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "sum(props['list'])"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -384,11 +379,10 @@ class TestPredicate:
 
     @staticmethod
     def test_abs(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test abs function."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "abs(props['neg'])"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -399,11 +393,10 @@ class TestPredicate:
 
     @staticmethod
     def test_not(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test not operator."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "not props['bool']"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -414,11 +407,10 @@ class TestPredicate:
 
     @staticmethod
     def test_props_int_keys(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test props with int keys."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "props['list'][1]"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -429,11 +421,10 @@ class TestPredicate:
 
     @staticmethod
     def test_props_get(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test props.get function."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "is_none(props.get('foo'))"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -444,11 +435,10 @@ class TestPredicate:
 
     @staticmethod
     def test_props_get_default(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test props.get function with default."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "props.get('foo', 42)"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -459,11 +449,10 @@ class TestPredicate:
 
     @staticmethod
     def test_in_list(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test in operator for list."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "1 in props.get('list')"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -474,11 +463,10 @@ class TestPredicate:
 
     @staticmethod
     def test_has_key_exception(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,  # noqa: ARG004
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test has_key function with exception."""
+        eval_globals, eval_locals, _ = extract_variables(scenario_variables)
         query = "has_key(1, 'a')"
         with pytest.raises(TypeError, match="(not iterable)|(Unsupported type)"):
             _ = eval(  # skipcq: PYL-W0123
@@ -489,12 +477,11 @@ class TestPredicate:
 
     @staticmethod
     def test_logical_and(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test logical and operator."""
         query = "props['bool'] & is_none(props['null'])"
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         result = eval(  # skipcq: PYL-W0123
             query,
             eval_globals,
@@ -504,12 +491,11 @@ class TestPredicate:
 
     @staticmethod
     def test_logical_or(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test logical or operator."""
         query = "props['bool'] | (props['int'] < 2)"
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         result = eval(  # skipcq: PYL-W0123
             query,
             eval_globals,
@@ -519,11 +505,10 @@ class TestPredicate:
 
     @staticmethod
     def test_nested_logic(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test nested logical operators."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "(props['bool'] | (props['int'] < 2)) & abs(props['neg'])"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -534,11 +519,10 @@ class TestPredicate:
 
     @staticmethod
     def test_contains_list(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test contains operator for list."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "1 in props['list']"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -549,11 +533,10 @@ class TestPredicate:
 
     @staticmethod
     def test_contains_dict(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test contains operator for dict."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "'a' in props['dict']"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -564,11 +547,10 @@ class TestPredicate:
 
     @staticmethod
     def test_contains_str(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test contains operator for str."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "'Hello' in props['string']"
         result = eval(  # skipcq: PYL-W0123
             query,
@@ -579,11 +561,10 @@ class TestPredicate:
 
     @staticmethod
     def test_key_with_period(
-        eval_globals: dict[str, object],
-        eval_locals: Mapping[str, object],
-        check: Callable,
+        scenario_variables: dict[str, dict],
     ) -> None:
         """Test key with period."""
+        eval_globals, eval_locals, check = extract_variables(scenario_variables)
         query = "props['dot.key']"
         result = eval(  # skipcq: PYL-W0123
             query,


### PR DESCRIPTION
- The new version of `pytest` (>=8.3.0) does not update variables properly in different scenarios. This causes the tests to fail. As a fix I have nested variables in a dictionary and then parse them for each function.
- Remove pin from `pytest` version.