### PR TITLE
:heavy_minus_sign: Remove `jinja2` dependency

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -2,7 +2,6 @@
 -r ../docs/requirements.txt
 coverage>=7.0.0
 docutils>=0.18.1
-jinja2>=3.0.3, <3.1.0
 mypy>=1.6.1
 pip>=22.3
 poetry-bumpversion>=0.3.1


### PR DESCRIPTION
-  `jinja2` was explicitly pinned for breaking changes in `sphinx`.
- `sphinx` manages this dependency on its own.