### PR TITLE
🐛 Fix Immutable Output from `WSIReader`

### DIFF
--- a/tiatoolbox/utils/transforms.py
+++ b/tiatoolbox/utils/transforms.py
@@ -53,9 +53,9 @@ def background_composite(
     )
     composite.alpha_composite(image)
     if not alpha:
-        return np.asarray(composite.convert("RGB"))
+        return np.array(composite.convert("RGB"))
 
-    return np.asarray(composite)
+    return np.array(composite)
 
 
 def _convert_scalar_to_width_height(array: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
- Resolve issue #837 

The output of WSI readers (read_rect, read_region, etc) are immutable, i.e. Read-only. We assume that created Numpy arrays created from PIL images in the `background_composite` are mutable by default.
After Numpy v1.16.0, doing np.asarray(pil_image) will return an immutable Numpy array. Gladly, there is an easy fix for this, we should use `np.array()` instead of `np.asarray`.
