### PR TITLE
:pushpin: Pin `bokeh` version to less than 3.6.0

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 # torch installation
 --extra-index-url https://download.pytorch.org/whl/cu118; sys_platform != "darwin"
 albumentations>=1.3.0
-bokeh>=3.1.1
+bokeh>=3.1.1, <3.6.0
 Click>=8.1.3
 defusedxml>=0.7.1
 filelock>=3.9.0


### PR DESCRIPTION
- Pin `bokeh` version to less than `3.6.0`
- `bokeh` 3.6.0 has breaking changes