### PR TITLE
:mute: Remove Unnecessary Logging

### DIFF
--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -3873,7 +3873,6 @@ class FsspecJsonWSIReader(WSIReader):
         path = Path(file_path)
 
         if path.suffix.lower() != ".json":
-            logger.error("File does not have a .json extension.")
             return False
 
         try:


### PR DESCRIPTION
 Unnecessary logging was introduced in the https://github.com/TissueImageAnalytics/tiatoolbox/pull/897

The error log now appears in the console on every WSI read. 

