### PR TITLE
:sparkles: Add `dict_to_store_semantic_segmentor`

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1858,3 +1858,76 @@ def test_torch_compile_compatibility(caplog: pytest.LogCaptureFixture) -> None:
 
     is_torch_compile_compatible()
     assert "torch.compile" in caplog.text
+
+
+def test_dict_to_store_semantic_segment() -> None:
+    """Tests multipoint behaviour in dict_to_store."""
+    test_pred = np.zeros(shape=(224, 224))
+
+    patch_output = {"predictions": test_pred}
+
+    store_ = misc.dict_to_store_semantic_segmentor(
+        patch_output=patch_output,
+        scale_factor=(1.0, 1.0),
+        class_dict=None,
+        save_path=None,
+    )
+    assert not store_.values()
+
+    patch_output["predictions"][100, 100] = 1
+
+    store_ = misc.dict_to_store_semantic_segmentor(
+        patch_output=patch_output,
+        scale_factor=(1.0, 1.0),
+        class_dict=None,
+        save_path=None,
+    )
+    assert len(store_) == 1
+
+    annotations_ = store_.values()
+
+    annotations_geometry_type = [
+        str(annotation_.geometry_type) for annotation_ in annotations_
+    ]
+
+    assert "Point" in annotations_geometry_type
+    assert "Polygon" not in annotations_geometry_type
+
+    patch_output["predictions"][110:155, 110:115] = 1
+
+    store_ = misc.dict_to_store_semantic_segmentor(
+        patch_output=patch_output,
+        scale_factor=(1.0, 1.0),
+        class_dict=None,
+        save_path=None,
+    )
+    assert len(store_) == 2
+
+    annotations_ = store_.values()
+
+    annotations_geometry_type = [
+        str(annotation_.geometry_type) for annotation_ in annotations_
+    ]
+
+    assert "Point" in annotations_geometry_type
+    assert "Polygon" in annotations_geometry_type
+
+    patch_output["predictions"][50, 50] = 1
+    patch_output["predictions"][50, 51] = 1
+
+    store_ = misc.dict_to_store_semantic_segmentor(
+        patch_output=patch_output,
+        scale_factor=(1.0, 1.0),
+        class_dict=None,
+        save_path=None,
+    )
+    assert len(store_) == 3
+    annotations_ = store_.values()
+
+    annotations_geometry_type = [
+        str(annotation_.geometry_type) for annotation_ in annotations_
+    ]
+
+    assert "Point" in annotations_geometry_type
+    assert "Polygon" in annotations_geometry_type
+    assert "Line String" in annotations_geometry_type

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -1201,6 +1201,115 @@ def add_from_dat(
     store.append_many(anns)
 
 
+def dict_to_store_semantic_segmentor(
+    patch_output: dict | zarr.group,
+    scale_factor: tuple[float, float],
+    class_dict: dict | None = None,
+    save_path: Path | None = None,
+) -> AnnotationStore | Path:
+    """Converts output of TIAToolbox SemanticSegmentor engine to AnnotationStore.
+
+    Args:
+        patch_output (dict | zarr.Group):
+            A dictionary with "probabilities", "predictions", and "labels" keys.
+        scale_factor (tuple[float, float]):
+            The scale factor to use when loading the
+            annotations. All coordinates will be multiplied by this factor to allow
+            conversion of annotations saved at non-baseline resolution to baseline.
+            Should be model_mpp/slide_mpp.
+        class_dict (dict):
+            Optional dictionary mapping class indices to class names.
+        save_path (str or Path):
+            Optional Output directory to save the Annotation
+            Store results.
+
+    Returns:
+        (SQLiteStore or Path):
+            An SQLiteStore containing Annotations for each patch
+            or Path to file storing SQLiteStore containing Annotations
+            for each patch.
+
+    """
+    preds = patch_output["predictions"]
+
+    # Get the number of unique predictions
+    layer_list = np.unique(preds)
+
+    layer_list = np.delete(layer_list, np.where(layer_list == 0))
+
+    count = 1
+
+    store = SQLiteStore()
+
+    _ = class_dict  # use it once overlay is working
+
+    annotations_list = []
+
+    for type_class in layer_list:
+        layer = np.where(preds == type_class, 1, 0)
+        contours, _ = cv2.findContours(
+            layer.astype("uint8"),
+            cv2.RETR_TREE,
+            cv2.CHAIN_APPROX_NONE,
+        )
+        for layer_ in contours:
+            coords = layer_.squeeze()
+            count += 1
+
+            scaled_coords = np.array([scale_factor * coords])
+
+            # save one points as a line, otherwise save the Polygon
+            if len(layer_) > 2:  # noqa: PLR2004
+                feature_geom = feature2geometry(
+                    {
+                        "type": "Polygon",
+                        "coordinates": scaled_coords,
+                    },
+                )
+                feature_geom = make_valid_poly(feature_geom)
+            # if two points, save as a line string
+            elif len(layer_) == 2:  # noqa: PLR2004
+                feature_geom = feature2geometry(
+                    {
+                        "type": "linestring",
+                        "coordinates": scaled_coords[0],
+                    },
+                )
+            # if single point, save it is a point
+            else:
+                feature_geom = feature2geometry(
+                    {
+                        "type": "point",
+                        "coordinates": scaled_coords,
+                    },
+                )
+
+            annotations_list.extend(
+                [
+                    Annotation(
+                        geometry=feature_geom,
+                        properties={"type": "mask"},
+                    )
+                ]
+            )
+
+    _ = store.append_many(
+        annotations_list, [str(i) for i in range(len(annotations_list))]
+    )
+
+    # # if a save director is provided, then dump store into a file
+    if save_path:
+        # ensure parent directory exists
+        save_path.parent.absolute().mkdir(parents=True, exist_ok=True)
+        # ensure proper db extension
+        save_path = save_path.parent.absolute() / (save_path.stem + ".db")
+        store.commit()
+        store.dump(save_path)
+        return save_path
+
+    return store
+
+
 def dict_to_store(
     patch_output: dict,
     scale_factor: tuple[int, int],


### PR DESCRIPTION
- Add a function to convert the output of TIAToolbox segmentation engine to AnnotationStore.