### PR TITLE
:bug: Fix `sccnn` Model

### DIFF
--- a/tests/models/test_arch_sccnn.py
+++ b/tests/models/test_arch_sccnn.py
@@ -39,15 +39,17 @@ def test_functionality(remote_sample: Callable) -> None:
         units="mpp",
         coord_space="resolution",
     )
-    batch = torch.from_numpy(patch)[None]
     model = _load_sccnn(name="sccnn-crchisto")
+    patch = model.preproc(patch)
+    batch = torch.from_numpy(patch)[None]
     output = model.infer_batch(
         model,
         batch,
         device=select_device(on_gpu=env_detection.has_gpu()),
     )
     output = model.postproc(output[0])
-    assert np.all(output == [[8, 7]])
+    np.testing.assert_array_equal(output, np.array([[8, 7]]))
+
     model = _load_sccnn(name="sccnn-conic")
     output = model.infer_batch(
         model,
@@ -55,4 +57,4 @@ def test_functionality(remote_sample: Callable) -> None:
         device=select_device(on_gpu=env_detection.has_gpu()),
     )
     output = model.postproc(output[0])
-    assert np.all(output == [[7, 8]])
+    np.testing.assert_array_equal(output, np.array([[7, 8]]))

--- a/tiatoolbox/data/pretrained_model.yaml
+++ b/tiatoolbox/data/pretrained_model.yaml
@@ -863,14 +863,14 @@ sccnn-crchisto:
         class: semantic_segmentor.IOSegmentorConfig
         kwargs:
             input_resolutions:
-                - { "units": "mpp", "resolution": 0.5 }
+                - { "units": "mpp", "resolution": 0.25 }
             output_resolutions:
-                - { "units": "mpp", "resolution": 0.5 }
+                - { "units": "mpp", "resolution": 0.25 }
             tile_shape: [ 2048, 2048 ]
             patch_input_shape: [ 31, 31 ]
             patch_output_shape: [ 13, 13 ]
             stride_shape: [ 8, 8 ]
-            save_resolution: { 'units': 'mpp', 'resolution': 0.5 }
+            save_resolution: { 'units': 'mpp', 'resolution': 0.25 }
 
 sccnn-conic:
     hf_repo_id: TIACentre/TIAToolbox_pretrained_weights
@@ -886,14 +886,14 @@ sccnn-conic:
         class: semantic_segmentor.IOSegmentorConfig
         kwargs:
             input_resolutions:
-                - { "units": "mpp", "resolution": 0.5 }
+                - { "units": "mpp", "resolution": 0.25 }
             output_resolutions:
-                - { "units": "mpp", "resolution": 0.5 }
+                - { "units": "mpp", "resolution": 0.25 }
             tile_shape: [ 2048, 2048 ]
             patch_input_shape: [ 31, 31 ]
             patch_output_shape: [ 13, 13 ]
             stride_shape: [ 8, 8 ]
-            save_resolution: { 'units': 'mpp', 'resolution': 0.5 }
+            save_resolution: { 'units': 'mpp', 'resolution': 0.25 }
 
 nuclick_original-pannuke:
     hf_repo_id: TIACentre/TIAToolbox_pretrained_weights

--- a/tiatoolbox/models/architecture/sccnn.py
+++ b/tiatoolbox/models/architecture/sccnn.py
@@ -239,7 +239,7 @@ class SCCNN(ModelABC):
         return sc2 * out_map_threshold
 
     @staticmethod
-    def preproc(image: torch.Tensor) -> torch.Tensor:
+    def preproc(image: np.ndarray) -> np.ndarray:
         """Transforming network input to desired format.
 
         This method is model and dataset specific, meaning that it can be replaced by
@@ -309,7 +309,6 @@ class SCCNN(ModelABC):
             sigmoid2 = sigmoid[:, 2:3, :, :]
             return sigmoid0, sigmoid1, sigmoid2
 
-        input_tensor = self.preproc(input_tensor)
         l1 = self.layer["l1"]["conv1"](input_tensor)
         p1 = self.layer["pool1"](l1)
         l2 = self.layer["l2"]["conv1"](p1)


### PR DESCRIPTION
This pull request fixes issues with the SCCNN model. Solving issue #969 .

- [x] Fix model forward function
- [x] Fix model preproc typing
- [x] Fix tests
- [x] Fix model config 

Firstly, the unit test is fixed by adding `model.preproc(patch)` step before calling `infer_batch()`, pre-processing function is supposed to be applied on the input patch before the model's forward pass in our engines.

In the unit test, `assert` is changed using numpy's assert function to compare two arrays. Previously what happened was the output could be an empty numpy array of shape `(0,2)`, the assert would still return `True`, which was wrong and unsafe. Example:
```python
postproc_output = np.array([]).reshape(0, 2)
print(postproc_output)               # []
print(postproc_output.shape)         # (0, 2)
cmp = (postproc_output == [[8, 7]])
print(cmp)                           # [] with shape (0, 2)
print(np.all(cmp))                   # True (!!)
```

I removed `preproc` from SCCNN's `forward()` function. It should not be used here.

Finally, I updated the input resolution for sccnn models, as from the unit test the resolution seems to be 0.25 mpp.

Regarding issue #969 : Previously the test passes, but as `preproc` was applied in the model's `forward` function. When I tried to run the model inside the `SementicSegmentor` engine, `preproc` was essentially ran twice, once from the `dataloader`, and once again in the `sccnn.forward()` function, which meant the input was divided by 255 twice, therefore the model only outputs zeros as the values were too small.

