### PR TITLE
✨ Add Feature to Write Model Probabilities as `ome.tiff` for Overlay

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import shutil
-import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
@@ -16,6 +15,7 @@ import pytest
 import tifffile
 import torch
 import zarr
+from defusedxml import ElementTree as ET  # noqa: N817
 from PIL import Image
 from requests import HTTPError
 from shapely.geometry import Polygon
@@ -1881,8 +1881,7 @@ def parse_ome_xml(xml_string: str | None) -> ET.Element | None:
         ET.register_namespace(
             "ome", "http://www.openmicroscopy.org/Schemas/OME/2016-06"
         )
-        root = ET.fromstring(xml_string)
-        return root
+        return ET.fromstring(xml_string)
     return None
 
 
@@ -1897,19 +1896,20 @@ def assert_ome_metadata_value(
         if pixels_elements:
             actual_value = pixels_elements[0].get(tag)
             assert actual_value == expected_value, (
-                f"Expected attribute '{tag}' to be '{expected_value}', but got '{actual_value}'."
+                f"Expected attribute '{tag}' to be '{expected_value}', "
+                f"but got '{actual_value}'."
             )
             return
 
     # If we reach here, the tag or attribute was not found
-    ET.dump(ome_xml)
-    assert False, f"Attribute '{tag}' not found in OME metadata."
+    pytest.fail(f"Attribute '{tag}' not found in OME metadata.")
 
 
-def test_save_numpy_array(tmp_path: Path) -> None:
+def test_save_numpy_array(tmp_path: Path, source_image: Path) -> None:
     """Tests saving a basic NumPy array."""
     image_path = tmp_path / "numpy_image.ome.tif"
-    img = np.random.randint(0, 256, size=(3, 100, 150), dtype=np.uint8)
+    img = utils.imread(source_image)
+    img = np.transpose(img, (2, 0, 1))
     misc.imwrite_ome_tiff(image_path, img, channels=["Red", "Green", "Blue"])
     assert image_path.is_file()
     saved_img = tifffile.imread(image_path)
@@ -1923,11 +1923,13 @@ def test_save_numpy_array(tmp_path: Path) -> None:
     assert_ome_metadata_value(ome_xml, "DimensionOrder", "XYCZT")
 
 
-def test_save_zarr_array(tmp_path: Path) -> None:
+def test_save_zarr_array(tmp_path: Path, source_image: Path) -> None:
     """Tests saving a Zarr array with uint8 dtype."""
     image_path = tmp_path / "zarr_uint8_image.ome.tif"
     img_zarr = zarr.zeros((2, 80, 120), dtype=np.uint8, chunks=(2, 40, 60))
-    img_zarr[:] = np.random.randint(0, 256, size=(2, 80, 120), dtype=np.uint8)
+    img = utils.imread(source_image)
+    img = img[:, :, 2]
+    img_zarr[:] = np.transpose(img, (2, 0, 1))
 
     misc.imwrite_ome_tiff(image_path, img_zarr)  # Pass the uint8 Zarr array
     assert image_path.is_file()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import shutil
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
@@ -12,10 +13,13 @@ import joblib
 import numpy as np
 import pandas as pd
 import pytest
+import tifffile
 import torch
+import zarr
 from PIL import Image
 from requests import HTTPError
 from shapely.geometry import Polygon
+from tifffile import TiffFile
 
 from tests.test_annotation_stores import cell_polygon
 from tiatoolbox import rcParam, utils
@@ -1858,3 +1862,77 @@ def test_torch_compile_compatibility(caplog: pytest.LogCaptureFixture) -> None:
 
     is_torch_compile_compatible()
     assert "torch.compile" in caplog.text
+
+
+# Tests for OME tiff writer
+
+
+def get_ome_metadata(tiff_path: Path) -> str | None:
+    """Extracts the OME metadata string from a TIFF file."""
+    with TiffFile(tiff_path) as tif:
+        if tif.ome_metadata:
+            return tif.ome_metadata
+    return None
+
+
+def parse_ome_xml(xml_string: str | None) -> ET.Element | None:
+    """Parses the OME XML string into an ElementTree object with namespace awareness."""
+    if xml_string:
+        ET.register_namespace(
+            "ome", "http://www.openmicroscopy.org/Schemas/OME/2016-06"
+        )
+        root = ET.fromstring(xml_string)
+        return root
+    return None
+
+
+def assert_ome_metadata_value(
+    ome_xml: ET.Element, tag: str, expected_value: str
+) -> None:
+    """Asserts the value of a specific OME metadata tag (as an attribute)."""
+    namespace = "{http://www.openmicroscopy.org/Schemas/OME/2016-06}"
+    image_elements = ome_xml.findall(f".//{namespace}Image")
+    if image_elements:
+        pixels_elements = image_elements[0].findall(f"./{namespace}Pixels")
+        if pixels_elements:
+            actual_value = pixels_elements[0].get(tag)
+            assert actual_value == expected_value, (
+                f"Expected attribute '{tag}' to be '{expected_value}', but got '{actual_value}'."
+            )
+            return
+
+    # If we reach here, the tag or attribute was not found
+    ET.dump(ome_xml)
+    assert False, f"Attribute '{tag}' not found in OME metadata."
+
+
+def test_save_numpy_array(tmp_path: Path) -> None:
+    """Tests saving a basic NumPy array."""
+    image_path = tmp_path / "numpy_image.ome.tif"
+    img = np.random.randint(0, 256, size=(100, 150, 3), dtype=np.uint8)
+    misc.imwrite_ome_tiff(image_path, img, tile_size=(64, 64))
+    assert image_path.is_file()
+    saved_img = tifffile.imread(image_path)
+    assert img.shape == saved_img.shape
+    assert img.dtype == saved_img.dtype
+    ome_xml = parse_ome_xml(get_ome_metadata(image_path))
+    assert ome_xml is not None
+    assert_ome_metadata_value(ome_xml, "SizeX", str(img.shape[1]))
+    assert_ome_metadata_value(ome_xml, "SizeY", str(img.shape[0]))
+    assert_ome_metadata_value(ome_xml, "SizeC", str(img.shape[2]))
+    assert_ome_metadata_value(ome_xml, "DimensionOrder", "XYCZT")
+
+
+def test_save_zarr_array(tmp_path: Path) -> None:
+    """Tests saving a Zarr array with uint8 dtype."""
+    image_path = tmp_path / "zarr_uint8_image.ome.tif"
+    img_zarr = zarr.zeros((80, 120, 2), dtype=np.uint8, chunks=(40, 60, 2))
+    img_zarr[:] = np.random.randint(0, 256, size=(80, 120, 2), dtype=np.uint8)
+
+    misc.imwrite_ome_tiff(image_path, img_zarr)  # Pass the uint8 Zarr array
+    assert image_path.is_file()
+    saved_img = tifffile.imread(image_path, squeeze=True)
+    assert img_zarr.shape == saved_img.shape
+    assert saved_img.dtype == np.uint8  # Expect uint8 to be preserved
+    ome_xml = parse_ome_xml(get_ome_metadata(image_path))
+    assert ome_xml is not None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1909,25 +1909,25 @@ def assert_ome_metadata_value(
 def test_save_numpy_array(tmp_path: Path) -> None:
     """Tests saving a basic NumPy array."""
     image_path = tmp_path / "numpy_image.ome.tif"
-    img = np.random.randint(0, 256, size=(100, 150, 3), dtype=np.uint8)
-    misc.imwrite_ome_tiff(image_path, img, tile_size=(64, 64))
+    img = np.random.randint(0, 256, size=(3, 100, 150), dtype=np.uint8)
+    misc.imwrite_ome_tiff(image_path, img, channels=["Red", "Green", "Blue"])
     assert image_path.is_file()
     saved_img = tifffile.imread(image_path)
     assert img.shape == saved_img.shape
     assert img.dtype == saved_img.dtype
     ome_xml = parse_ome_xml(get_ome_metadata(image_path))
     assert ome_xml is not None
-    assert_ome_metadata_value(ome_xml, "SizeX", str(img.shape[1]))
-    assert_ome_metadata_value(ome_xml, "SizeY", str(img.shape[0]))
-    assert_ome_metadata_value(ome_xml, "SizeC", str(img.shape[2]))
+    assert_ome_metadata_value(ome_xml, "SizeX", str(img.shape[2]))
+    assert_ome_metadata_value(ome_xml, "SizeY", str(img.shape[1]))
+    assert_ome_metadata_value(ome_xml, "SizeC", str(img.shape[0]))
     assert_ome_metadata_value(ome_xml, "DimensionOrder", "XYCZT")
 
 
 def test_save_zarr_array(tmp_path: Path) -> None:
     """Tests saving a Zarr array with uint8 dtype."""
     image_path = tmp_path / "zarr_uint8_image.ome.tif"
-    img_zarr = zarr.zeros((80, 120, 2), dtype=np.uint8, chunks=(40, 60, 2))
-    img_zarr[:] = np.random.randint(0, 256, size=(80, 120, 2), dtype=np.uint8)
+    img_zarr = zarr.zeros((2, 80, 120), dtype=np.uint8, chunks=(2, 40, 60))
+    img_zarr[:] = np.random.randint(0, 256, size=(2, 80, 120), dtype=np.uint8)
 
     misc.imwrite_ome_tiff(image_path, img_zarr)  # Pass the uint8 Zarr array
     assert image_path.is_file()
@@ -1936,3 +1936,7 @@ def test_save_zarr_array(tmp_path: Path) -> None:
     assert saved_img.dtype == np.uint8  # Expect uint8 to be preserved
     ome_xml = parse_ome_xml(get_ome_metadata(image_path))
     assert ome_xml is not None
+    assert_ome_metadata_value(ome_xml, "SizeX", str(img_zarr.shape[2]))
+    assert_ome_metadata_value(ome_xml, "SizeY", str(img_zarr.shape[1]))
+    assert_ome_metadata_value(ome_xml, "SizeC", str(img_zarr.shape[0]))
+    assert_ome_metadata_value(ome_xml, "DimensionOrder", "XYCZT")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1899,20 +1899,31 @@ def test_save_numpy_array(tmp_path: Path, source_image: Path) -> None:
     """Tests saving a basic NumPy array."""
     image_path = tmp_path / "numpy_image.ome.tif"
     img = utils.imread(source_image)
-    img = np.transpose(img, (2, 0, 1))
     misc.imwrite_ome_tiff(
-        image_path, img, channels=["Red", "Green", "Blue"], photometric="rgb"
+        image_path=image_path,
+        img=img,
+        tile_size=(10, 15),
+        channels=["Red", "Green", "Blue"],
+        mpp=(0.5, 0.5),
+        photometric="rgb",
     )
     assert image_path.is_file()
     saved_img = tifffile.imread(image_path)
+    saved_img = np.transpose(saved_img, (1, 2, 0))
+    assert np.all(saved_img == img)
     assert img.shape == saved_img.shape
     assert img.dtype == saved_img.dtype
     ome_xml = ET.fromstring(get_ome_metadata(image_path))
     assert ome_xml is not None
-    assert_ome_metadata_value(ome_xml, "SizeX", str(img.shape[2]))
-    assert_ome_metadata_value(ome_xml, "SizeY", str(img.shape[1]))
-    assert_ome_metadata_value(ome_xml, "SizeC", str(img.shape[0]))
+
+    assert_ome_metadata_value(ome_xml, "SizeY", str(img.shape[0]))
+    assert_ome_metadata_value(ome_xml, "SizeX", str(img.shape[1]))
+    assert_ome_metadata_value(ome_xml, "SizeC", str(img.shape[2]))
     assert_ome_metadata_value(ome_xml, "DimensionOrder", "XYCZT")
+    assert_ome_metadata_value(ome_xml, "PhysicalSizeX", "0.5")
+    assert_ome_metadata_value(ome_xml, "PhysicalSizeY", "0.5")
+    assert_ome_metadata_value(ome_xml, "PhysicalSizeXUnit", "µm")
+    assert_ome_metadata_value(ome_xml, "PhysicalSizeYUnit", "µm")
 
 
 def test_save_zarr_array(tmp_path: Path, source_image: Path) -> None:
@@ -1920,19 +1931,20 @@ def test_save_zarr_array(tmp_path: Path, source_image: Path) -> None:
     image_path = tmp_path / "zarr_uint8_image.ome.tif"
 
     img = utils.imread(source_image)
-    img = img[:, :, 0:2]
-    img = np.transpose(img, axes=(2, 0, 1))
-    img_zarr = zarr.zeros(shape=img.shape, dtype=np.uint8, chunks=(2, 40, 60))
+    img = img[:, 0:200, :]
+    img = np.concatenate((img, img), axis=2)
+    img_zarr = zarr.zeros(shape=img.shape, dtype=np.uint8)
     img_zarr[:] = img
 
-    misc.imwrite_ome_tiff(image_path, img_zarr)  # Pass the uint8 Zarr array
+    misc.imwrite_ome_tiff(image_path, img_zarr, tile_size=(10, 20))
     assert image_path.is_file()
     saved_img = tifffile.imread(image_path, squeeze=True)
-    assert img_zarr.shape == saved_img.shape
-    assert saved_img.dtype == np.uint8  # Expect uint8 to be preserved
+    saved_img = np.transpose(saved_img, (1, 2, 0))
+    assert np.all(saved_img == img_zarr)
     ome_xml = ET.fromstring(get_ome_metadata(image_path))
     assert ome_xml is not None
-    assert_ome_metadata_value(ome_xml, "SizeX", str(img_zarr.shape[2]))
-    assert_ome_metadata_value(ome_xml, "SizeY", str(img_zarr.shape[1]))
-    assert_ome_metadata_value(ome_xml, "SizeC", str(img_zarr.shape[0]))
+
+    assert_ome_metadata_value(ome_xml, "SizeY", str(img_zarr.shape[0]))
+    assert_ome_metadata_value(ome_xml, "SizeX", str(img_zarr.shape[1]))
+    assert_ome_metadata_value(ome_xml, "SizeC", str(img_zarr.shape[2]))
     assert_ome_metadata_value(ome_xml, "DimensionOrder", "XYCZT")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1895,6 +1895,28 @@ def assert_ome_metadata_value(
     pytest.fail(f"Attribute '{tag}' not found in OME metadata.")
 
 
+def test_imwrite_ome_tiff_errors(tmp_path: Path) -> None:
+    """Test expected errors in `imwrite_ome_tiff`."""
+    img = np.zeros(shape=(256, 256))
+
+    # Input image must have 3 (CYX) dimensions.
+    with pytest.raises(ValueError, match=r".*must have 3 \(CYX\).*"):
+        misc.imwrite_ome_tiff(
+            image_path=tmp_path / "failed_test.tif",
+            img=img,
+        )
+
+    img = np.zeros(shape=(256, 256, 3))
+    img = torch.from_numpy(img)
+
+    # Input image must be a NumPy array or a Zarr array.
+    with pytest.raises(TypeError, match=r".*must be a NumPy array or a Zarr.*"):
+        misc.imwrite_ome_tiff(
+            image_path=tmp_path / "failed_test.tif",
+            img=img,
+        )
+
+
 def test_save_numpy_array(tmp_path: Path, source_image: Path) -> None:
     """Tests saving a basic NumPy array."""
     image_path = tmp_path / "numpy_image.ome.tif"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1875,6 +1875,21 @@ def get_ome_metadata(tiff_path: Path) -> str | None:
     return None
 
 
+def assert_channel_names_from_ome_metadata(
+    ome_metadata: str, expected_channel_names: list[str]
+) -> None:
+    """Asserts channel naems from OME metadata."""
+    root = ET.fromstring(ome_metadata)
+    namespace = "{http://www.openmicroscopy.org/Schemas/OME/2016-06}"
+    channel_elements = root.findall(
+        f".//{namespace}Image/{namespace}Pixels/{namespace}Channel"
+    )
+    channel_names = [
+        channel.get("Name") for channel in channel_elements if channel.get("Name")
+    ]
+    assert channel_names == expected_channel_names
+
+
 def assert_ome_metadata_value(
     ome_xml: ET.Element, tag: str, expected_value: str
 ) -> None:
@@ -1916,6 +1931,19 @@ def test_imwrite_ome_tiff_errors(tmp_path: Path) -> None:
             img=img,
         )
 
+    img = np.zeros(shape=(256, 256, 3))
+
+    # Input image must be a NumPy array or a Zarr array.
+    with pytest.raises(
+        ValueError,
+        match=r".*This function currently supports photometric = 'minisblack'.*",
+    ):
+        misc.imwrite_ome_tiff(
+            image_path=tmp_path / "failed_test.tif",
+            img=img,
+            photometric="rgb",
+        )
+
 
 def test_save_numpy_array(tmp_path: Path, source_image: Path) -> None:
     """Tests saving a basic NumPy array."""
@@ -1927,7 +1955,7 @@ def test_save_numpy_array(tmp_path: Path, source_image: Path) -> None:
         tile_size=(10, 15),
         channels=["Red", "Green", "Blue"],
         mpp=(0.5, 0.5),
-        photometric="rgb",
+        photometric="minisblack",
     )
     assert image_path.is_file()
     saved_img = tifffile.imread(image_path)
@@ -1946,6 +1974,10 @@ def test_save_numpy_array(tmp_path: Path, source_image: Path) -> None:
     assert_ome_metadata_value(ome_xml, "PhysicalSizeY", "0.5")
     assert_ome_metadata_value(ome_xml, "PhysicalSizeXUnit", "µm")
     assert_ome_metadata_value(ome_xml, "PhysicalSizeYUnit", "µm")
+    assert_channel_names_from_ome_metadata(
+        ome_metadata=get_ome_metadata(image_path),
+        expected_channel_names=["Red", "Green", "Blue"],
+    )
 
 
 def test_save_zarr_array(tmp_path: Path, source_image: Path) -> None:
@@ -1974,3 +2006,14 @@ def test_save_zarr_array(tmp_path: Path, source_image: Path) -> None:
     assert_ome_metadata_value(ome_xml, "PhysicalSizeY", "0.25")
     assert_ome_metadata_value(ome_xml, "PhysicalSizeXUnit", "µm")
     assert_ome_metadata_value(ome_xml, "PhysicalSizeYUnit", "µm")
+    assert_channel_names_from_ome_metadata(
+        ome_metadata=get_ome_metadata(image_path),
+        expected_channel_names=[
+            "Channel1",
+            "Channel2",
+            "Channel3",
+            "Channel4",
+            "Channel5",
+            "Channel6",
+        ],
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1875,21 +1875,6 @@ def get_ome_metadata(tiff_path: Path) -> str | None:
     return None
 
 
-def assert_channel_names_from_ome_metadata(
-    ome_metadata: str, expected_channel_names: list[str]
-) -> None:
-    """Asserts channel naems from OME metadata."""
-    root = ET.fromstring(ome_metadata)
-    namespace = "{http://www.openmicroscopy.org/Schemas/OME/2016-06}"
-    channel_elements = root.findall(
-        f".//{namespace}Image/{namespace}Pixels/{namespace}Channel"
-    )
-    channel_names = [
-        channel.get("Name") for channel in channel_elements if channel.get("Name")
-    ]
-    assert channel_names == expected_channel_names
-
-
 def assert_ome_metadata_value(
     ome_xml: ET.Element, tag: str, expected_value: str
 ) -> None:
@@ -1910,110 +1895,90 @@ def assert_ome_metadata_value(
     pytest.fail(f"Attribute '{tag}' not found in OME metadata.")
 
 
-def test_imwrite_ome_tiff_errors(tmp_path: Path) -> None:
-    """Test expected errors in `imwrite_ome_tiff`."""
-    img = np.zeros(shape=(256, 256))
+def test_iwrite_probability_heatmap_as_ome_tiff_errors(tmp_path: Path) -> None:
+    """Test expected errors in `write_probability_heatmap_as_ome_tiff`."""
+    probability = np.zeros(shape=(256, 256, 3))
 
-    # Input image must have 3 (CYX) dimensions.
-    with pytest.raises(ValueError, match=r".*must have 3 \(YXC\).*"):
-        misc.imwrite_ome_tiff(
+    # Input image must have 2 (CY) dimensions.
+    with pytest.raises(ValueError, match=r".*must have 2 \(YX\).*"):
+        misc.write_probability_heatmap_as_ome_tiff(
             image_path=tmp_path / "failed_test.tif",
-            img=img,
+            probability=probability,
         )
 
-    img = np.zeros(shape=(256, 256, 3))
-    img = torch.from_numpy(img)
+    probability = np.zeros(shape=(256, 256, 3))
+    probability = torch.from_numpy(probability)
 
     # Input image must be a NumPy array or a Zarr array.
     with pytest.raises(TypeError, match=r".*must be a NumPy array or a Zarr.*"):
-        misc.imwrite_ome_tiff(
+        misc.write_probability_heatmap_as_ome_tiff(
             image_path=tmp_path / "failed_test.tif",
-            img=img,
-        )
-
-    img = np.zeros(shape=(256, 256, 3))
-
-    # Input image must be a NumPy array or a Zarr array.
-    with pytest.raises(
-        ValueError,
-        match=r".*This function currently supports photometric = 'minisblack'.*",
-    ):
-        misc.imwrite_ome_tiff(
-            image_path=tmp_path / "failed_test.tif",
-            img=img,
-            photometric="rgb",
+            probability=probability,
         )
 
 
-def test_save_numpy_array(tmp_path: Path, source_image: Path) -> None:
+def test_save_numpy_array_proability_ome_tiff(
+    tmp_path: Path, source_image: Path
+) -> None:
     """Tests saving a basic NumPy array."""
     image_path = tmp_path / "numpy_image.ome.tif"
-    img = utils.imread(source_image)
-    misc.imwrite_ome_tiff(
+    probability = utils.imread(source_image)
+    probability_0 = probability[:, :, 0]
+    misc.write_probability_heatmap_as_ome_tiff(
         image_path=image_path,
-        img=img,
-        tile_size=(10, 15),
-        channels=["Red", "Green", "Blue"],
+        probability=probability_0,
+        tile_size=(64, 64),
         mpp=(0.5, 0.5),
-        photometric="minisblack",
+        levels=2,
+        colormap=cv2.COLORMAP_JET,
     )
     assert image_path.is_file()
     saved_img = tifffile.imread(image_path)
-    saved_img = np.transpose(saved_img, (1, 2, 0))
-    assert np.all(saved_img == img)
-    assert img.shape == saved_img.shape
-    assert img.dtype == saved_img.dtype
+    assert probability.shape == saved_img.shape
+    assert probability.dtype == saved_img.dtype
     ome_xml = ET.fromstring(get_ome_metadata(image_path))
     assert ome_xml is not None
 
-    assert_ome_metadata_value(ome_xml, "SizeY", str(img.shape[0]))
-    assert_ome_metadata_value(ome_xml, "SizeX", str(img.shape[1]))
-    assert_ome_metadata_value(ome_xml, "SizeC", str(img.shape[2]))
+    assert_ome_metadata_value(ome_xml, "SizeY", str(probability.shape[0]))
+    assert_ome_metadata_value(ome_xml, "SizeX", str(probability.shape[1]))
+    assert_ome_metadata_value(ome_xml, "SizeC", str(3))
     assert_ome_metadata_value(ome_xml, "DimensionOrder", "XYCZT")
     assert_ome_metadata_value(ome_xml, "PhysicalSizeX", "0.5")
     assert_ome_metadata_value(ome_xml, "PhysicalSizeY", "0.5")
     assert_ome_metadata_value(ome_xml, "PhysicalSizeXUnit", "µm")
     assert_ome_metadata_value(ome_xml, "PhysicalSizeYUnit", "µm")
-    assert_channel_names_from_ome_metadata(
-        ome_metadata=get_ome_metadata(image_path),
-        expected_channel_names=["Red", "Green", "Blue"],
-    )
 
 
-def test_save_zarr_array(tmp_path: Path, source_image: Path) -> None:
+def test_save_zarr_array_probability_ome_tiff(
+    tmp_path: Path, source_image: Path
+) -> None:
     """Tests saving a Zarr array with uint8 dtype."""
     image_path = tmp_path / "zarr_uint8_image.ome.tif"
 
     img = utils.imread(source_image)
-    img = img[:, 0:200, :]
-    img = np.concatenate((img, img), axis=2)
-    img_zarr = zarr.zeros(shape=img.shape, dtype=np.uint8)
-    img_zarr[:] = img
+    probability = img[:, 0:200, 0]
+    img_zarr = zarr.zeros(shape=probability.shape, dtype=np.uint8)
+    img_zarr[:] = probability
 
-    misc.imwrite_ome_tiff(image_path, img_zarr, tile_size=(10, 20))
+    misc.write_probability_heatmap_as_ome_tiff(
+        image_path,
+        img_zarr,
+        tile_size=(32, 32),
+        levels=2,
+        colormap=cv2.COLORMAP_INFERNO,
+    )
     assert image_path.is_file()
     saved_img = tifffile.imread(image_path, squeeze=True)
-    saved_img = np.transpose(saved_img, (1, 2, 0))
-    assert np.all(saved_img == img_zarr)
+    assert img_zarr.shape == saved_img.shape[0:2]
+    assert img_zarr.dtype == saved_img.dtype
     ome_xml = ET.fromstring(get_ome_metadata(image_path))
     assert ome_xml is not None
 
     assert_ome_metadata_value(ome_xml, "SizeY", str(img_zarr.shape[0]))
     assert_ome_metadata_value(ome_xml, "SizeX", str(img_zarr.shape[1]))
-    assert_ome_metadata_value(ome_xml, "SizeC", str(img_zarr.shape[2]))
+    assert_ome_metadata_value(ome_xml, "SizeC", str(3))
     assert_ome_metadata_value(ome_xml, "DimensionOrder", "XYCZT")
     assert_ome_metadata_value(ome_xml, "PhysicalSizeX", "0.25")
     assert_ome_metadata_value(ome_xml, "PhysicalSizeY", "0.25")
     assert_ome_metadata_value(ome_xml, "PhysicalSizeXUnit", "µm")
     assert_ome_metadata_value(ome_xml, "PhysicalSizeYUnit", "µm")
-    assert_channel_names_from_ome_metadata(
-        ome_metadata=get_ome_metadata(image_path),
-        expected_channel_names=[
-            "Channel1",
-            "Channel2",
-            "Channel3",
-            "Channel4",
-            "Channel5",
-            "Channel6",
-        ],
-    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1875,16 +1875,6 @@ def get_ome_metadata(tiff_path: Path) -> str | None:
     return None
 
 
-def parse_ome_xml(xml_string: str | None) -> ET.Element | None:
-    """Parses the OME XML string into an ElementTree object with namespace awareness."""
-    if xml_string:
-        ET.register_namespace(
-            "ome", "http://www.openmicroscopy.org/Schemas/OME/2016-06"
-        )
-        return ET.fromstring(xml_string)
-    return None
-
-
 def assert_ome_metadata_value(
     ome_xml: ET.Element, tag: str, expected_value: str
 ) -> None:
@@ -1910,12 +1900,14 @@ def test_save_numpy_array(tmp_path: Path, source_image: Path) -> None:
     image_path = tmp_path / "numpy_image.ome.tif"
     img = utils.imread(source_image)
     img = np.transpose(img, (2, 0, 1))
-    misc.imwrite_ome_tiff(image_path, img, channels=["Red", "Green", "Blue"])
+    misc.imwrite_ome_tiff(
+        image_path, img, channels=["Red", "Green", "Blue"], photometric="rgb"
+    )
     assert image_path.is_file()
     saved_img = tifffile.imread(image_path)
     assert img.shape == saved_img.shape
     assert img.dtype == saved_img.dtype
-    ome_xml = parse_ome_xml(get_ome_metadata(image_path))
+    ome_xml = ET.fromstring(get_ome_metadata(image_path))
     assert ome_xml is not None
     assert_ome_metadata_value(ome_xml, "SizeX", str(img.shape[2]))
     assert_ome_metadata_value(ome_xml, "SizeY", str(img.shape[1]))
@@ -1926,17 +1918,19 @@ def test_save_numpy_array(tmp_path: Path, source_image: Path) -> None:
 def test_save_zarr_array(tmp_path: Path, source_image: Path) -> None:
     """Tests saving a Zarr array with uint8 dtype."""
     image_path = tmp_path / "zarr_uint8_image.ome.tif"
-    img_zarr = zarr.zeros((2, 80, 120), dtype=np.uint8, chunks=(2, 40, 60))
+
     img = utils.imread(source_image)
-    img = img[:, :, 2]
-    img_zarr[:] = np.transpose(img, (2, 0, 1))
+    img = img[:, :, 0:2]
+    img = np.transpose(img, axes=(2, 0, 1))
+    img_zarr = zarr.zeros(shape=img.shape, dtype=np.uint8, chunks=(2, 40, 60))
+    img_zarr[:] = img
 
     misc.imwrite_ome_tiff(image_path, img_zarr)  # Pass the uint8 Zarr array
     assert image_path.is_file()
     saved_img = tifffile.imread(image_path, squeeze=True)
     assert img_zarr.shape == saved_img.shape
     assert saved_img.dtype == np.uint8  # Expect uint8 to be preserved
-    ome_xml = parse_ome_xml(get_ome_metadata(image_path))
+    ome_xml = ET.fromstring(get_ome_metadata(image_path))
     assert ome_xml is not None
     assert_ome_metadata_value(ome_xml, "SizeX", str(img_zarr.shape[2]))
     assert_ome_metadata_value(ome_xml, "SizeY", str(img_zarr.shape[1]))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1970,3 +1970,7 @@ def test_save_zarr_array(tmp_path: Path, source_image: Path) -> None:
     assert_ome_metadata_value(ome_xml, "SizeX", str(img_zarr.shape[1]))
     assert_ome_metadata_value(ome_xml, "SizeC", str(img_zarr.shape[2]))
     assert_ome_metadata_value(ome_xml, "DimensionOrder", "XYCZT")
+    assert_ome_metadata_value(ome_xml, "PhysicalSizeX", "0.25")
+    assert_ome_metadata_value(ome_xml, "PhysicalSizeY", "0.25")
+    assert_ome_metadata_value(ome_xml, "PhysicalSizeXUnit", "µm")
+    assert_ome_metadata_value(ome_xml, "PhysicalSizeYUnit", "µm")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1900,7 +1900,7 @@ def test_imwrite_ome_tiff_errors(tmp_path: Path) -> None:
     img = np.zeros(shape=(256, 256))
 
     # Input image must have 3 (CYX) dimensions.
-    with pytest.raises(ValueError, match=r".*must have 3 \(CYX\).*"):
+    with pytest.raises(ValueError, match=r".*must have 3 \(YXC\).*"):
         misc.imwrite_ome_tiff(
             image_path=tmp_path / "failed_test.tif",
             img=img,

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -163,24 +163,25 @@ def imwrite(image_path: PathLike, img: np.ndarray) -> None:
 def imwrite_ome_tiff(
     image_path: PathLike,
     img: np.ndarray | zarr.core.Array,
+    tile_size: tuple[int, int] = (256, 256),
     channels: list[str] | None = None,
     mpp: tuple[float, float] = (0.25, 0.25),
     photometric: str = "minisblack",
 ) -> None:
-    """Saves a NumPy or Zarr array (CYX/CHW) as an OME-TIFF file with metadata.
+    """Saves a NumPy or Zarr array (YXC/HWC) as an OME-TIFF in chunks.
 
     Args:
         image_path (PathLike):
             File path (including extension) to save image to.
         img (np.ndarray or zarr.core.Array):
-            The input image data in CYX (Channels, Height, Width) format.
+            The input image data in YXC (Height, Width, Channels) format.
         tile_size (tuple):
-            Tile size for writing the tiff file. Default is (256, 256).
+            Tile/Chunk size (YX/HW) for writing the tiff file. Default is (256, 256).
         channels (list[str]):
             List containing channel names. This can be an output of a DL model with
             labels.
         mpp (tuple[float, float]):
-            Tuple of mpp values in x and y. Default is (0.25, 0.25).
+            Tuple of mpp values in y and x (YX/HW). Default is (0.25, 0.25).
         photometric (str):
             Color space of image for tifffile. Default is "minisblack".
             *MINISBLACK*: for bilevel and grayscale images, 0 is black.
@@ -194,6 +195,17 @@ def imwrite_ome_tiff(
         ValueError:
             If input dimensions is not 3 (HWC) dimensions.
 
+    Examples:
+        >>> img = imread("path/to/image")
+        >>> imwrite_ome_tiff(
+        ... image_path=image_path,
+        ... img=img,
+        ... tile_size=(10, 15),
+        ... channels=["Red", "Green", "Blue"],
+        ... mpp=(0.5, 0.5),
+        ... photometric="rgb",
+    )
+
     """
     if channels is None:
         channels = []
@@ -206,7 +218,7 @@ def imwrite_ome_tiff(
         raise ValueError(msg)
 
     if not channels:
-        channels = [f"Channel{c + 1}" for c in range(img.shape[0])]
+        channels = [f"Channel{c + 1}" for c in range(img.shape[2])]
 
     ome_metadata = {
         "axes": "CYX",
@@ -220,7 +232,7 @@ def imwrite_ome_tiff(
 
     tifffile.imwrite(
         image_path,
-        shape=img.shape,
+        shape=(img.shape[2], img.shape[0], img.shape[1]),
         dtype=img.dtype,
         metadata=ome_metadata,
         photometric=photometric,
@@ -228,7 +240,15 @@ def imwrite_ome_tiff(
 
     store = tifffile.imread(image_path, mode="r+", aszarr=True)
     z = zarr.open(store, mode="r+")
-    z[:] = img
+
+    for y in range(0, img.shape[0], tile_size[0]):
+        for x in range(0, img.shape[1], tile_size[1]):
+            tile = img[y : y + tile_size[0], x : x + tile_size[1], :]
+
+            # Convert to CYX required by OME-tiff
+            tile = np.transpose(tile, axes=(2, 0, 1))
+            z[:, y : y + tile_size[0], x : x + tile_size[1]] = tile
+
     store.close()
     msg = f"Image saved as OME-TIFF to {image_path}."
     logger.info(msg)

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -167,17 +167,17 @@ def imwrite(image_path: PathLike, img: np.ndarray) -> None:
 def imwrite_ome_tiff(
     image_path: PathLike,
     img: np.ndarray | zarr.core.Array,
-    tile_size: tuple = (256, 256),
+    tile_size: tuple[int, int] = (256, 256),
     channels: list[str] | None = None,
     mpp: tuple[float, float] = (0.25, 0.25),
 ) -> None:
-    """Saves a NumPy or Zarr array (HWC) as an OME-TIFF file with metadata.
+    """Saves a NumPy or Zarr array (YXC/HWC) as an OME-TIFF file with metadata.
 
     Args:
         image_path (PathLike):
             File path (including extension) to save image to.
         img (np.ndarray or zarr.core.Array):
-            The input image data in HWC (Height, Width, Channels) format.
+            The input image data in YXC (Height, Width, Channels) format.
         tile_size (tuple):
             Tile size for writing the tiff file. Default is (256, 256).
         channels (list[str]):
@@ -206,7 +206,7 @@ def imwrite_ome_tiff(
 
     height, width, num_channels = img.shape
 
-    if not channels or len(channels) == 0:
+    if not channels:
         channels = [f"Channel{c + 1}" for c in range(num_channels)]
 
     # Calculate the number of tiles in X and Y
@@ -215,11 +215,11 @@ def imwrite_ome_tiff(
 
     # Construct the base OME metadata as an ElementTree object
     ome = ET.Element("OME", xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06")
-    image_element = ET.SubElement(ome, "Image", ID="Image:0", Name=str(image_path))
+    image_element = ET.Element("Image", ID="Image:0", Name=str(image_path))
     pixels = ET.SubElement(
         image_element,
         "Pixels",
-        DimensionOrder="YXCZT",
+        DimensionOrder="XYCZT",
         ID="Pixels:0",
         Type=str(img.dtype),
     )
@@ -252,17 +252,25 @@ def imwrite_ome_tiff(
 
     # Convert the ElementTree to a string for tifffile
     def prettify_xml(elem: Element) -> str | None:
-        """Prettify OME XML."""
+        """Prettify OME XML using defusedxml for security.
+
+        Args:
+            elem: The XML ElementTree Element to prettify.
+
+        """
         rough_string = ET.tostring(elem, encoding="utf-8", method="xml")
         reparsed = minidom.parseString(rough_string)
         return reparsed.toprettyxml(indent="  ")
 
     ome_metadata_str = prettify_xml(ome)
 
+    # Prepare metadata dictionary for tifffile
+    ome_dict: dict[str, str] = {"ome": ome_metadata_str}
+
     # Iterate through channels and tiles to save chunk-wise
     with TiffWriter(image_path, bigtiff=True) as tif:
         # Write the OME metadata as the first page (with None as data)
-        tif.write(None, metadata=ome_metadata_str)
+        tif.write(None, metadata=ome_dict, dtype=np.uint8, shape=img.shape)
 
         # Iterate through tiles to save chunk-wise
         for y in range(num_tiles_y):
@@ -273,12 +281,8 @@ def imwrite_ome_tiff(
                 start_x = x * tile_size[1]
                 end_x = min((x + 1) * tile_size[1], width)
 
-                # Extract the tile for the current channel (HWC)
+                # Extract the tile for the current channel (YXC/HWC)
                 tile = img[start_y:end_y, start_x:end_x, :]
-
-                # If it's a Zarr array, compute the chunk
-                if isinstance(img, zarr.core.Array):
-                    tile = tile.compute()
 
                 # Ensure the chunk is compatible with JPEG compression
                 if tile.dtype != "uint8":

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -204,7 +204,7 @@ def imwrite_ome_tiff(
         ... channels=["Red", "Green", "Blue"],
         ... mpp=(0.5, 0.5),
         ... photometric="rgb",
-    )
+        ... )
 
     """
     if channels is None:

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -24,12 +24,14 @@ from shapely.affinity import translate
 from shapely.geometry import Polygon
 from shapely.geometry import shape as feature2geometry
 from skimage import exposure
+from tqdm import trange
 
 from tiatoolbox import logger
 from tiatoolbox.annotation.storage import Annotation, AnnotationStore, SQLiteStore
 from tiatoolbox.utils.exceptions import FileNotSupportedError
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Iterator
     from os import PathLike
 
     from shapely import geometry
@@ -158,105 +160,6 @@ def imwrite(image_path: PathLike, img: np.ndarray) -> None:
     if not cv2.imwrite(image_path_str, cv2.cvtColor(img, cv2.COLOR_RGB2BGR)):
         msg = "Could not write image."
         raise OSError(msg)
-
-
-def imwrite_ome_tiff(
-    image_path: PathLike,
-    img: np.ndarray | zarr.core.Array,
-    tile_size: tuple[int, int] = (256, 256),
-    channels: list[str] | None = None,
-    mpp: tuple[float, float] = (0.25, 0.25),
-    photometric: str = "minisblack",
-) -> None:
-    """Saves a NumPy or Zarr array (YXC/HWC) as an OME-TIFF in chunks.
-
-    Args:
-        image_path (PathLike):
-            File path (including extension) to save image to.
-        img (np.ndarray or zarr.core.Array):
-            The input image data in YXC (Height, Width, Channels) format.
-        tile_size (tuple):
-            Tile/Chunk size (YX/HW) for writing the tiff file. Default is (256, 256).
-        channels (list[str]):
-            List containing channel names. This can be an output of a DL model with
-            labels.
-        mpp (tuple[float, float]):
-            Tuple of mpp values in y and x (YX/HW). Default is (0.25, 0.25).
-        photometric (str):
-            Color space of image for tifffile. Default is "minisblack".
-            *MINISBLACK*: for bilevel and grayscale images, 0 is black.
-            See tifffile for more options.
-
-    Raises:
-        TypeError:
-            If the input `img` is not a NumPy or Zarr array or does not have 3
-            dimensions.
-        ValueError:
-            If input dimensions is not 3 (HWC) dimensions.
-
-    Examples:
-        >>> img = imread("path/to/image")
-        >>> imwrite_ome_tiff(
-        ... image_path=image_path,
-        ... img=img,
-        ... tile_size=(10, 15),
-        ... channels=["Red", "Green", "Blue"],
-        ... mpp=(0.5, 0.5),
-        ... photometric="rgb",
-        ... )
-
-    """
-    if channels is None:
-        channels = []
-    if not isinstance(img, (zarr.core.Array, np.ndarray)):
-        msg = "Input 'img' must be a NumPy array or a Zarr array."
-        raise TypeError(msg)
-
-    if img.ndim != 3:  # noqa: PLR2004
-        msg = "Input 'img' must have 3 (YXC) dimensions."
-        raise ValueError(msg)
-
-    if photometric.lower() != "minisblack":
-        msg = (
-            f"photometric = {photometric} is not supported. "
-            f"This function currently supports photometric = 'minisblack'."
-        )
-        raise ValueError(msg)
-
-    if not channels:
-        channels = [f"Channel{c + 1}" for c in range(img.shape[2])]
-
-    ome_metadata = {
-        "axes": "CYX",
-        "PhysicalSizeX": mpp[1],
-        "PhysicalSizeXUnit": "µm",
-        "PhysicalSizeY": mpp[0],
-        "PhysicalSizeYUnit": "µm",
-        "Channel": {"Name": channels},
-    }
-
-    tifffile.imwrite(
-        image_path,
-        shape=(img.shape[2], img.shape[0], img.shape[1]),
-        dtype=img.dtype,
-        metadata=ome_metadata,
-        photometric=photometric,
-    )
-
-    store = tifffile.imread(image_path, mode="r+", aszarr=True)
-    z = zarr.open(store, mode="r+")
-
-    for y in range(0, img.shape[0], tile_size[0]):
-        for x in range(0, img.shape[1], tile_size[1]):
-            tile = img[y : y + tile_size[0], x : x + tile_size[1], :]
-
-            # Convert to CYX required by OME-tiff
-            tile = np.transpose(tile, axes=(2, 0, 1))
-            z[:, y : y + tile_size[0], x : x + tile_size[1]] = tile
-
-    store.close()
-    msg = f"Image saved as OME-TIFF to {image_path}."
-    logger.info(msg)
 
 
 def imread(image_path: PathLike, as_uint8: bool | None = None) -> np.ndarray:
@@ -1381,6 +1284,117 @@ def dict_to_store(
         return save_path
 
     return store
+
+
+def _tiles(
+    in_img: np.ndarray | zarr.core.Array,
+    tile_size: tuple[int, int],
+    colormap: int = cv2.COLORMAP_JET,
+    level: int = 0,
+) -> Iterator[np.ndarray]:
+    for y in trange(0, in_img.shape[0], tile_size[0]):
+        for x in range(0, in_img.shape[1], tile_size[1]):
+            in_img_ = in_img[
+                y : y + tile_size[0] : 2**level, x : x + tile_size[1] : 2**level
+            ]
+            yield cv2.applyColorMap(in_img_, colormap)
+
+
+def write_probability_heatmap_as_ome_tiff(
+    image_path: Path,
+    probability: np.ndarray | zarr.core.Array,
+    tile_size: tuple[int, int] = (64, 64),
+    levels: int = 2,
+    mpp: tuple[float, float] = (0.25, 0.25),
+    colormap: int = cv2.COLORMAP_JET,
+) -> None:
+    """Saves output probability maps from segmentation models as heatmaps.
+
+    This function converts the probability maps from individual classes to heatmaps
+    and saves them as pyramidal ome tiffs.
+
+    Args:
+        image_path (Path):
+            File path (including extension) to save image to.
+        probability (np.ndarray or zarr.core.Array):
+            The input image data in YXC (Height, Width, Channels) format.
+        tile_size (tuple):
+            Tile/Chunk size (YX/HW) for writing the tiff file.
+            Only allows tile shapes allowed by tifffile. Default is (64, 64).
+        levels (int):
+            Number of levels for saving pyramidal ome tiffs. Default is 2.
+        mpp (tuple[float, float]):
+            Tuple of mpp values in y and x (YX/HW). Default is (0.25, 0.25).
+        colormap (int):
+            Colormap to save the heatmaps. Default is 2 (cv2.COLORMAP_JET).
+
+    Raises:
+        TypeError:
+            If the input `img` is not a NumPy or Zarr array or does not have 3
+            dimensions.
+        ValueError:
+            If input dimensions is not 3 (HWC) dimensions.
+
+    Examples:
+        >>> probability_map = imread("path/to/probability_map")
+        >>> write_probability_heatmap_as_ome_tiff(
+        ... image_path=image_path,
+        ... probability=probability_map,
+        ... tile_size=(64, 64),
+        ... class_name="tumor",
+        ... levels=2,
+        ... mpp=(0.5, 0.5),
+        ... colormap=cv2.COLORMAP_JET,
+        ... )
+
+    """
+    if not isinstance(probability, (zarr.core.Array, np.ndarray)):
+        msg = "Input 'probability' must be a NumPy array or a Zarr array."
+        raise TypeError(msg)
+
+    if probability.ndim != 2:  # noqa: PLR2004
+        msg = "Input 'probability' must have 2 (YX) dimensions."
+        raise ValueError(msg)
+
+    ome_metadata = {
+        "axes": "YXC",
+        "PhysicalSizeX": mpp[1],
+        "PhysicalSizeXUnit": "µm",
+        "PhysicalSizeY": mpp[0],
+        "PhysicalSizeYUnit": "µm",
+    }
+
+    h = probability.shape[0]
+    w = probability.shape[1]
+
+    with tifffile.TiffWriter(image_path, bigtiff=True, ome=True) as tif:
+        tif.write(
+            _tiles(in_img=probability, tile_size=tile_size, colormap=colormap),
+            dtype="uint8",
+            shape=(h, w, 3),
+            tile=tile_size,
+            compression="jpeg",
+            metadata=ome_metadata,
+            subifds=levels - 1,
+        )
+
+        for level_ in range(1, levels):
+            tif.write(
+                _tiles(
+                    in_img=probability,
+                    tile_size=tile_size,
+                    colormap=colormap,
+                    level=level_,
+                ),
+                dtype="uint8",
+                shape=(h // 2**level_, w // 2**level_, 3),
+                tile=(tile_size[0] // 2**level_, tile_size[1] // 2**level_),
+                compression="jpeg",
+                subfiletype=0,
+            )
+
+    msg = f"Image saved as OME-TIFF to {image_path}."
+    logger.info(msg)
 
 
 def dict_to_zarr(

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -185,7 +185,6 @@ def imwrite_ome_tiff(
         photometric (str):
             Color space of image for tifffile. Default is "minisblack".
             *MINISBLACK*: for bilevel and grayscale images, 0 is black.
-            *RGB*: the image contains red, green and blue samples.
             See tifffile for more options.
 
     Raises:
@@ -217,12 +216,18 @@ def imwrite_ome_tiff(
         msg = "Input 'img' must have 3 (YXC) dimensions."
         raise ValueError(msg)
 
+    if photometric.lower() != "minisblack":
+        msg = (
+            f"photometric = {photometric} is not supported. "
+            f"This function currently supports photometric = 'minisblack'."
+        )
+        raise ValueError(msg)
+
     if not channels:
         channels = [f"Channel{c + 1}" for c in range(img.shape[2])]
 
     ome_metadata = {
         "axes": "CYX",
-        "SignificantBits": 8,
         "PhysicalSizeX": mpp[1],
         "PhysicalSizeXUnit": "µm",
         "PhysicalSizeY": mpp[0],

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import copy
 import json
-import math
 import shutil
 import tempfile
-import xml.etree.ElementTree as ET
 import zipfile
 from pathlib import Path
 from typing import IO, TYPE_CHECKING
@@ -18,15 +16,14 @@ import numcodecs
 import numpy as np
 import pandas as pd
 import requests
+import tifffile
 import yaml
 import zarr
-from defusedxml import minidom
 from filelock import FileLock
 from shapely.affinity import translate
 from shapely.geometry import Polygon
 from shapely.geometry import shape as feature2geometry
 from skimage import exposure
-from tifffile import TiffWriter
 
 from tiatoolbox import logger
 from tiatoolbox.annotation.storage import Annotation, AnnotationStore, SQLiteStore
@@ -34,7 +31,6 @@ from tiatoolbox.utils.exceptions import FileNotSupportedError
 
 if TYPE_CHECKING:  # pragma: no cover
     from os import PathLike
-    from xml.dom.minidom import Element
 
     from shapely import geometry
 
@@ -167,17 +163,16 @@ def imwrite(image_path: PathLike, img: np.ndarray) -> None:
 def imwrite_ome_tiff(
     image_path: PathLike,
     img: np.ndarray | zarr.core.Array,
-    tile_size: tuple[int, int] = (256, 256),
     channels: list[str] | None = None,
     mpp: tuple[float, float] = (0.25, 0.25),
 ) -> None:
-    """Saves a NumPy or Zarr array (YXC/HWC) as an OME-TIFF file with metadata.
+    """Saves a NumPy or Zarr array (CYX/CHW) as an OME-TIFF file with metadata.
 
     Args:
         image_path (PathLike):
             File path (including extension) to save image to.
         img (np.ndarray or zarr.core.Array):
-            The input image data in YXC (Height, Width, Channels) format.
+            The input image data in CYX (Channels, Height, Width) format.
         tile_size (tuple):
             Tile size for writing the tiff file. Default is (256, 256).
         channels (list[str]):
@@ -201,97 +196,38 @@ def imwrite_ome_tiff(
         raise TypeError(msg)
 
     if img.ndim != 3:  # noqa: PLR2004
-        msg = "Input 'img' must have 3 (HWC) dimensions."
+        msg = "Input 'img' must have 3 (CYX) dimensions."
         raise ValueError(msg)
 
-    height, width, num_channels = img.shape
+    num_channels, height, width = img.shape
 
     if not channels:
         channels = [f"Channel{c + 1}" for c in range(num_channels)]
 
-    # Calculate the number of tiles in X and Y
-    num_tiles_x = math.ceil(width / tile_size[1])
-    num_tiles_y = math.ceil(height / tile_size[0])
+    ome_metadata = {
+        "axes": "CYX",
+        "SignificantBits": 8,
+        "PhysicalSizeX": mpp[1],
+        "PhysicalSizeXUnit": "µm",
+        "PhysicalSizeY": mpp[0],
+        "PhysicalSizeYUnit": "µm",
+        "Channel": {"Name": channels},
+    }
 
-    # Construct the base OME metadata as an ElementTree object
-    ome = ET.Element("OME", xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06")
-    image_element = ET.Element("Image", ID="Image:0", Name=str(image_path))
-    pixels = ET.SubElement(
-        image_element,
-        "Pixels",
-        DimensionOrder="XYCZT",
-        ID="Pixels:0",
-        Type=str(img.dtype),
+    tifffile.imwrite(
+        image_path,
+        shape=img.shape,
+        dtype=img.dtype,
+        metadata=ome_metadata,
+        photometric="minisblack",
     )
-    ET.SubElement(pixels, "SizeX", Value=str(width))
-    ET.SubElement(pixels, "SizeY", Value=str(height))
-    ET.SubElement(pixels, "SizeC", Value=str(num_channels))
-    ET.SubElement(pixels, "SizeZ", Value="1")
-    ET.SubElement(pixels, "SizeT", Value="1")
 
-    for i, c in enumerate(channels):
-        ET.SubElement(pixels, "Channel", ID=f"Channel:{i}", Name=f"{c}")
+    store = tifffile.imread(image_path, mode="r+", aszarr=True)
+    z = zarr.open(store, mode="r+")
+    z[:] = img
+    store.close()
 
-    # Add Plane elements for each tile and channel
-    for c in range(num_channels):
-        for y in range(num_tiles_y):
-            for x in range(num_tiles_x):
-                ET.SubElement(
-                    pixels,
-                    "Plane",
-                    TheC=str(c),
-                    TheZ="0",
-                    TheY=str(y),
-                    TheX=str(x),
-                    TheT="0",
-                )
-
-    # Add the Spatial Calibration (MPP) to the OME metadata
-    ET.SubElement(pixels, "PhysicalSizeX", Value=str(mpp[0]), Unit="µm")
-    ET.SubElement(pixels, "PhysicalSizeY", Value=str(mpp[1]), Unit="µm")
-
-    # Convert the ElementTree to a string for tifffile
-    def prettify_xml(elem: Element) -> str | None:
-        """Prettify OME XML using defusedxml for security.
-
-        Args:
-            elem: The XML ElementTree Element to prettify.
-
-        """
-        rough_string = ET.tostring(elem, encoding="utf-8", method="xml")
-        reparsed = minidom.parseString(rough_string)
-        return reparsed.toprettyxml(indent="  ")
-
-    ome_metadata_str = prettify_xml(ome)
-
-    # Prepare metadata dictionary for tifffile
-    ome_dict: dict[str, str] = {"ome": ome_metadata_str}
-
-    # Iterate through channels and tiles to save chunk-wise
-    with TiffWriter(image_path, bigtiff=True) as tif:
-        # Write the OME metadata as the first page (with None as data)
-        tif.write(None, metadata=ome_dict, dtype=np.uint8, shape=img.shape)
-
-        # Iterate through tiles to save chunk-wise
-        for y in range(num_tiles_y):
-            for x in range(num_tiles_x):
-                # Calculate the start and end indices for the current tile
-                start_y = y * tile_size[0]
-                end_y = min((y + 1) * tile_size[0], height)
-                start_x = x * tile_size[1]
-                end_x = min((x + 1) * tile_size[1], width)
-
-                # Extract the tile for the current channel (YXC/HWC)
-                tile = img[start_y:end_y, start_x:end_x, :]
-
-                # Ensure the chunk is compatible with JPEG compression
-                if tile.dtype != "uint8":
-                    tile = (tile * 255).astype("uint8")
-
-                # Write the chunk with tiling
-                tif.write(tile, tile=tile_size, compression="jpeg")
-
-        logger.info(f"Image saved as OME-TIFF to {image_path}")
+    logger.info(f"Image saved as OME-TIFF to {image_path}")
 
 
 def imread(image_path: PathLike, as_uint8: bool | None = None) -> np.ndarray:

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import copy
 import json
+import math
 import shutil
 import tempfile
+import xml.etree.ElementTree as ET
 import zipfile
 from pathlib import Path
 from typing import IO, TYPE_CHECKING
@@ -18,11 +20,13 @@ import pandas as pd
 import requests
 import yaml
 import zarr
+from defusedxml import minidom
 from filelock import FileLock
 from shapely.affinity import translate
 from shapely.geometry import Polygon
 from shapely.geometry import shape as feature2geometry
 from skimage import exposure
+from tifffile import TiffWriter
 
 from tiatoolbox import logger
 from tiatoolbox.annotation.storage import Annotation, AnnotationStore, SQLiteStore
@@ -30,6 +34,7 @@ from tiatoolbox.utils.exceptions import FileNotSupportedError
 
 if TYPE_CHECKING:  # pragma: no cover
     from os import PathLike
+    from xml.dom.minidom import Element
 
     from shapely import geometry
 
@@ -159,8 +164,134 @@ def imwrite(image_path: PathLike, img: np.ndarray) -> None:
         raise OSError(msg)
 
 
+def imwrite_ome_tiff(
+    image_path: PathLike,
+    img: np.ndarray | zarr.core.Array,
+    tile_size: tuple = (256, 256),
+    channels: list[str] | None = None,
+    mpp: tuple[float, float] = (0.25, 0.25),
+) -> None:
+    """Saves a NumPy or Zarr array (HWC) as an OME-TIFF file with metadata.
+
+    Args:
+        image_path (PathLike):
+            File path (including extension) to save image to.
+        img (np.ndarray or zarr.core.Array):
+            The input image data in HWC (Height, Width, Channels) format.
+        tile_size (tuple):
+            Tile size for writing the tiff file. Default is (256, 256).
+        channels (list[str]):
+            List containing channel names. This can be an output of a DL model with
+            labels.
+        mpp (tuple[float, float]):
+            Tuple of mpp values in x and y. Default is (0.25, 0.25).
+
+    Raises:
+        TypeError:
+            If the input `img` is not a NumPy or Zarr array or does not have 3
+            dimensions.
+        ValueError:
+            If input dimensions is not 3 (HWC) dimensions.
+
+    """
+    if channels is None:
+        channels = []
+    if not isinstance(img, (zarr.core.Array, np.ndarray)):
+        msg = "Input 'img' must be a NumPy array or a Zarr array."
+        raise TypeError(msg)
+
+    if img.ndim != 3:  # noqa: PLR2004
+        msg = "Input 'img' must have 3 (HWC) dimensions."
+        raise ValueError(msg)
+
+    height, width, num_channels = img.shape
+
+    if not channels or len(channels) == 0:
+        channels = [f"Channel{c + 1}" for c in range(num_channels)]
+
+    # Calculate the number of tiles in X and Y
+    num_tiles_x = math.ceil(width / tile_size[1])
+    num_tiles_y = math.ceil(height / tile_size[0])
+
+    # Construct the base OME metadata as an ElementTree object
+    ome = ET.Element("OME", xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06")
+    image_element = ET.SubElement(ome, "Image", ID="Image:0", Name=str(image_path))
+    pixels = ET.SubElement(
+        image_element,
+        "Pixels",
+        DimensionOrder="YXCZT",
+        ID="Pixels:0",
+        Type=str(img.dtype),
+    )
+    ET.SubElement(pixels, "SizeX", Value=str(width))
+    ET.SubElement(pixels, "SizeY", Value=str(height))
+    ET.SubElement(pixels, "SizeC", Value=str(num_channels))
+    ET.SubElement(pixels, "SizeZ", Value="1")
+    ET.SubElement(pixels, "SizeT", Value="1")
+
+    for i, c in enumerate(channels):
+        ET.SubElement(pixels, "Channel", ID=f"Channel:{i}", Name=f"{c}")
+
+    # Add Plane elements for each tile and channel
+    for c in range(num_channels):
+        for y in range(num_tiles_y):
+            for x in range(num_tiles_x):
+                ET.SubElement(
+                    pixels,
+                    "Plane",
+                    TheC=str(c),
+                    TheZ="0",
+                    TheY=str(y),
+                    TheX=str(x),
+                    TheT="0",
+                )
+
+    # Add the Spatial Calibration (MPP) to the OME metadata
+    ET.SubElement(pixels, "PhysicalSizeX", Value=str(mpp[0]), Unit="µm")
+    ET.SubElement(pixels, "PhysicalSizeY", Value=str(mpp[1]), Unit="µm")
+
+    # Convert the ElementTree to a string for tifffile
+    def prettify_xml(elem: Element) -> str | None:
+        """Prettify OME XML."""
+        rough_string = ET.tostring(elem, encoding="utf-8", method="xml")
+        reparsed = minidom.parseString(rough_string)
+        return reparsed.toprettyxml(indent="  ")
+
+    ome_metadata_str = prettify_xml(ome)
+
+    # Iterate through channels and tiles to save chunk-wise
+    with TiffWriter(image_path, bigtiff=True) as tif:
+        # Write the OME metadata as the first page (with None as data)
+        tif.write(None, metadata=ome_metadata_str)
+
+        # Iterate through tiles to save chunk-wise
+        for y in range(num_tiles_y):
+            for x in range(num_tiles_x):
+                # Calculate the start and end indices for the current tile
+                start_y = y * tile_size[0]
+                end_y = min((y + 1) * tile_size[0], height)
+                start_x = x * tile_size[1]
+                end_x = min((x + 1) * tile_size[1], width)
+
+                # Extract the tile for the current channel (HWC)
+                tile = img[start_y:end_y, start_x:end_x, :]
+
+                # If it's a Zarr array, compute the chunk
+                if isinstance(img, zarr.core.Array):
+                    tile = tile.compute()
+
+                # Ensure the chunk is compatible with JPEG compression
+                if tile.dtype != "uint8":
+                    tile = (tile * 255).astype("uint8")
+
+                # Write the chunk with tiling
+                tif.write(tile, tile=tile_size, compression="jpeg")
+
+        logger.info(f"Image saved as OME-TIFF to {image_path}")
+
+
 def imread(image_path: PathLike, as_uint8: bool | None = None) -> np.ndarray:
-    """Read an image as numpy array.
+    """Read an image as a NumPy array.
 
     Args:
         image_path (PathLike):

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -214,7 +214,7 @@ def imwrite_ome_tiff(
         raise TypeError(msg)
 
     if img.ndim != 3:  # noqa: PLR2004
-        msg = "Input 'img' must have 3 (CYX) dimensions."
+        msg = "Input 'img' must have 3 (YXC) dimensions."
         raise ValueError(msg)
 
     if not channels:

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -165,6 +165,7 @@ def imwrite_ome_tiff(
     img: np.ndarray | zarr.core.Array,
     channels: list[str] | None = None,
     mpp: tuple[float, float] = (0.25, 0.25),
+    photometric: str = "minisblack",
 ) -> None:
     """Saves a NumPy or Zarr array (CYX/CHW) as an OME-TIFF file with metadata.
 
@@ -180,6 +181,11 @@ def imwrite_ome_tiff(
             labels.
         mpp (tuple[float, float]):
             Tuple of mpp values in x and y. Default is (0.25, 0.25).
+        photometric (str):
+            Color space of image for tifffile. Default is "minisblack".
+            *MINISBLACK*: for bilevel and grayscale images, 0 is black.
+            *RGB*: the image contains red, green and blue samples.
+            See tifffile for more options.
 
     Raises:
         TypeError:
@@ -199,10 +205,8 @@ def imwrite_ome_tiff(
         msg = "Input 'img' must have 3 (CYX) dimensions."
         raise ValueError(msg)
 
-    num_channels, height, width = img.shape
-
     if not channels:
-        channels = [f"Channel{c + 1}" for c in range(num_channels)]
+        channels = [f"Channel{c + 1}" for c in range(img.shape[0])]
 
     ome_metadata = {
         "axes": "CYX",
@@ -219,15 +223,15 @@ def imwrite_ome_tiff(
         shape=img.shape,
         dtype=img.dtype,
         metadata=ome_metadata,
-        photometric="minisblack",
+        photometric=photometric,
     )
 
     store = tifffile.imread(image_path, mode="r+", aszarr=True)
     z = zarr.open(store, mode="r+")
     z[:] = img
     store.close()
-
-    logger.info(f"Image saved as OME-TIFF to {image_path}")
+    msg = f"Image saved as OME-TIFF to {image_path}."
+    logger.info(msg)
 
 
 def imread(image_path: PathLike, as_uint8: bool | None = None) -> np.ndarray:


### PR DESCRIPTION
- This PR saves a NumPy or Zarr Array to OME tiff. This will help to save probability maps from deep learning models as ome.tiff which can be visualized using TIAViz.
- The image is written as tiles and stitched in OME tiff along with associated necessary metadata for heatmaps generated by segmentation engine.  #866 
- Reading with QuPath has been tested.