### PR TITLE
:white_check_mark: Optimize Tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -714,3 +714,15 @@ def module_teardown() -> None:
         if path.exists():
             shutil.rmtree(path)
             print(f"Cleaned up: {path}")
+
+
+@pytest.fixture(scope="session")
+def rm_dir(tmp_samples_path: str) -> Callable:  # noqa: ARG001
+    """Factory fixture to remove directory."""
+
+    def _rm_dir(tmp_samples_path: Path) -> None:
+        """Helper func to remove directory."""
+        if tmp_samples_path.exists():
+            shutil.rmtree(tmp_samples_path, ignore_errors=True)
+
+    return _rm_dir

--- a/tests/engines/test_engine_abc.py
+++ b/tests/engines/test_engine_abc.py
@@ -6,7 +6,6 @@ import copy
 import logging
 import shutil
 from pathlib import Path
-from typing import NoReturn
 
 import dask.array as da
 import numpy as np
@@ -31,65 +30,7 @@ from tiatoolbox.models.engine.io_config import ModelIOConfigABC
 device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
 
-class TestEngineABC(EngineABC):
-    """Test EngineABC."""
-
-    def __init__(
-        self: TestEngineABC,
-        model: str | torch.nn.Module,
-        weights: str | Path | None = None,
-        *,
-        verbose: bool | None = None,
-    ) -> NoReturn:
-        """Test EngineABC init."""
-        super().__init__(model=model, weights=weights, verbose=verbose)
-
-    def get_dataloader(
-        self: EngineABC,
-        images: Path,
-        masks: Path | None = None,
-        labels: list | None = None,
-        ioconfig: ModelIOConfigABC | None = None,
-        *,
-        patch_mode: bool = True,
-    ) -> torch.utils.data.DataLoader:
-        """Test pre process images."""
-        return super().get_dataloader(
-            images,
-            masks,
-            labels,
-            ioconfig,
-            patch_mode=patch_mode,
-        )
-
-    def post_process_wsi(
-        self: EngineABC,
-        raw_predictions: dict | Path,
-        save_path: Path,
-        **kwargs: Unpack[EngineABCRunParams],
-    ) -> dict | Path:
-        """Post process WSI output."""
-        return super().post_process_wsi(
-            raw_predictions=raw_predictions,
-            save_path=save_path,
-            **kwargs,
-        )
-
-    def infer_wsi(
-        self: EngineABC,
-        dataloader: torch.utils.data.DataLoader,
-        save_path: Path,
-        **kwargs: dict,
-    ) -> dict | np.ndarray:
-        """Test infer_wsi."""
-        return super().infer_wsi(  # skipcq: PYL-E1121
-            dataloader,
-            save_path,
-            **kwargs,
-        )
-
-
-def test_engine_abc_incorrect_model_type() -> NoReturn:
+def test_engine_abc_incorrect_model_type() -> None:
     """Test EngineABC initialization with incorrect model type."""
     with pytest.raises(
         TypeError,
@@ -104,19 +45,19 @@ def test_engine_abc_incorrect_model_type() -> NoReturn:
         TestEngineABC(model=1)
 
 
-def test_incorrect_ioconfig() -> NoReturn:
+def test_incorrect_ioconfig() -> None:
     """Test EngineABC initialization with incorrect ioconfig."""
     model = torch_models.resnet18()
-    engine = TestEngineABC(model=model)
+    engine_ = TestEngineABC(model=model)
 
     with pytest.raises(
         ValueError,
         match=r".*Must provide.*`ioconfig`.*",
     ):
-        engine.run(images=[], masks=[], ioconfig=None)
+        engine_.run(images=[], masks=[], ioconfig=None)
 
 
-def test_incorrect_output_type() -> NoReturn:
+def test_incorrect_output_type() -> None:
     """Test EngineABC for incorrect output type."""
     pretrained_model = "alexnet-kather100k"
 
@@ -129,14 +70,14 @@ def test_incorrect_output_type() -> NoReturn:
     ):
         _ = eng.run(
             images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
-            on_gpu=False,
+            device=device,
             patch_mode=True,
             ioconfig=None,
             output_type="random",
         )
 
 
-def test_pretrained_ioconfig() -> NoReturn:
+def test_pretrained_ioconfig() -> None:
     """Test EngineABC initialization with pretrained model name in the toolbox."""
     pretrained_model = "alexnet-kather100k"
 
@@ -144,7 +85,7 @@ def test_pretrained_ioconfig() -> NoReturn:
     eng = TestEngineABC(model=pretrained_model)
     out = eng.run(
         images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
-        on_gpu=False,
+        device=device,
         patch_mode=True,
         ioconfig=None,
     )
@@ -152,7 +93,7 @@ def test_pretrained_ioconfig() -> NoReturn:
     assert "labels" not in out
 
 
-def test_ioconfig() -> NoReturn:
+def test_ioconfig() -> None:
     """Test EngineABC initialization with valid ioconfig."""
     ioconfig = ModelIOConfigABC(
         input_resolutions=[
@@ -174,7 +115,7 @@ def test_ioconfig() -> NoReturn:
 def test_prepare_engines_save_dir(
     track_tmp_path: pytest.TempPathFactory,
     caplog: pytest.LogCaptureFixture,
-) -> NoReturn:
+) -> None:
     """Test prepare save directory for engines."""
     out_dir = prepare_engines_save_dir(
         save_dir=track_tmp_path / "patch_output",
@@ -254,7 +195,7 @@ def test_prepare_engines_save_dir(
         )
 
 
-def test_engine_initalization() -> NoReturn:
+def test_engine_initalization() -> None:
     """Test engine initialization."""
     with pytest.raises(
         TypeError,
@@ -281,7 +222,7 @@ def test_engine_initalization() -> NoReturn:
     assert eng._get_model_attr("test_attr") is True
 
 
-def test_engine_run() -> NoReturn:
+def test_engine_run() -> None:
     """Test engine run."""
     eng = TestEngineABC(model="alexnet-kather100k")
     assert isinstance(eng, EngineABC)
@@ -308,7 +249,7 @@ def test_engine_run() -> NoReturn:
         eng.run(
             images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
             labels=list(range(1)),
-            on_gpu=False,
+            device=device,
         )
 
     with pytest.raises(
@@ -318,7 +259,7 @@ def test_engine_run() -> NoReturn:
         eng.run(
             images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
             masks=np.zeros((1, 224, 224, 3)),
-            on_gpu=False,
+            device=device,
         )
 
     eng = TestEngineABC(model="alexnet-kather100k")
@@ -329,13 +270,13 @@ def test_engine_run() -> NoReturn:
         eng.run(
             images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
             masks=np.zeros((10, 3)),
-            on_gpu=False,
+            device=device,
         )
 
     eng = TestEngineABC(model="alexnet-kather100k")
     out = eng.run(
         images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
-        on_gpu=False,
+        device=device,
         patch_mode=True,
     )
     assert "probabilities" in out
@@ -344,7 +285,7 @@ def test_engine_run() -> NoReturn:
     eng = TestEngineABC(model="alexnet-kather100k")
     out = eng.run(
         images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
-        on_gpu=False,
+        device=device,
         verbose=False,
     )
     assert "probabilities" in out
@@ -354,7 +295,7 @@ def test_engine_run() -> NoReturn:
     out = eng.run(
         images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
         labels=list(range(10)),
-        on_gpu=False,
+        device=device,
     )
     assert "probabilities" in out
     assert "labels" in out
@@ -368,7 +309,7 @@ def test_engine_run() -> NoReturn:
     np.testing.assert_array_equal(pred, raw_output)
 
 
-def test_engine_run_with_verbose() -> NoReturn:
+def test_engine_run_with_verbose() -> None:
     """Test engine run with verbose."""
     # Run pytest with `-rP` option to view progress bar on the captured stderr call.
 
@@ -383,14 +324,14 @@ def test_engine_run_with_verbose() -> NoReturn:
     assert "labels" in out
 
 
-def test_patch_pred_zarr_store(track_tmp_path: pytest.TempPathFactory) -> NoReturn:
+def test_patch_pred_zarr_store(track_tmp_path: pytest.TempPathFactory) -> None:
     """Test the engine run and patch pred store."""
     save_dir = track_tmp_path / "patch_output"
 
     eng = TestEngineABC(model="alexnet-kather100k")
     out = eng.run(
         images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
-        on_gpu=False,
+        device=device,
         save_dir=save_dir,
         overwrite=True,
     )
@@ -399,7 +340,7 @@ def test_patch_pred_zarr_store(track_tmp_path: pytest.TempPathFactory) -> NoRetu
     eng = TestEngineABC(model="alexnet-kather100k")
     out = eng.run(
         images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
-        on_gpu=False,
+        device=device,
         verbose=False,
         save_dir=save_dir,
         overwrite=True,
@@ -410,7 +351,7 @@ def test_patch_pred_zarr_store(track_tmp_path: pytest.TempPathFactory) -> NoRetu
     out = eng.run(
         images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
         labels=list(range(10)),
-        on_gpu=False,
+        device=device,
         save_dir=save_dir,
         overwrite=True,
     )
@@ -421,7 +362,7 @@ def test_patch_pred_zarr_store(track_tmp_path: pytest.TempPathFactory) -> NoRetu
     out = eng.run(
         images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
         labels=list(range(10)),
-        on_gpu=False,
+        device=device,
         save_dir=save_dir,
         overwrite=True,
         output_file="patch_pred_output",
@@ -436,7 +377,7 @@ def test_patch_pred_zarr_store(track_tmp_path: pytest.TempPathFactory) -> NoRetu
         _ = eng.run(
             images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
             labels=list(range(10)),
-            on_gpu=False,
+            device=device,
             save_dir=save_dir,
             overwrite=True,
             output_type="AnnotationStore",
@@ -449,7 +390,7 @@ def test_patch_pred_zarr_store(track_tmp_path: pytest.TempPathFactory) -> NoRetu
         _ = eng.run(
             images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
             labels=list(range(10)),
-            on_gpu=False,
+            device=device,
             save_dir=save_dir,
             overwrite=True,
             output_type="AnnotationStore",
@@ -463,7 +404,7 @@ def test_patch_pred_zarr_store(track_tmp_path: pytest.TempPathFactory) -> NoRetu
         _ = eng.run(
             images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
             labels=list(range(10)),
-            on_gpu=False,
+            device=device,
             save_dir=save_dir,
             overwrite=True,
             output_type="AnnotationStore",
@@ -503,14 +444,14 @@ def test_io_config_delegation(
     """Test for delegating args to io config."""
     # test not providing config / full input info for not pretrained models
     model = CNNModel("resnet50")
-    eng = TestEngineABC(model=model)
+    eng_ = TestEngineABC(model=model)
 
     kwargs = {
-        "patch_input_shape": [224, 224],
+        "patch_input_shape": (224, 224),
         "input_resolutions": [{"units": "mpp", "resolution": 1.75}],
     }
     with caplog.at_level(logging.WARNING):
-        eng.run(
+        eng_.run(
             np.zeros((10, 224, 224, 3)),
             patch_mode=True,
             save_dir=track_tmp_path / "dump",
@@ -526,58 +467,58 @@ def test_io_config_delegation(
         stride_shape=(256, 256),
         input_resolutions=[{"resolution": 1.35, "units": "mpp"}],
     )
-    eng.run(
+    eng_.run(
         images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
         patch_mode=True,
-        save_dir=f"{track_tmp_path}/dump",
+        save_dir=Path(f"{track_tmp_path}/dump"),
         ioconfig=ioconfig,
     )
-    assert eng._ioconfig.patch_input_shape == (224, 224)
-    assert eng._ioconfig.stride_shape == (256, 256)
-    assert eng._ioconfig.input_resolutions == [{"resolution": 1.35, "units": "mpp"}]
+    assert eng_._ioconfig.patch_input_shape == (224, 224)
+    assert eng_._ioconfig.stride_shape == (256, 256)
+    assert eng_._ioconfig.input_resolutions == [{"resolution": 1.35, "units": "mpp"}]
     shutil.rmtree(track_tmp_path / "dump", ignore_errors=True)
 
-    eng.run(
+    eng_.run(
         images=np.zeros((10, 224, 224, 3), dtype=np.uint8),
         patch_mode=True,
-        save_dir=f"{track_tmp_path}/dump",
+        save_dir=Path(f"{track_tmp_path}/dump"),
         **kwargs,
     )
-    assert eng._ioconfig.patch_input_shape == [224, 224]
-    assert eng._ioconfig.stride_shape == [224, 224]
-    assert eng._ioconfig.input_resolutions == [{"resolution": 1.75, "units": "mpp"}]
+    assert eng_._ioconfig.patch_input_shape == (224, 224)
+    assert eng_._ioconfig.stride_shape == (224, 224)
+    assert eng_._ioconfig.input_resolutions == [{"resolution": 1.75, "units": "mpp"}]
     shutil.rmtree(track_tmp_path / "dump", ignore_errors=True)
 
     # test overwriting pretrained ioconfig
-    eng = TestEngineABC(model="alexnet-kather100k")
-    eng.run(
+    eng_ = TestEngineABC(model="alexnet-kather100k")
+    eng_.run(
         images=np.zeros((10, 300, 300, 3), dtype=np.uint8),
         patch_input_shape=(300, 300),
         stride_shape=(300, 300),
         input_resolutions=[{"units": "baseline", "resolution": 1.99}],
         patch_mode=True,
-        save_dir=f"{track_tmp_path}/dump",
+        save_dir=Path(f"{track_tmp_path}/dump"),
     )
-    assert eng._ioconfig.patch_input_shape == (300, 300)
-    assert eng._ioconfig.stride_shape == (300, 300)
-    assert eng._ioconfig.input_resolutions[0]["resolution"] == 1.99
-    assert eng._ioconfig.input_resolutions[0]["units"] == "baseline"
+    assert eng_._ioconfig.patch_input_shape == (300, 300)
+    assert eng_._ioconfig.stride_shape == (300, 300)
+    assert eng_._ioconfig.input_resolutions[0]["resolution"] == 1.99
+    assert eng_._ioconfig.input_resolutions[0]["units"] == "baseline"
     shutil.rmtree(track_tmp_path / "dump", ignore_errors=True)
 
-    eng.run(
+    eng_.run(
         images=np.zeros((10, 300, 300, 3), dtype=np.uint8),
         patch_input_shape=(300, 300),
         stride_shape=(300, 300),
         input_resolutions=None,
         patch_mode=True,
-        save_dir=f"{track_tmp_path}/dump",
+        save_dir=Path(f"{track_tmp_path}/dump"),
     )
-    assert eng._ioconfig.patch_input_shape == (300, 300)
-    assert eng._ioconfig.stride_shape == (300, 300)
+    assert eng_._ioconfig.patch_input_shape == (300, 300)
+    assert eng_._ioconfig.stride_shape == (300, 300)
     shutil.rmtree(track_tmp_path / "dump", ignore_errors=True)
 
-    eng.ioconfig = None
-    _ioconfig = eng._update_ioconfig(
+    eng_.ioconfig = None
+    _ioconfig = eng_._update_ioconfig(
         ioconfig=None,
         patch_input_shape=(300, 300),
         stride_shape=(300, 300),
@@ -597,7 +538,7 @@ def test_io_config_delegation(
             match=r".*Must provide either `ioconfig` or "
             r"`patch_input_shape` and `input_resolutions`*",
         ):
-            eng._update_ioconfig(
+            eng_._update_ioconfig(
                 ioconfig=None,
                 patch_input_shape=_kwargs["patch_input_shape"],
                 stride_shape=(1, 1),
@@ -611,3 +552,61 @@ def test_save_predictions_incorrect_output_type() -> None:
 
     with pytest.raises(TypeError, match=r".*Unsupported output type.* "):
         eng.save_predictions({"predictions": np.zeros((20, 9))}, output_type="random")
+
+
+class TestEngineABC(EngineABC):
+    """Test EngineABC."""
+
+    def __init__(
+        self: TestEngineABC,
+        model: str | torch.nn.Module,
+        weights: str | Path | None = None,
+        *,
+        verbose: bool | None = None,
+    ) -> None:
+        """Test EngineABC init."""
+        super().__init__(model=model, weights=weights, verbose=verbose)
+
+    def get_dataloader(
+        self: EngineABC,
+        images: Path | np.ndarray | list[np.ndarray],
+        masks: Path | None = None,
+        labels: list | None = None,
+        ioconfig: ModelIOConfigABC | None = None,
+        *,
+        patch_mode: bool = True,
+    ) -> torch.utils.data.DataLoader:
+        """Test pre process images."""
+        return super().get_dataloader(
+            images,
+            masks,
+            labels,
+            ioconfig,
+            patch_mode=patch_mode,
+        )
+
+    def post_process_wsi(
+        self: EngineABC,
+        raw_predictions: dict | Path,
+        save_path: Path,
+        **kwargs: Unpack[EngineABCRunParams],
+    ) -> dict | Path:
+        """Post process WSI output."""
+        return super().post_process_wsi(
+            raw_predictions=raw_predictions,
+            save_path=save_path,
+            **kwargs,
+        )
+
+    def infer_wsi(
+        self: EngineABC,
+        dataloader: torch.utils.data.DataLoader,
+        save_path: Path,
+        **kwargs: dict,
+    ) -> dict | np.ndarray:
+        """Test infer_wsi."""
+        return super().infer_wsi(  # skipcq: PYL-E1121
+            dataloader,
+            save_path,
+            **kwargs,
+        )

--- a/tests/engines/test_feature_extractor.py
+++ b/tests/engines/test_feature_extractor.py
@@ -14,6 +14,7 @@ from tiatoolbox import cli
 from tiatoolbox.models import IOPatchPredictorConfig
 from tiatoolbox.models.architecture.vanilla import CNNBackbone, TimmBackbone
 from tiatoolbox.models.engine.deep_feature_extractor import DeepFeatureExtractor
+from tiatoolbox.models.models_abc import ModelABC
 from tiatoolbox.utils import env_detection as toolbox_env
 from tiatoolbox.wsicore.wsireader import WSIReader
 
@@ -68,7 +69,7 @@ def test_feature_extractor_wsi(remote_sample: Callable, track_tmp_path: Path) ->
     """Test feature extraction with DeepFeatureExtractor engine."""
     save_dir = track_tmp_path / "output"
     # # convert to pathlib Path to prevent wsireader complaint
-    mini_wsi_svs = Path(remote_sample("wsi2_4k_4k_svs"))
+    mini_wsi_svs = Path(remote_sample("wsi4_512_512_svs"))
 
     # * test providing pretrained from torch vs pretrained_model.yaml
     shutil.rmtree(save_dir, ignore_errors=True)  # default output dir test
@@ -101,14 +102,14 @@ def test_feature_extractor_wsi(remote_sample: Callable, track_tmp_path: Path) ->
     ],
 )
 def test_full_inference(
-    remote_sample: Callable, track_tmp_path: Path, model: Callable
+    remote_sample: Callable, track_tmp_path: Path, model: ModelABC
 ) -> None:
     """Test full inference with CNNBackbone and TimmBackbone models."""
     save_dir = track_tmp_path / "output"
     # pre-emptive clean up
     shutil.rmtree(save_dir, ignore_errors=True)  # default output dir test
 
-    mini_wsi_svs = Path(remote_sample("wsi4_1k_1k_svs"))
+    mini_wsi_svs = Path(remote_sample("wsi4_512_512_svs"))
 
     ioconfig = IOPatchPredictorConfig(
         input_resolutions=[
@@ -206,16 +207,17 @@ def test_multi_gpu_feature_extraction(
 # -------------------------------------------------------------------------------------
 
 
-def test_cli_model_single_file(sample_svs: Path, track_tmp_path: Path) -> None:
+def test_cli_model_single_file(remote_sample: Callable, track_tmp_path: Path) -> None:
     """Test for feature extractor CLI single file."""
     runner = CliRunner()
+    wsi4_512_512_svs = remote_sample("wsi4_512_512_svs")
 
     models_wsi_result = runner.invoke(
         cli.main,
         [
             "deep-feature-extractor",
             "--img-input",
-            str(sample_svs),
+            str(wsi4_512_512_svs),
             "--model",
             "resnet18",
             "--patch-mode",
@@ -231,11 +233,11 @@ def test_cli_model_single_file(sample_svs: Path, track_tmp_path: Path) -> None:
     )
 
     assert models_wsi_result.exit_code == 0
-    assert (track_tmp_path / "output" / (sample_svs.stem + ".zarr")).exists()
+    assert (track_tmp_path / "output" / (wsi4_512_512_svs.stem + ".zarr")).exists()
 
     output = zarr.open(
-        track_tmp_path / "output" / (sample_svs.stem + ".zarr"), mode="r"
+        str(track_tmp_path / "output" / (wsi4_512_512_svs.stem + ".zarr")), mode="r"
     )
 
     # Output shape should be # of patches x feature size
-    assert output["features"].shape == (255, 512)
+    assert output["features"].shape == (9, 512)

--- a/tests/engines/test_feature_extractor.py
+++ b/tests/engines/test_feature_extractor.py
@@ -65,18 +65,16 @@ def test_feature_extractor_patches(
         )
 
 
-def test_feature_extractor_wsi(remote_sample: Callable, track_tmp_path: Path) -> None:
+def test_feature_extractor_wsi(sample_svs: Path, track_tmp_path: Path) -> None:
     """Test feature extraction with DeepFeatureExtractor engine."""
     save_dir = track_tmp_path / "output"
-    # # convert to pathlib Path to prevent wsireader complaint
-    mini_wsi_svs = Path(remote_sample("wsi4_512_512_svs"))
 
     # * test providing pretrained from torch vs pretrained_model.yaml
     shutil.rmtree(save_dir, ignore_errors=True)  # default output dir test
 
     extractor = DeepFeatureExtractor(batch_size=1, model="fcn-tissue_mask")
     output = extractor.run(
-        images=[mini_wsi_svs],
+        images=[sample_svs],
         return_probabilities=False,
         return_labels=False,
         device=device,
@@ -84,10 +82,10 @@ def test_feature_extractor_wsi(remote_sample: Callable, track_tmp_path: Path) ->
         save_dir=track_tmp_path / "wsi_out_check",
         batch_size=1,
         output_type="zarr",
-        memory_threshold=1,
+        memory_threshold=0,
     )
 
-    output_ = zarr.open(output[mini_wsi_svs], mode="r")
+    output_ = zarr.open(output[sample_svs], mode="r")
     assert len(output_["coordinates"].shape) == 2
     assert len(output_["features"].shape) == 3
 

--- a/tests/engines/test_nucleus_detection_engine.py
+++ b/tests/engines/test_nucleus_detection_engine.py
@@ -1,6 +1,5 @@
 """Tests for NucleusDetector."""
 
-import shutil
 from collections.abc import Callable
 from pathlib import Path
 
@@ -20,12 +19,6 @@ from tiatoolbox.utils.misc import imwrite
 from tiatoolbox.wsicore.wsireader import WSIReader
 
 device = "cuda" if toolbox_env.has_gpu() else "cpu"
-
-
-def _rm_dir(path: Path) -> None:
-    """Helper func to remove directory."""
-    if path.exists():
-        shutil.rmtree(path, ignore_errors=True)
 
 
 def test_centroid_maps_to_detection_arrays() -> None:
@@ -89,14 +82,14 @@ def test_write_detection_records_to_store_no_class_dict() -> None:
 
 
 def test_nucleus_detector_patch_annotation_store_output(
-    remote_sample: Callable, track_tmp_path: Path
+    remote_sample: Callable, track_tmp_path: Path, rm_dir: Callable
 ) -> None:
     """Test for nucleus detection engine in patch mode."""
-    mini_wsi_svs = Path(remote_sample("wsi1_2k_2k_svs"))
+    mini_wsi_svs = Path(remote_sample("wsi4_512_512_svs"))
 
     wsi_reader = WSIReader.open(mini_wsi_svs)
     patch_1 = wsi_reader.read_bounds(
-        (30, 30, 61, 61),
+        (120, 120, 151, 151),
         resolution=0.25,
         units="mpp",
         coord_space="resolution",
@@ -109,11 +102,11 @@ def test_nucleus_detector_patch_annotation_store_output(
 
     nucleus_detector = NucleusDetector(model=pretrained_model)
     _ = nucleus_detector.run(
+        images=[patch_1, patch_2],
         patch_mode=True,
         device=device,
         output_type="annotationstore",
         memory_threshold=50,
-        images=[patch_1, patch_2],
         save_dir=save_dir,
         overwrite=True,
         class_dict=None,
@@ -147,18 +140,18 @@ def test_nucleus_detector_patch_annotation_store_output(
     assert len(store_2.values()) == 0
     store_2.close()
 
-    _rm_dir(save_dir)
+    rm_dir(save_dir)
 
 
 def test_nucleus_detector_patches_dict_output(
     remote_sample: Callable,
 ) -> None:
     """Test for nucleus detection engine in patch mode."""
-    mini_wsi_svs = Path(remote_sample("wsi1_2k_2k_svs"))
+    mini_wsi_svs = Path(remote_sample("wsi4_512_512_svs"))
 
     wsi_reader = WSIReader.open(mini_wsi_svs)
     patch_1 = wsi_reader.read_bounds(
-        (30, 30, 61, 61),
+        (120, 120, 151, 151),
         resolution=0.25,
         units="mpp",
         coord_space="resolution",
@@ -194,13 +187,13 @@ def test_nucleus_detector_patches_dict_output(
 
 
 def test_nucleus_detector_patches_zarr_output(
-    remote_sample: Callable, track_tmp_path: Path
+    remote_sample: Callable, track_tmp_path: Path, rm_dir: Callable
 ) -> None:
     """Test for nucleus detection engine in patch mode."""
-    mini_wsi_svs = Path(remote_sample("wsi1_2k_2k_svs"))
+    mini_wsi_svs = Path(remote_sample("wsi4_512_512_svs"))
     wsi_reader = WSIReader.open(mini_wsi_svs)
     patch_1 = wsi_reader.read_bounds(
-        (30, 30, 61, 61),
+        (120, 120, 151, 151),
         resolution=0.25,
         units="mpp",
         coord_space="resolution",
@@ -236,10 +229,12 @@ def test_nucleus_detector_patches_zarr_output(
     assert output_zarr["probabilities"][0].size == 1
     assert output_zarr["probabilities"][1].size == 0
 
-    _rm_dir(save_dir)
+    rm_dir(save_dir)
 
 
-def test_nucleus_detector_wsi(remote_sample: Callable, track_tmp_path: Path) -> None:
+def test_nucleus_detector_wsi(
+    remote_sample: Callable, track_tmp_path: Path, rm_dir: Callable
+) -> None:
     """Test for nucleus detection engine."""
     mini_wsi_svs = Path(remote_sample("wsi4_512_512_svs"))
 
@@ -302,7 +297,7 @@ def test_nucleus_detector_wsi(remote_sample: Callable, track_tmp_path: Path) -> 
     assert 245 <= len(ys) <= 255
     assert 245 <= len(classes) <= 255
 
-    _rm_dir(save_dir)
+    rm_dir(save_dir)
 
 
 # -------------------------------------------------------------------------------------

--- a/tests/engines/test_patch_predictor.py
+++ b/tests/engines/test_patch_predictor.py
@@ -35,7 +35,7 @@ device = "cuda" if toolbox_env.has_gpu() else "cpu"
 
 def test_io_config_delegation(remote_sample: Callable, track_tmp_path: Path) -> None:
     """Test for delegating args to io config."""
-    mini_wsi_svs = Path(remote_sample("wsi2_4k_4k_svs"))
+    mini_wsi_svs = Path(remote_sample("wsi4_512_512_svs"))
     model = CNNModel("resnet50")
     predictor = PatchPredictor(model=model, weights=None)
     kwargs = {
@@ -492,15 +492,16 @@ def test_patch_predictor_torch_compile(
 # -------------------------------------------------------------------------------------
 
 
-def test_cli_model_single_file(sample_svs: Path, track_tmp_path: Path) -> None:
+def test_cli_model_single_file(remote_sample: Callable, track_tmp_path: Path) -> None:
     """Test for models CLI single file."""
+    wsi4_512_512_svs = remote_sample("wsi4_512_512_svs")
     runner = CliRunner()
     models_wsi_result = runner.invoke(
         cli.main,
         [
             "patch-predictor",
             "--img-input",
-            str(sample_svs),
+            str(wsi4_512_512_svs),
             "--patch-mode",
             "False",
             "--output-path",
@@ -509,7 +510,7 @@ def test_cli_model_single_file(sample_svs: Path, track_tmp_path: Path) -> None:
     )
 
     assert models_wsi_result.exit_code == 0
-    assert (track_tmp_path / "output" / (sample_svs.stem + ".db")).exists()
+    assert (track_tmp_path / "output" / (wsi4_512_512_svs.stem + ".db")).exists()
 
 
 def test_cli_model_multiple_file_mask(

--- a/tests/engines/test_patch_predictor.py
+++ b/tests/engines/test_patch_predictor.py
@@ -9,6 +9,7 @@ import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import dask.array as da
 import numpy as np
 import torch
 import yaml
@@ -244,6 +245,65 @@ def test_patch_predictor_api(
     assert len(output["probabilities"]) == len(output["labels"])
     assert list(output["labels"]) == [1, 2]
 
+    processed_predictions = {
+        k: da.from_array(v) for k, v in output.items() if k != "labels"
+    }
+    processed_predictions["coordinates"] = np.asarray(
+        [[0, 0, 224, 224], [0, 0, 224, 224]]
+    )
+
+    output_ = predictor.save_predictions(
+        processed_predictions=processed_predictions,
+        output_type="annotationstore",
+        save_path=track_tmp_path / "patch_out_check" / "output.db",
+    )
+
+    assert output_.exists()
+    output_ann = _extract_probabilities_from_annotation_store(output_)
+    assert np.all(np.array(output_ann["probabilities"]) <= 1)
+    assert np.all(np.array(output_ann["probabilities"]) >= 0)
+
+
+def test_patch_predictor_patch_mode_no_probabilities(
+    sample_patch1: Path,
+    sample_patch2: Path,
+    track_tmp_path: Path,
+) -> None:
+    """Test the output of patch classification models on Kather100K dataset."""
+    inputs = [Path(sample_patch1), Path(sample_patch2)]
+
+    predictor = PatchPredictor(
+        model="alexnet-kather100k",
+        batch_size=32,
+        verbose=False,
+    )
+
+    output = predictor.run(
+        images=inputs,
+        return_probabilities=False,
+        return_labels=False,
+        device=device,
+        patch_mode=True,
+    )
+
+    assert "probabilities" not in output
+
+    processed_predictions = {k: v for k, v in output.items() if k != "labels"}
+    processed_predictions["coordinates"] = np.asarray(
+        [[0, 0, 224, 224], [0, 0, 224, 224]]
+    )
+
+    output_ = predictor.save_predictions(
+        processed_predictions=processed_predictions,
+        output_type="annotationstore",
+        save_path=track_tmp_path / "patch_out_check" / "output.db",
+    )
+
+    assert output_.exists()
+    output_ann = _extract_probabilities_from_annotation_store(output_)
+    assert np.all(output_ann["predictions"] == [6, 3])
+    assert "probabilities" not in output
+
 
 def test_wsi_predictor_api(
     sample_wsi_dict: dict,
@@ -422,78 +482,6 @@ def test_wsi_predictor_zarr(
     assert output_["predictions"].ndim == 1
     assert _validate_probabilities(output=output_)
     assert "Output file saved at " in caplog.text
-
-
-def test_patch_predictor_patch_mode_annotation_store(
-    sample_patch1: Path,
-    sample_patch2: Path,
-    track_tmp_path: Path,
-) -> None:
-    """Test the output of patch classification models on Kather100K dataset."""
-    inputs = [Path(sample_patch1), Path(sample_patch2)]
-
-    predictor = PatchPredictor(
-        model="alexnet-kather100k",
-        batch_size=32,
-        verbose=False,
-    )
-    # don't run test on GPU
-    output = predictor.run(
-        images=inputs,
-        return_probabilities=True,
-        return_labels=False,
-        device=device,
-        patch_mode=True,
-        save_dir=track_tmp_path / "patch_out_check",
-        output_type="annotationstore",
-    )
-
-    assert output.exists()
-    output = _extract_probabilities_from_annotation_store(output)
-    assert np.all(output["predictions"] == [6, 3])
-    assert np.all(np.array(output["probabilities"]) <= 1)
-    assert np.all(np.array(output["probabilities"]) >= 0)
-
-
-def test_patch_predictor_patch_mode_no_probabilities(
-    sample_patch1: Path,
-    sample_patch2: Path,
-    track_tmp_path: Path,
-) -> None:
-    """Test the output of patch classification models on Kather100K dataset."""
-    inputs = [Path(sample_patch1), Path(sample_patch2)]
-
-    predictor = PatchPredictor(
-        model="alexnet-kather100k",
-        batch_size=32,
-        verbose=False,
-    )
-
-    output = predictor.run(
-        images=inputs,
-        return_probabilities=False,
-        return_labels=False,
-        device=device,
-        patch_mode=True,
-    )
-
-    assert "probabilities" not in output
-
-    # don't run test on GPU
-    output = predictor.run(
-        images=inputs,
-        return_probabilities=False,
-        return_labels=False,
-        device=device,
-        patch_mode=True,
-        save_dir=track_tmp_path / "patch_out_check",
-        output_type="annotationstore",
-    )
-
-    assert output.exists()
-    output = _extract_probabilities_from_annotation_store(output)
-    assert np.all(output["predictions"] == [6, 3])
-    assert output["probabilities"] == []
 
 
 def test_engine_run_wsi_annotation_store(

--- a/tests/engines/test_patch_predictor.py
+++ b/tests/engines/test_patch_predictor.py
@@ -33,58 +33,6 @@ if TYPE_CHECKING:
 device = "cuda" if toolbox_env.has_gpu() else "cpu"
 
 
-def _test_predictor_output(
-    inputs: list,
-    model: str,
-    probabilities_check: list | None = None,
-    classification_check: list | None = None,
-    output_type: str = "dict",
-    track_tmp_path: Path | None = None,
-) -> None:
-    """Test the predictions of multiple models included in tiatoolbox."""
-    cache_mode = None if track_tmp_path is None else True
-    save_dir = None if track_tmp_path is None else track_tmp_path / "output"
-    predictor = PatchPredictor(
-        model=model,
-        batch_size=32,
-        verbose=False,
-    )
-    # don't run test on GPU
-    output = predictor.run(
-        inputs,
-        return_labels=False,
-        device=device,
-        cache_mode=cache_mode,
-        save_dir=save_dir,
-        output_type=output_type,
-        return_probabilities=True,
-    )
-
-    if track_tmp_path is not None:
-        output = zarr.open(output, mode="r")
-
-    probabilities = output["probabilities"]
-    classification = output["predictions"]
-    for idx, probabilities_ in enumerate(probabilities):
-        probabilities_max = max(probabilities_)
-        assert np.abs(probabilities_max - probabilities_check[idx]) <= 1e-3, (
-            model,
-            probabilities_max,
-            probabilities_check[idx],
-            probabilities_,
-            classification_check[idx],
-        )
-        assert classification[idx] == classification_check[idx], (
-            model,
-            probabilities_max,
-            probabilities_check[idx],
-            probabilities_,
-            classification_check[idx],
-        )
-    if save_dir:
-        shutil.rmtree(save_dir)
-
-
 def test_io_config_delegation(remote_sample: Callable, track_tmp_path: Path) -> None:
     """Test for delegating args to io config."""
     mini_wsi_svs = Path(remote_sample("wsi2_4k_4k_svs"))
@@ -105,14 +53,14 @@ def test_io_config_delegation(remote_sample: Callable, track_tmp_path: Path) -> 
         images=[mini_wsi_svs],
         ioconfig=ioconfig,
         patch_mode=False,
-        save_dir=f"{track_tmp_path}/dump",
+        save_dir=Path(f"{track_tmp_path}/dump"),
     )
     shutil.rmtree(track_tmp_path / "dump", ignore_errors=True)
 
     predictor.run(
         images=[mini_wsi_svs],
         patch_mode=False,
-        save_dir=f"{track_tmp_path}/dump",
+        save_dir=Path(f"{track_tmp_path}/dump"),
         **kwargs,
     )
     shutil.rmtree(track_tmp_path / "dump", ignore_errors=True)
@@ -123,7 +71,7 @@ def test_io_config_delegation(remote_sample: Callable, track_tmp_path: Path) -> 
         images=[mini_wsi_svs],
         patch_input_shape=(300, 300),
         patch_mode=False,
-        save_dir=f"{track_tmp_path}/dump",
+        save_dir=Path(f"{track_tmp_path}/dump"),
     )
     assert predictor._ioconfig.patch_input_shape == (300, 300)
     shutil.rmtree(track_tmp_path / "dump", ignore_errors=True)
@@ -132,7 +80,7 @@ def test_io_config_delegation(remote_sample: Callable, track_tmp_path: Path) -> 
         images=[mini_wsi_svs],
         stride_shape=(300, 300),
         patch_mode=False,
-        save_dir=f"{track_tmp_path}/dump",
+        save_dir=Path(f"{track_tmp_path}/dump"),
     )
     assert predictor._ioconfig.stride_shape == (300, 300)
     shutil.rmtree(track_tmp_path / "dump", ignore_errors=True)
@@ -141,7 +89,7 @@ def test_io_config_delegation(remote_sample: Callable, track_tmp_path: Path) -> 
         images=[mini_wsi_svs],
         input_resolutions=[{"units": "mpp", "resolution": 1.99}],
         patch_mode=False,
-        save_dir=f"{track_tmp_path}/dump",
+        save_dir=Path(f"{track_tmp_path}/dump"),
     )
     assert predictor._ioconfig.input_resolutions[0]["resolution"] == 1.99
     shutil.rmtree(track_tmp_path / "dump", ignore_errors=True)
@@ -150,7 +98,7 @@ def test_io_config_delegation(remote_sample: Callable, track_tmp_path: Path) -> 
         images=[mini_wsi_svs],
         input_resolutions=[{"units": "baseline", "resolution": 1.0}],
         patch_mode=False,
-        save_dir=f"{track_tmp_path}/dump",
+        save_dir=Path(f"{track_tmp_path}/dump"),
     )
     assert predictor._ioconfig.input_resolutions[0]["units"] == "baseline"
     shutil.rmtree(track_tmp_path / "dump", ignore_errors=True)
@@ -159,7 +107,7 @@ def test_io_config_delegation(remote_sample: Callable, track_tmp_path: Path) -> 
         images=[mini_wsi_svs],
         input_resolutions=[{"units": "level", "resolution": 0}],
         patch_mode=False,
-        save_dir=f"{track_tmp_path}/dump",
+        save_dir=Path(f"{track_tmp_path}/dump"),
     )
     assert predictor._ioconfig.input_resolutions[0]["units"] == "level"
     assert predictor._ioconfig.input_resolutions[0]["resolution"] == 0
@@ -169,7 +117,7 @@ def test_io_config_delegation(remote_sample: Callable, track_tmp_path: Path) -> 
         images=[mini_wsi_svs],
         input_resolutions=[{"units": "power", "resolution": 20}],
         patch_mode=False,
-        save_dir=f"{track_tmp_path}/dump",
+        save_dir=Path(f"{track_tmp_path}/dump"),
     )
     assert predictor._ioconfig.input_resolutions[0]["units"] == "power"
     assert predictor._ioconfig.input_resolutions[0]["resolution"] == 20
@@ -315,7 +263,7 @@ def test_wsi_predictor_api(
     # Test both Path and str input
     mini_wsi_svs = Path(sample_wsi_dict["wsi2_4k_4k_svs"])
     mini_wsi_jpg = sample_wsi_dict["wsi2_4k_4k_jpg"]
-    mini_wsi_msk = str(sample_wsi_dict["wsi2_4k_4k_msk"])
+    mini_wsi_msk = Path(sample_wsi_dict["wsi2_4k_4k_msk"])
 
     patch_size = np.array([224, 224])
     predictor = PatchPredictor(model="resnet18-kather100k", batch_size=32)
@@ -381,47 +329,6 @@ def test_patch_predictor_kather100k_output(
             classification_check=[6, 3],
             track_tmp_path=track_tmp_path,
         )
-
-
-def _extract_probabilities_from_annotation_store(dbfile: str) -> dict:
-    """Helper function to extract probabilities from Annotation Store."""
-    con = sqlite3.connect(dbfile)
-    cur = con.cursor()
-    annotations_properties = list(cur.execute("SELECT properties FROM annotations"))
-
-    output = {"probabilities": [], "predictions": []}
-
-    for item in annotations_properties:
-        for json_str in item:
-            probs_dict = json.loads(json_str)
-            if "proba_0" in probs_dict:
-                output["probabilities"].append(probs_dict.pop("prob_0"))
-            output["predictions"].append(probs_dict.pop("type"))
-
-    return output
-
-
-def _validate_probabilities(output: list | dict | zarr.group) -> bool:
-    """Helper function to test if the probabilities value are valid."""
-    probabilities = np.array([0.5])
-
-    if "probabilities" in output:
-        probabilities = output["probabilities"]
-
-    predictions = output["predictions"]
-    if isinstance(probabilities, dict):
-        return all(0 <= probability <= 1 for _, probability in probabilities.items())
-
-    predictions = np.array(get_zarr_array(predictions)).astype(int)
-    probabilities = get_zarr_array(probabilities)
-
-    if not np.all(np.array(probabilities) <= 1):
-        return False
-
-    if not np.all(np.array(probabilities) >= 0):
-        return False
-
-    return np.all(predictions[:][0:5] == [7, 3, 2, 3, 3])
 
 
 def test_wsi_predictor_zarr(
@@ -612,7 +519,7 @@ def test_cli_model_multiple_file_mask(
     mini_wsi_svs = Path(remote_sample("svs-1-small"))
     sample_wsi_msk = remote_sample("small_svs_tissue_mask")
     sample_wsi_msk = np.load(sample_wsi_msk).astype(np.uint8)
-    imwrite(f"{track_tmp_path}/small_svs_tissue_mask.jpg", sample_wsi_msk)
+    imwrite(Path(f"{track_tmp_path}/small_svs_tissue_mask.jpg"), sample_wsi_msk)
     mini_wsi_msk = track_tmp_path.joinpath("small_svs_tissue_mask.jpg")
 
     # Make multiple copies for test
@@ -679,3 +586,96 @@ def test_cli_model_multiple_file_mask(
     assert (track_tmp_path / "output" / ("1_" + mini_wsi_svs.stem + ".zarr")).exists()
     assert (track_tmp_path / "output" / ("2_" + mini_wsi_svs.stem + ".zarr")).exists()
     assert (track_tmp_path / "output" / ("3_" + mini_wsi_svs.stem + ".zarr")).exists()
+
+
+def _test_predictor_output(
+    inputs: list,
+    model: str,
+    probabilities_check: list | None = None,
+    classification_check: list | None = None,
+    output_type: str = "dict",
+    track_tmp_path: Path | None = None,
+) -> None:
+    """Test the predictions of multiple models included in tiatoolbox."""
+    cache_mode = None if track_tmp_path is None else True
+    save_dir = None if track_tmp_path is None else track_tmp_path / "output"
+    predictor = PatchPredictor(
+        model=model,
+        batch_size=32,
+        verbose=False,
+    )
+    # don't run test on GPU
+    output = predictor.run(
+        inputs,
+        return_labels=False,
+        device=device,
+        cache_mode=cache_mode,
+        save_dir=save_dir,
+        output_type=output_type,
+        return_probabilities=True,
+    )
+
+    if track_tmp_path is not None:
+        output = zarr.open(output, mode="r")
+
+    probabilities = output["probabilities"]
+    classification = output["predictions"]
+    for idx, probabilities_ in enumerate(probabilities):
+        probabilities_max = max(probabilities_)
+        assert np.abs(probabilities_max - probabilities_check[idx]) <= 1e-3, (
+            model,
+            probabilities_max,
+            probabilities_check[idx],
+            probabilities_,
+            classification_check[idx],
+        )
+        assert classification[idx] == classification_check[idx], (
+            model,
+            probabilities_max,
+            probabilities_check[idx],
+            probabilities_,
+            classification_check[idx],
+        )
+    if save_dir:
+        shutil.rmtree(save_dir)
+
+
+def _extract_probabilities_from_annotation_store(dbfile: str | Path) -> dict:
+    """Helper function to extract probabilities from Annotation Store."""
+    con = sqlite3.connect(dbfile)
+    cur = con.cursor()
+    annotations_properties = list(cur.execute("SELECT properties FROM annotations"))
+
+    output = {"probabilities": [], "predictions": []}
+
+    for item in annotations_properties:
+        for json_str in item:
+            probs_dict = json.loads(json_str)
+            if "proba_0" in probs_dict:
+                output["probabilities"].append(probs_dict.pop("prob_0"))
+            output["predictions"].append(probs_dict.pop("type"))
+
+    return output
+
+
+def _validate_probabilities(output: list | dict | zarr.group) -> bool:
+    """Helper function to test if the probabilities value are valid."""
+    probabilities = np.array([0.5])
+
+    if "probabilities" in output:
+        probabilities = output["probabilities"]
+
+    predictions = output["predictions"]
+    if isinstance(probabilities, dict):
+        return all(0 <= probability <= 1 for _, probability in probabilities.items())
+
+    predictions = np.array(get_zarr_array(predictions)).astype(int)
+    probabilities = get_zarr_array(probabilities)
+
+    if not np.all(np.array(probabilities) <= 1):
+        return False
+
+    if not np.all(np.array(probabilities) >= 0):
+        return False
+
+    return np.all(predictions[:][0:5] == [7, 3, 2, 3, 3])

--- a/tests/engines/test_semantic_segmentor.py
+++ b/tests/engines/test_semantic_segmentor.py
@@ -93,6 +93,8 @@ def test_semantic_segmentor_patches(
     assert 0.62 < np.mean(output["predictions"][:]) < 0.66
     assert 0.48 < np.mean(output["probabilities"][:]) < 0.52
 
+    # Test str input
+    inputs = [Path(sample_image)]
     output = segmentor.run(
         images=inputs,
         return_probabilities=False,
@@ -105,53 +107,25 @@ def test_semantic_segmentor_patches(
 
     assert output == track_tmp_path / "output1" / "output.zarr"
 
-    output = zarr.open(output, mode="r")
-    assert 0.62 < np.mean(output["predictions"][:]) < 0.66
-    assert "probabilities" not in output.keys()  # noqa: SIM118
+    output_ = zarr.open(output, mode="r")
+    assert 0.62 < np.mean(output_["predictions"][:]) < 0.66
+    assert "probabilities" not in output_.keys()  # noqa: SIM118
+    assert "predictions" in output_
 
-    output = segmentor.run(
-        images=inputs,
-        return_probabilities=False,
-        return_labels=False,
-        device=device,
-        patch_mode=True,
-        save_dir=track_tmp_path / "output2",
-        output_type="zarr",
+    processed_predictions = {
+        k: da.from_zarr(v) for k, v in output_.items() if k != "labels"
+    }
+
+    # Test for saving output as annotation store.
+    output_seg = segmentor.save_predictions(
+        processed_predictions=processed_predictions,
+        output_type="annotationstore",
+        save_path=output.with_suffix(".db"),
     )
 
-    assert output == track_tmp_path / "output2" / "output.zarr"
-
-    output = zarr.open(output, mode="r")
-    assert 0.62 < np.mean(output["predictions"][:]) < 0.66
-    assert "probabilities" not in output
-    assert "predictions" in output
-
-
-def _test_store_output_patch(output: Path) -> None:
-    """Helper method to test annotation store output for a patch."""
-    store_ = SQLiteStore.open(output)
-    annotations_ = store_.values()
-    annotations_geometry_type = [
-        str(annotation_.geometry_type) for annotation_ in annotations_
-    ]
-    assert "Polygon" in annotations_geometry_type
-
-    con = sqlite3.connect(output)
-    cur = con.cursor()
-    annotations_properties = list(cur.execute("SELECT properties FROM annotations"))
-
-    annotation_types = set()
-
-    for item in annotations_properties:
-        for json_str in item:
-            probs = json.loads(json_str)
-            if "type" in probs:
-                annotation_types.add(probs.pop("type"))
-    # When class_dict is none, types are assigned as 0, 1, ...
-    assert 0 in annotation_types
-    assert 1 in annotation_types
-
-    assert annotations_properties is not None
+    assert output_seg[0] == track_tmp_path / "output1" / (sample_image.stem + ".db")
+    assert len(output_seg) == 1
+    _test_store_output_patch(output_seg[0])
 
 
 def test_semantic_segmentor_tiles(track_tmp_path: Path) -> None:
@@ -181,39 +155,11 @@ def test_semantic_segmentor_tiles(track_tmp_path: Path) -> None:
         input_resolutions=[{"units": "baseline", "resolution": 1.0}],
         patch_input_shape=(1024, 1024),
     )
-    print(output)
     output = zarr.open(output[sample_image], mode="r")
 
     assert output["predictions"].shape == (2048, 3584)
 
     sample_image.unlink()
-
-
-def test_save_annotation_store(remote_sample: Callable, track_tmp_path: Path) -> None:
-    """Test for saving output as annotation store."""
-    segmentor = SemanticSegmentor(
-        model="fcn-tissue_mask", batch_size=32, verbose=False, device=device
-    )
-
-    # Test str input
-    sample_image = remote_sample("thumbnail-1k-1k")
-
-    inputs = [str(sample_image)]
-
-    output = segmentor.run(
-        images=inputs,
-        return_probabilities=False,
-        return_labels=False,
-        device=device,
-        patch_mode=True,
-        save_dir=track_tmp_path / "output1",
-        output_type="annotationstore",
-        verbose=True,
-    )
-
-    assert output[0] == track_tmp_path / "output1" / (sample_image.stem + ".db")
-    assert len(output) == 1
-    _test_store_output_patch(output[0])
 
 
 def test_save_annotation_store_nparray(
@@ -394,10 +340,11 @@ def test_merge_vertical_chunkwise_memory_threshold_triggered() -> None:
 
 
 def test_raise_value_error_return_labels_wsi(
-    sample_svs: Path,
+    remote_sample: Callable,
     track_tmp_path: Path,
 ) -> None:
     """Test for raises value error for return_labels in wsi mode."""
+    wsi4_512_512_svs = remote_sample("wsi4_512_512_svs")
     segmentor = SemanticSegmentor(
         model="fcn-tissue_mask",
         batch_size=64,
@@ -409,7 +356,7 @@ def test_raise_value_error_return_labels_wsi(
         match=r".*return_labels` is not supported when `patch_mode` is False",
     ):
         _ = segmentor.run(
-            images=[sample_svs],
+            images=[wsi4_512_512_svs],
             return_probabilities=False,
             return_labels=True,
             device=device,
@@ -426,7 +373,7 @@ def test_wsi_segmentor_zarr(
     track_tmp_path: Path,
 ) -> None:
     """Test SemanticSegmentor for WSIs with zarr output."""
-    wsi1_2k_2k_svs = Path(remote_sample("wsi1_2k_2k_svs"))
+    wsi4_512_512_svs = Path(remote_sample("wsi4_512_512_svs"))
 
     segmentor = SemanticSegmentor(
         model="fcn-tissue_mask",
@@ -436,7 +383,7 @@ def test_wsi_segmentor_zarr(
     )
     # Return Probabilities is False
     output = segmentor.run(
-        images=[sample_svs],
+        images=[wsi4_512_512_svs],
         return_probabilities=False,
         return_labels=False,
         device=device,
@@ -447,8 +394,8 @@ def test_wsi_segmentor_zarr(
         memory_threshold=1,
     )
 
-    output_ = zarr.open(output[sample_svs], mode="r")
-    assert 0.17 < np.mean(output_["predictions"][:]) < 0.21
+    output_ = zarr.open(output[wsi4_512_512_svs], mode="r")
+    assert 0.0 < np.mean(output_["predictions"][:]) < 0.02
     assert "probabilities" not in output_
     assert "canvas" not in output_
     assert "count" not in output_
@@ -462,7 +409,7 @@ def test_wsi_segmentor_zarr(
     # Return Probabilities is True
     # Testing with WSIReader
     output = segmentor.run(
-        images=[WSIReader.open(sample_svs)],
+        images=[WSIReader.open(wsi4_512_512_svs)],
         return_probabilities=True,
         return_labels=False,
         device=device,
@@ -473,8 +420,8 @@ def test_wsi_segmentor_zarr(
         memory_threshold=1,
     )
 
-    output_ = zarr.open(output[sample_svs], mode="r")
-    assert 0.17 < np.mean(output_["predictions"][:]) < 0.21
+    output_ = zarr.open(output[wsi4_512_512_svs], mode="r")
+    assert 0.0 < np.mean(output_["predictions"][:]) < 0.02
     assert "probabilities" in output_
     assert "canvas" not in output_
     assert "count" not in output_
@@ -489,7 +436,7 @@ def test_wsi_segmentor_zarr(
     )
     segmentor.drop_keys = []
     output = segmentor.run(
-        images=[sample_svs, wsi1_2k_2k_svs],
+        images=[sample_svs, wsi4_512_512_svs],
         return_probabilities=True,
         return_labels=False,
         device=device,
@@ -502,15 +449,16 @@ def test_wsi_segmentor_zarr(
     assert 0.17 < np.mean(output_["predictions"][:]) < 0.21
     assert 0.48 < np.mean(output_["probabilities"][:]) < 0.52
 
-    output_ = zarr.open(output[wsi1_2k_2k_svs], mode="r")
-    assert 0.24 < np.mean(output_["predictions"][:]) < 0.25
+    output_ = zarr.open(output[wsi4_512_512_svs], mode="r")
+    assert 0.0 < np.mean(output_["predictions"][:]) < 0.02
     assert 0.48 < np.mean(output_["probabilities"][:]) < 0.52
 
 
 def test_wsi_segmentor_annotationstore(
-    sample_svs: Path, track_tmp_path: Path, caplog: pytest.CaptureFixture
+    remote_sample: Callable, track_tmp_path: Path, caplog: pytest.CaptureFixture
 ) -> None:
     """Test SemanticSegmentor for WSIs with AnnotationStore output."""
+    wsi4_512_512_svs = remote_sample("wsi4_512_512_svs")
     segmentor = SemanticSegmentor(
         model="fcn-tissue_mask",
         batch_size=32,
@@ -518,7 +466,7 @@ def test_wsi_segmentor_annotationstore(
     )
     # Return Probabilities is False
     output = segmentor.run(
-        images=[sample_svs],
+        images=[wsi4_512_512_svs],
         return_probabilities=False,
         return_labels=False,
         device=device,
@@ -528,8 +476,8 @@ def test_wsi_segmentor_annotationstore(
         output_type="annotationstore",
     )
 
-    assert output[sample_svs] == track_tmp_path / "wsi_out_check" / (
-        sample_svs.stem + ".db"
+    assert output[wsi4_512_512_svs] == track_tmp_path / "wsi_out_check" / (
+        wsi4_512_512_svs.stem + ".db"
     )
 
     # Return Probabilities
@@ -540,7 +488,7 @@ def test_wsi_segmentor_annotationstore(
     )
     # Return Probabilities is True
     output = segmentor.run(
-        images=[sample_svs],
+        images=[wsi4_512_512_svs],
         return_probabilities=True,
         return_labels=False,
         device=device,
@@ -550,12 +498,12 @@ def test_wsi_segmentor_annotationstore(
         output_type="annotationstore",
     )
 
-    assert output[sample_svs] == track_tmp_path / "wsi_prob_out_check" / (
-        sample_svs.stem + ".db"
+    assert output[wsi4_512_512_svs] == track_tmp_path / "wsi_prob_out_check" / (
+        wsi4_512_512_svs.stem + ".db"
     )
-    assert output[sample_svs].with_suffix(".zarr").exists()
+    assert output[wsi4_512_512_svs].with_suffix(".zarr").exists()
 
-    zarr_group = zarr.open(output[sample_svs].with_suffix(".zarr"), mode="r")
+    zarr_group = zarr.open(output[wsi4_512_512_svs].with_suffix(".zarr"), mode="r")
     assert "probabilities" in zarr_group
     assert "Probability maps cannot be saved as AnnotationStore." in caplog.text
 
@@ -974,3 +922,30 @@ def test_cli_model_single_file(remote_sample: Callable, track_tmp_path: Path) ->
 
     assert models_wsi_result.exit_code == 0
     assert (track_tmp_path / "output" / (wsi4_512_512_svs.stem + ".db")).exists()
+
+
+def _test_store_output_patch(output: Path) -> None:
+    """Helper method to test annotation store output for a patch."""
+    store_ = SQLiteStore.open(output)
+    annotations_ = store_.values()
+    annotations_geometry_type = [
+        str(annotation_.geometry_type) for annotation_ in annotations_
+    ]
+    assert "Polygon" in annotations_geometry_type
+
+    con = sqlite3.connect(output)
+    cur = con.cursor()
+    annotations_properties = list(cur.execute("SELECT properties FROM annotations"))
+
+    annotation_types = set()
+
+    for item in annotations_properties:
+        for json_str in item:
+            probs = json.loads(json_str)
+            if "type" in probs:
+                annotation_types.add(probs.pop("type"))
+    # When class_dict is none, types are assigned as 0, 1, ...
+    assert 0 in annotation_types
+    assert 1 in annotation_types
+
+    assert annotations_properties is not None

--- a/tests/engines/test_semantic_segmentor.py
+++ b/tests/engines/test_semantic_segmentor.py
@@ -383,7 +383,7 @@ def test_wsi_segmentor_zarr(
     )
     # Return Probabilities is False
     output = segmentor.run(
-        images=[wsi4_512_512_svs],
+        images=[sample_svs],
         return_probabilities=False,
         return_labels=False,
         device=device,
@@ -394,8 +394,8 @@ def test_wsi_segmentor_zarr(
         memory_threshold=1,
     )
 
-    output_ = zarr.open(output[wsi4_512_512_svs], mode="r")
-    assert 0.0 < np.mean(output_["predictions"][:]) < 0.02
+    output_ = zarr.open(output[sample_svs], mode="r")
+    assert 0.17 < np.mean(output_["predictions"][:]) < 0.21
     assert "probabilities" not in output_
     assert "canvas" not in output_
     assert "count" not in output_
@@ -409,7 +409,7 @@ def test_wsi_segmentor_zarr(
     # Return Probabilities is True
     # Testing with WSIReader
     output = segmentor.run(
-        images=[WSIReader.open(wsi4_512_512_svs)],
+        images=[WSIReader.open(sample_svs)],
         return_probabilities=True,
         return_labels=False,
         device=device,
@@ -420,8 +420,8 @@ def test_wsi_segmentor_zarr(
         memory_threshold=1,
     )
 
-    output_ = zarr.open(output[wsi4_512_512_svs], mode="r")
-    assert 0.0 < np.mean(output_["predictions"][:]) < 0.02
+    output_ = zarr.open(output[sample_svs], mode="r")
+    assert 0.17 < np.mean(output_["predictions"][:]) < 0.21
     assert "probabilities" in output_
     assert "canvas" not in output_
     assert "count" not in output_

--- a/tiatoolbox/models/engine/deep_feature_extractor.py
+++ b/tiatoolbox/models/engine/deep_feature_extractor.py
@@ -66,85 +66,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from tiatoolbox.wsicore import WSIReader
 
 
-def save_to_cache(
-    probabilities: list[da.Array],
-    coordinates: list[da.Array],
-    probabilities_zarr: zarr.Array | None,
-    coordinates_zarr: zarr.Array | None,
-    save_path: str | Path = "temp.zarr",
-) -> tuple[zarr.Array, zarr.Array]:
-    """Save computed feature and coordinate arrays to Zarr cache.
-
-    This function computes the given Dask arrays (`probabilities` and `coordinates`),
-    resizes the corresponding Zarr datasets to accommodate the new data, and appends
-    the results. If the Zarr datasets do not exist, it initializes them within the
-    specified Zarr group.
-
-    Args:
-        probabilities (list[dask.array.Array]):
-            List of Dask arrays representing extracted feature maps.
-        coordinates (list[dask.array.Array]):
-            List of Dask arrays representing patch coordinates.
-        probabilities_zarr (zarr.Array | None):
-            Existing Zarr dataset for feature maps. If None, a new one is created.
-        coordinates_zarr (zarr.Array | None):
-            Existing Zarr dataset for coordinates. If None, a new one is created.
-        save_path (str | Path):
-            Path to the Zarr group for saving datasets. Defaults to "temp.zarr".
-
-    Returns:
-        tuple[zarr.Array, zarr.Array]:
-            Updated Zarr datasets for feature maps and coordinates.
-
-    """
-    if len(probabilities) == 0:
-        return probabilities_zarr, coordinates_zarr
-
-    coordinates = da.concatenate(coordinates, axis=0)
-    probabilities = da.concatenate(probabilities, axis=0)
-
-    computed_values = compute(*[probabilities, coordinates])
-    probabilities_computed, coordinates_computed = computed_values
-
-    chunk_shape = tuple(chunk[0] for chunk in probabilities.chunks)
-    if probabilities_zarr is None:
-        zarr_group = zarr.open(str(save_path), mode="w")
-
-        probabilities_zarr = zarr_group.create_dataset(
-            name="canvas",
-            shape=(0, *probabilities_computed.shape[1:]),
-            chunks=(chunk_shape[0], *probabilities_computed.shape[1:]),
-            dtype=probabilities_computed.dtype,
-            overwrite=True,
-        )
-
-        coordinates_zarr = zarr_group.create_dataset(
-            name="count",
-            shape=(0, *coordinates_computed.shape[1:]),
-            dtype=coordinates_computed.dtype,
-            chunks=(chunk_shape[0], *coordinates_computed.shape[1:]),
-            overwrite=True,
-        )
-
-    probabilities_zarr.resize(
-        (
-            probabilities_zarr.shape[0] + probabilities_computed.shape[0],
-            *probabilities_zarr.shape[1:],
-        )
-    )
-    probabilities_zarr[-probabilities_computed.shape[0] :] = probabilities_computed
-
-    coordinates_zarr.resize(
-        (
-            coordinates_zarr.shape[0] + coordinates_computed.shape[0],
-            *coordinates_zarr.shape[1:],
-        )
-    )
-    coordinates_zarr[-coordinates_computed.shape[0] :] = coordinates_computed
-
-    return probabilities_zarr, coordinates_zarr
-
-
 class DeepFeatureExtractor(PatchPredictor):
     r"""Generic deep feature extractor for digital pathology images.
 
@@ -726,3 +647,82 @@ class DeepFeatureExtractor(PatchPredictor):
             output_type=output_type,
             **kwargs,
         )
+
+
+def save_to_cache(
+    probabilities: list[da.Array],
+    coordinates: list[da.Array],
+    probabilities_zarr: zarr.Array | None,
+    coordinates_zarr: zarr.Array | None,
+    save_path: str | Path = "temp.zarr",
+) -> tuple[zarr.Array, zarr.Array]:
+    """Save computed feature and coordinate arrays to Zarr cache.
+
+    This function computes the given Dask arrays (`probabilities` and `coordinates`),
+    resizes the corresponding Zarr datasets to accommodate the new data, and appends
+    the results. If the Zarr datasets do not exist, it initializes them within the
+    specified Zarr group.
+
+    Args:
+        probabilities (list[dask.array.Array]):
+            List of Dask arrays representing extracted feature maps.
+        coordinates (list[dask.array.Array]):
+            List of Dask arrays representing patch coordinates.
+        probabilities_zarr (zarr.Array | None):
+            Existing Zarr dataset for feature maps. If None, a new one is created.
+        coordinates_zarr (zarr.Array | None):
+            Existing Zarr dataset for coordinates. If None, a new one is created.
+        save_path (str | Path):
+            Path to the Zarr group for saving datasets. Defaults to "temp.zarr".
+
+    Returns:
+        tuple[zarr.Array, zarr.Array]:
+            Updated Zarr datasets for feature maps and coordinates.
+
+    """
+    if len(probabilities) == 0:
+        return probabilities_zarr, coordinates_zarr
+
+    coordinates = da.concatenate(coordinates, axis=0)
+    probabilities = da.concatenate(probabilities, axis=0)
+
+    computed_values = compute(*[probabilities, coordinates])
+    probabilities_computed, coordinates_computed = computed_values
+
+    chunk_shape = tuple(chunk[0] for chunk in probabilities.chunks)
+    if probabilities_zarr is None:
+        zarr_group = zarr.open(str(save_path), mode="w")
+
+        probabilities_zarr = zarr_group.create_dataset(
+            name="canvas",
+            shape=(0, *probabilities_computed.shape[1:]),
+            chunks=(chunk_shape[0], *probabilities_computed.shape[1:]),
+            dtype=probabilities_computed.dtype,
+            overwrite=True,
+        )
+
+        coordinates_zarr = zarr_group.create_dataset(
+            name="count",
+            shape=(0, *coordinates_computed.shape[1:]),
+            dtype=coordinates_computed.dtype,
+            chunks=(chunk_shape[0], *coordinates_computed.shape[1:]),
+            overwrite=True,
+        )
+
+    probabilities_zarr.resize(
+        (
+            probabilities_zarr.shape[0] + probabilities_computed.shape[0],
+            *probabilities_zarr.shape[1:],
+        )
+    )
+    probabilities_zarr[-probabilities_computed.shape[0] :] = probabilities_computed
+
+    coordinates_zarr.resize(
+        (
+            coordinates_zarr.shape[0] + coordinates_computed.shape[0],
+            *coordinates_zarr.shape[1:],
+        )
+    )
+    coordinates_zarr[-coordinates_computed.shape[0] :] = coordinates_computed
+
+    return probabilities_zarr, coordinates_zarr

--- a/tiatoolbox/models/engine/nucleus_detector.py
+++ b/tiatoolbox/models/engine/nucleus_detector.py
@@ -897,7 +897,7 @@ class NucleusDetector(SemanticSegmentor):
 
     @staticmethod
     def save_detection_arrays_to_store(
-        detection_arrays: dict[str, da.Array],
+        detection_arrays: dict[str, da.Array | np.ndarray],
         scale_factor: tuple[float, float] = (1.0, 1.0),
         class_dict: dict | None = None,
         save_path: Path | None = None,
@@ -981,7 +981,7 @@ class NucleusDetector(SemanticSegmentor):
 
     def run(
         self: NucleusDetector,
-        images: list[os.PathLike | Path | WSIReader] | np.ndarray,
+        images: list[os.PathLike | Path | WSIReader | np.ndarray] | np.ndarray,
         *,
         masks: list[os.PathLike | Path] | np.ndarray | None = None,
         input_resolutions: list[dict[Units, Resolution]] | None = None,


### PR DESCRIPTION
## Summary
This PR reduces duplicated test logic and speeds up the test suite by switching to smaller sample images and consolidating shared utilities. Tests are updated for consistency with the current API and to improve reliability and performance in CI.

## Key Changes
Replaced large WSIs and patches with 512×512 sample images for faster execution.
Added shared fixtures (e.g., rm_dir) and removed duplicated helper functions across tests.
Standardised usage of Path, tuple-shaped configurations, and device= instead of deprecated flags.
Consolidated and moved TestEngineABC and related helpers to eliminate repetition.
Cleaned up redundant annotation‑store utilities and unified implementations.
Updated DeepFeatureExtractor’s save_to_cache to a single, consistent version.