### PR TITLE
📌 Pin `zarr<3.0.0`

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -34,4 +34,4 @@ torchvision>=0.15.0
 tqdm>=4.64.1
 umap-learn>=0.5.3
 wsidicom>=0.18.0
-zarr>=2.13.3
+zarr>=2.13.3, <3.0.0


### PR DESCRIPTION
Zarr 3.0 breaks lots of things, probably wont be a quick fix to make toolbox compatible with it, so probably best to pin <3.0 for now

See: https://zarr.readthedocs.io/en/latest/user-guide/v3_migration.html  and #904 for more details