### PR TITLE
:pushpin: Pin `tifffile<=2025.5.10`

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -29,7 +29,7 @@ scipy>=1.8
 shapely>=2.0.0
 SimpleITK>=2.2.1
 sphinx>=5.3.0
-tifffile>=2022.10.10
+tifffile>=2022.10.10, <=2025.5.10
 timm>=1.0.3
 torch>=2.1.0
 torchvision>=0.15.0


### PR DESCRIPTION
This PR refines the dependency version requirements by pinning tifffile with an explicit upper bound.  
- Pin tifffile with both a minimum version (2022.10.10) and maximum version (2025.5.10).  
- This ensures controlled compatibility for tifffile across environments.