### PR TITLE
:bug: Fix Division by Count in `SemanticSegmentor`

### DIFF
--- a/tests/engines/test_nucleus_detection_engine.py
+++ b/tests/engines/test_nucleus_detection_engine.py
@@ -264,7 +264,7 @@ def test_nucleus_detector_wsi(remote_sample: Callable, track_tmp_path: Path) -> 
     )
 
     store = SQLiteStore.open(save_dir / "wsi4_512_512.db")
-    assert 255 <= len(store.values()) <= 265
+    assert 245 <= len(store.values()) <= 255
     annotation = next(iter(store.values()))
     assert annotation.properties["type"] == "test_nucleus"
     store.close()
@@ -298,9 +298,9 @@ def test_nucleus_detector_wsi(remote_sample: Callable, track_tmp_path: Path) -> 
     classes = zarr_group["classes"][:]
     probs = zarr_group.get("probabilities", None)
     assert probs is None
-    assert 255 <= len(xs) <= 265
-    assert 255 <= len(ys) <= 265
-    assert 255 <= len(classes) <= 265
+    assert 245 <= len(xs) <= 255
+    assert 245 <= len(ys) <= 255
+    assert 245 <= len(classes) <= 255
 
     _rm_dir(save_dir)
     mini_wsi_svs.unlink()

--- a/tests/engines/test_nucleus_detection_engine.py
+++ b/tests/engines/test_nucleus_detection_engine.py
@@ -303,7 +303,6 @@ def test_nucleus_detector_wsi(remote_sample: Callable, track_tmp_path: Path) -> 
     assert 245 <= len(classes) <= 255
 
     _rm_dir(save_dir)
-    mini_wsi_svs.unlink()
 
 
 # -------------------------------------------------------------------------------------
@@ -330,3 +329,4 @@ def test_cli_model_single_file(remote_sample: Callable, track_tmp_path: Path) ->
 
     assert models_wsi_result.exit_code == 0, models_wsi_result.output
     assert (track_tmp_path / "output" / ("wsi4_512_512" + ".db")).exists()
+    mini_wsi_svs.unlink()

--- a/tests/engines/test_semantic_segmentor.py
+++ b/tests/engines/test_semantic_segmentor.py
@@ -432,7 +432,7 @@ def test_wsi_segmentor_zarr(
 
     output_ = zarr.open(output[sample_svs], mode="r")
     assert 0.17 < np.mean(output_["predictions"][:]) < 0.19
-    assert 0.52 < np.mean(output_["probabilities"][:]) < 0.56
+    assert 0.48 < np.mean(output_["probabilities"][:]) < 0.52
 
     output_ = zarr.open(output[wsi1_2k_2k_svs], mode="r")
     assert 0.24 < np.mean(output_["predictions"][:]) < 0.25
@@ -470,7 +470,7 @@ def test_wsi_segmentor_annotationstore(
         batch_size=32,
         verbose=False,
     )
-    # Return Probabilities is False
+    # Return Probabilities is True
     output = segmentor.run(
         images=[sample_svs],
         return_probabilities=True,
@@ -497,15 +497,16 @@ def test_wsi_segmentor_annotationstore(
 # -------------------------------------------------------------------------------------
 
 
-def test_cli_model_single_file(sample_svs: Path, track_tmp_path: Path) -> None:
+def test_cli_model_single_file(remote_sample: Callable, track_tmp_path: Path) -> None:
     """Test semantic segmentor CLI single file."""
+    wsi4_512_512_svs = remote_sample("wsi4_512_512_svs")
     runner = CliRunner()
     models_wsi_result = runner.invoke(
         cli.main,
         [
             "semantic-segmentor",
             "--img-input",
-            str(sample_svs),
+            str(wsi4_512_512_svs),
             "--patch-mode",
             "False",
             "--output-path",
@@ -514,4 +515,4 @@ def test_cli_model_single_file(sample_svs: Path, track_tmp_path: Path) -> None:
     )
 
     assert models_wsi_result.exit_code == 0
-    assert (track_tmp_path / "output" / (sample_svs.stem + ".db")).exists()
+    assert (track_tmp_path / "output" / (wsi4_512_512_svs.stem + ".db")).exists()

--- a/tiatoolbox/models/engine/semantic_segmentor.py
+++ b/tiatoolbox/models/engine/semantic_segmentor.py
@@ -588,7 +588,7 @@ class SemanticSegmentor(PatchPredictor):
         output_type: str,
         save_path: Path | None = None,
         **kwargs: Unpack[SemanticSegmentorRunParams],
-    ) -> dict | AnnotationStore | Path:
+    ) -> dict | AnnotationStore | Path | list[Path]:
         """Save semantic segmentation predictions to disk or return them in memory.
 
         This method saves predictions in one of the supported formats:
@@ -646,11 +646,11 @@ class SemanticSegmentor(PatchPredictor):
                         Whether to enable verbose logging.
 
         Returns:
-            dict | AnnotationStore | Path:
+            dict | AnnotationStore | Path | list[Path]:
                 - If output_type is "dict": returns predictions as a dictionary.
                 - If output_type is "zarr": returns path to saved Zarr file.
                 - If output_type is "annotationstore": returns AnnotationStore
-                  or path to .db file.
+                  or path or list of paths to .db file.
 
         """
         # Conversion to annotationstore uses a different function for SemanticSegmentor
@@ -679,7 +679,7 @@ class SemanticSegmentor(PatchPredictor):
         # scale_factor set from kwargs
         scale_factor = kwargs.get("scale_factor", (1.0, 1.0))
         # class_dict set from kwargs
-        class_dict = kwargs.get("class_dict")
+        class_dict = kwargs.get("class_dict", self.model.class_dict)
 
         # Need to add support for zarr conversion.
         save_paths = []
@@ -961,7 +961,7 @@ class SemanticSegmentor(PatchPredictor):
 
 
 def concatenate_none(
-    old_arr: np.ndarray | da.Array,
+    old_arr: np.ndarray | da.Array | None,
     new_arr: np.ndarray | da.Array,
 ) -> np.ndarray | da.Array:
     """Concatenate arrays, handling None values gracefully.
@@ -971,7 +971,7 @@ def concatenate_none(
     arrays.
 
     Args:
-        old_arr (np.ndarray | da.Array):
+        old_arr (np.ndarray | da.Array | None):
             Existing array to append to. Can be None.
         new_arr (np.ndarray | da.Array):
             New array to append.
@@ -1024,7 +1024,7 @@ def merge_batch_to_canvas(
             continue
         # To deal with edge cases
         canvas[0 : ye - ys, xs:xe, :] += block[0 : ye - ys, 0 : xe - xs, :]
-        count[ys:ye, xs:xe, 0] += 1
+        count[0 : ye - ys, xs:xe, 0] += 1
     return canvas, count
 
 
@@ -1034,7 +1034,7 @@ def merge_horizontal(
     output_locs_y_: np.ndarray,
     canvas_np: np.ndarray,
     output_locs: np.ndarray,
-    change_indices: np.ndarray | list[np.ndarray],
+    change_indices: np.ndarray | list[int],
 ) -> tuple[da.Array, da.Array, np.ndarray, np.ndarray, np.ndarray]:
     """Merge horizontal patches incrementally for each row of patches.
 
@@ -1283,6 +1283,7 @@ def store_probabilities(
     probabilities_zarr: zarr.Array | None,
     probabilities_da: da.Array | None,
     zarr_group: zarr.Group | None,
+    name: str = "probabilities",
 ) -> tuple[zarr.Array | None, da.Array | None]:
     """Store computed probability data into a Zarr dataset or accumulate in memory.
 
@@ -1301,6 +1302,8 @@ def store_probabilities(
             Existing Dask array for in-memory accumulation.
         zarr_group (zarr.Group | None):
             Zarr group used to create or access the dataset.
+        name (str):
+            Name to create Zarr dataset.
 
     Returns:
         tuple[zarr.Array | None, da.Array | None]:
@@ -1310,7 +1313,7 @@ def store_probabilities(
     if zarr_group is not None:
         if probabilities_zarr is None:
             probabilities_zarr = zarr_group.create_dataset(
-                name="probabilities",
+                name=name,
                 shape=(0, *probabilities.shape[1:]),
                 chunks=(chunk_shape[0], *probabilities.shape[1:]),
                 dtype=probabilities.dtype,

--- a/tiatoolbox/models/models_abc.py
+++ b/tiatoolbox/models/models_abc.py
@@ -92,6 +92,7 @@ class ModelABC(ABC, torch.nn.Module):
         super().__init__()
         self._postproc = self.postproc
         self._preproc = self.preproc
+        self.class_dict = None
 
     @abstractmethod
     # This is generic abc, else pylint will complain


### PR DESCRIPTION
## 🐛 Fix Division by Count in `SemanticSegmentor`

This PR fixes a core issue in patch merging that caused incorrect normalization of segmentation outputs, and includes several related improvements for consistency and correctness.

### Key Fixes

### 1. Correct patch‑merge count accumulation
- The `count` array was indexed incorrectly, so only the first patch row was normalized properly.
- Updated indexing ensures accurate per‑pixel accumulation across all rows.

### 2. Add `class_dict` to all models
- Introduces `class_dict` in `ModelABC`.
- Ensures `SemanticSegmentor` can reliably use class dictionaries when none are passed explicitly.

### 3. Improve output type handling
- `SemanticSegmentor.run()` now correctly indicates that it may return a `list[Path]` when multiple `.db` files are produced.

### 4. More flexible probability storage
- `store_probabilities()` now accepts a `name` parameter, enabling multiple probability datasets in Zarr outputs.

### 5. Test updates
- Adjusted expected nucleus counts and probability means to reflect corrected normalization.
- Updated CLI tests to use remote samples and ensure proper cleanup.
