### PR TITLE
:pushpin: Update `bokeh` to `3.8.2` and Above

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.8.1
 albumentations>=1.3.0
-bokeh>=3.1.1, <3.6.0
+bokeh>=3.8.2
 Click>=8.2.0
 defusedxml>=0.7.1
 filelock>=3.9.0


### PR DESCRIPTION
- Fix security issue listed in https://github.com/TissueImageAnalytics/tiatoolbox/security/dependabot/3