### PR TITLE
🐛 Fix Contours with Holes

### DIFF
--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -1225,7 +1225,7 @@ def process_contours(
 
     """
     annotations_list: list[Annotation] = []
-    outer_contours: dict[int : np.ndarray] = {}
+    outer_contours: dict[int, np.ndarray] = {}
     holes_dict: dict[int, list[np.ndarray]] = {}
 
     for i, layer_ in enumerate(contours):

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -1225,7 +1225,7 @@ def process_contours(
 
     """
     annotations_list: list[Annotation] = []
-    outer_contours: list[np.ndarray] = []
+    outer_contours: dict[int : np.ndarray] = {}
     holes_dict: dict[int, list[np.ndarray]] = {}
 
     for i, layer_ in enumerate(contours):
@@ -1235,7 +1235,7 @@ def process_contours(
         # save one points as a line, otherwise save the Polygon
         if len(layer_) > 2:  # noqa: PLR2004
             if int(hierarchy[0][i][3]) == -1:  # Outer contour
-                outer_contours.append(scaled_coords[0])
+                outer_contours[i] = scaled_coords[0]
             else:  # Hole
                 parent_idx: int = int(hierarchy[0][i][3])
                 if parent_idx not in holes_dict:
@@ -1274,7 +1274,7 @@ def process_contours(
                 ]
             )
 
-    for idx, outer in enumerate(outer_contours):
+    for idx, outer in outer_contours.items():
         holes: list[np.ndarray] = holes_dict.get(idx, [])
         if len(holes) != 0:
             feature_geom = feature2geometry(


### PR DESCRIPTION
This PR fixes the problem of dict_to_store_semantic_segmentor failing to handle holes properly. The problem was, that the code was not associating the holes with the correct parent contour.

For a segmentation mask like:

<img width="511" height="389" alt="Screenshot 2025-09-19 023727" src="https://github.com/user-attachments/assets/4c2c289a-add3-4238-bb4d-f6db33353849" />

Old code would give an annotation store looking like:

<img width="892" height="658" alt="Screenshot 2025-09-19 024357" src="https://github.com/user-attachments/assets/fad41c8d-ff07-4db4-bc09-ece5c82de9c7" />

With this PR, that store now looks like:

<img width="961" height="666" alt="image" src="https://github.com/user-attachments/assets/cf372cab-95f4-410b-8609-a9bed74d9d46" />
