### PR TITLE
📝 Update Notebook `09-multi-task-segmentation` for New Engines API

### DIFF
--- a/tests/engines/test_engine_abc.py
+++ b/tests/engines/test_engine_abc.py
@@ -6,6 +6,7 @@ import copy
 import logging
 import shutil
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import dask.array as da
 import numpy as np
@@ -26,6 +27,9 @@ from tiatoolbox.models.engine.engine_abc import (
     prepare_engines_save_dir,
 )
 from tiatoolbox.models.engine.io_config import ModelIOConfigABC
+
+if TYPE_CHECKING:
+    from tiatoolbox.wsicore import WSIReaderParams
 
 device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
@@ -559,12 +563,14 @@ class TestEngineABC(EngineABC):
 
     def get_dataloader(
         self: EngineABC,
-        images: Path | np.ndarray | list[np.ndarray],
+        images: str | Path | list[str | Path] | np.ndarray,
         masks: Path | None = None,
         labels: list | None = None,
         ioconfig: ModelIOConfigABC | None = None,
         *,
         patch_mode: bool = True,
+        auto_get_mask: bool = True,
+        wsireader_kwargs: WSIReaderParams | None = None,
     ) -> torch.utils.data.DataLoader:
         """Test pre process images."""
         return super().get_dataloader(
@@ -573,6 +579,8 @@ class TestEngineABC(EngineABC):
             labels,
             ioconfig,
             patch_mode=patch_mode,
+            wsireader_kwargs=wsireader_kwargs,
+            auto_get_mask=auto_get_mask,
         )
 
     def post_process_wsi(
@@ -592,7 +600,7 @@ class TestEngineABC(EngineABC):
         self: EngineABC,
         dataloader: torch.utils.data.DataLoader,
         save_path: Path,
-        **kwargs: dict,
+        **kwargs: Unpack[EngineABCRunParams],
     ) -> dict | np.ndarray:
         """Test infer_wsi."""
         return super().infer_wsi(  # skipcq: PYL-E1121

--- a/tests/engines/test_multi_task_segmentor.py
+++ b/tests/engines/test_multi_task_segmentor.py
@@ -26,8 +26,8 @@ from tiatoolbox.models.engine.multi_task_segmentor import (
     _get_sel_indices_margin_lines,
     _save_multitask_vertical_to_cache,
 )
+from tiatoolbox.utils import download_data, imwrite
 from tiatoolbox.utils import env_detection as toolbox_env
-from tiatoolbox.utils import imwrite
 from tiatoolbox.wsicore import WSIReader
 
 if TYPE_CHECKING:
@@ -201,6 +201,41 @@ def test_mtsegmentor_patches(remote_sample: Callable, track_tmp_path: Path) -> N
             expected_counts=expected_counts,
             task_name=task_name,
         )
+
+
+def test_mtsegmentor_tiles_no_metadata(track_tmp_path: Path) -> None:
+    """Tests MultiTaskSegmentor on a tile with no metadata."""
+    img_file_name = track_tmp_path / "tcga_hnscc.png"
+    download_data(
+        "https://huggingface.co/datasets/TIACentre/TIAToolBox_Remote_Samples/resolve/main/sample_imgs/tcga_hnscc.png",
+        img_file_name,
+    )
+    # Tile prediction
+    multi_segmentor = MultiTaskSegmentor(
+        model="hovernetplus-oed",
+        num_workers=0,
+        batch_size=4,
+    )
+
+    tile_output = multi_segmentor.run(
+        [img_file_name],
+        save_dir=track_tmp_path / "sample_tile_results",
+        patch_mode=False,
+        device=device,
+        auto_get_mask=False,
+        wsireader_kwargs={"mpp": 0.25},
+    )
+
+    assert tile_output[img_file_name].exists()
+    output_zarr = zarr.open(tile_output[img_file_name], mode="r")
+    assert "nuclei_segmentation" in output_zarr
+    assert "layer_segmentation" in output_zarr
+    fields_layer = ["contours", "type"]
+    assert (field in output_zarr["layer_segmentation"] for field in fields_layer)
+    fields_nuclei = ["box", "centroid", "contours", "prob", "type"]
+    assert (field in output_zarr["nuclei_segmentation"] for field in fields_nuclei)
+    assert len(output_zarr["layer_segmentation"]["contours"]) == 12
+    assert len(output_zarr["nuclei_segmentation"]["contours"]) == 1299
 
 
 def test_single_task_mtsegmentor(

--- a/tests/engines/test_multi_task_segmentor.py
+++ b/tests/engines/test_multi_task_segmentor.py
@@ -74,6 +74,7 @@ def test_mtsegmentor_patches(remote_sample: Callable, track_tmp_path: Path) -> N
         return_labels=False,
         device=device,
         patch_mode=True,
+        return_predictions=(True, True),
     )
 
     expected_counts_nuclei = [95, 33, 0]
@@ -103,28 +104,28 @@ def test_mtsegmentor_patches(remote_sample: Callable, track_tmp_path: Path) -> N
         output_type="zarr",
         save_dir=track_tmp_path / "patch_output_zarr",
     )
-    output_zarr = zarr.open(output_zarr, mode="r")
+    output_zarr_ = zarr.open(output_zarr, mode="r")
 
     assert_output_lengths(
-        output_zarr["nuclei_segmentation"],
+        output_zarr_["nuclei_segmentation"],
         expected_counts_nuclei,
         fields=["box", "centroid", "contours", "prob", "type"],
     )
     assert_output_lengths(
-        output_zarr["layer_segmentation"],
+        output_zarr_["layer_segmentation"],
         expected_counts_layer,
         fields=["contours", "type"],
     )
 
     assert_output_equal(
-        output_zarr["nuclei_segmentation"],
+        output_zarr_["nuclei_segmentation"],
         output_dict["nuclei_segmentation"],
         fields=["box", "centroid", "contours", "prob", "type"],
         indices_a=[0, 1, 2],
         indices_b=[0, 1, 2],
     )
     assert_output_equal(
-        output_zarr["layer_segmentation"],
+        output_zarr_["layer_segmentation"],
         output_dict["layer_segmentation"],
         fields=["contours", "type"],
         indices_a=[0, 1, 2],
@@ -132,12 +133,16 @@ def test_mtsegmentor_patches(remote_sample: Callable, track_tmp_path: Path) -> N
     )
 
     # AnnotationStore output comparison
-    output_ann = mtsegmentor.run(
-        images=patches,
-        patch_mode=True,
-        device=device,
+    processed_predictions = convert_to_dask(output_dict)
+
+    output_ann = mtsegmentor.save_predictions(
+        processed_predictions=processed_predictions,
         output_type="annotationstore",
-        save_dir=track_tmp_path / "patch_output_annotationstore",
+        save_path=track_tmp_path
+        / "patch_output_annotationstore"
+        / (output_zarr.stem + "_ann.db"),
+        return_probabilities=False,
+        return_predictions=(True, True),
     )
 
     assert len(output_ann) == 6
@@ -165,14 +170,17 @@ def test_mtsegmentor_patches(remote_sample: Callable, track_tmp_path: Path) -> N
         )
 
     # QuPath JSON does not have fields
+    processed_predictions = convert_to_dask(output_dict)
     fields_nuclei = ["contours", "prob", "type"]
     # QuPath output comparison
-    output_json = mtsegmentor.run(
-        images=patches,
-        patch_mode=True,
-        device=device,
-        output_type="QuPath",
-        save_dir=track_tmp_path / "patch_output_qupath",
+    output_json = mtsegmentor.save_predictions(
+        processed_predictions=processed_predictions,
+        output_type="qupath",
+        save_path=track_tmp_path
+        / "patch_output_qupath"
+        / (output_zarr.stem + "_qupath.db"),
+        return_probabilities=False,
+        return_predictions=(True, True),
     )
 
     assert len(output_json) == 6
@@ -1137,6 +1145,23 @@ def assert_qupath_json_patch_output(  # skipcq: PY-R1000
 
             # Allow small geometric differences
             assert sum(matches) / len(matches) >= 0.95
+
+
+def convert_to_dask(output_dict: dict | list[dict]) -> dict | list[dict]:
+    """Helper function to convert dict with np arrays into a dict with dask arrays."""
+    if isinstance(output_dict, dict):
+        return {k: convert_to_dask(v) for k, v in output_dict.items()}
+    if isinstance(output_dict, list):
+        if all(isinstance(x, str) for x in output_dict):
+            arr = np.array(output_dict, dtype=object)
+            return da.from_array(arr, chunks=(len(arr),))
+        return [convert_to_dask(x) for x in output_dict]
+    if isinstance(output_dict, np.ndarray):
+        if output_dict.dtype == object:
+            # Force chunking for object arrays
+            return da.from_array(output_dict, chunks=(1,) * output_dict.ndim)
+        return da.from_array(output_dict)
+    return output_dict
 
 
 # -------------------------------------------------------------------------------------

--- a/tests/engines/test_multi_task_segmentor.py
+++ b/tests/engines/test_multi_task_segmentor.py
@@ -97,13 +97,15 @@ def test_mtsegmentor_patches(remote_sample: Callable, track_tmp_path: Path) -> N
     )
 
     # Zarr output comparison
-    output_zarr = mtsegmentor.run(
-        images=patches,
-        patch_mode=True,
-        device=device,
+    processed_predictions = convert_to_dask(output_dict)
+    output_zarr = mtsegmentor.save_predictions(
+        processed_predictions=processed_predictions.copy(),
         output_type="zarr",
-        save_dir=track_tmp_path / "patch_output_zarr",
+        save_path=track_tmp_path / "patch_output_zarr" / "output.zarr",
+        return_probabilities=False,
+        return_predictions=(True, True),
     )
+
     output_zarr_ = zarr.open(output_zarr, mode="r")
 
     assert_output_lengths(
@@ -133,10 +135,8 @@ def test_mtsegmentor_patches(remote_sample: Callable, track_tmp_path: Path) -> N
     )
 
     # AnnotationStore output comparison
-    processed_predictions = convert_to_dask(output_dict)
-
     output_ann = mtsegmentor.save_predictions(
-        processed_predictions=processed_predictions,
+        processed_predictions=processed_predictions.copy(),
         output_type="annotationstore",
         save_path=track_tmp_path
         / "patch_output_annotationstore"
@@ -170,11 +170,10 @@ def test_mtsegmentor_patches(remote_sample: Callable, track_tmp_path: Path) -> N
         )
 
     # QuPath JSON does not have fields
-    processed_predictions = convert_to_dask(output_dict)
     fields_nuclei = ["contours", "prob", "type"]
     # QuPath output comparison
     output_json = mtsegmentor.save_predictions(
-        processed_predictions=processed_predictions,
+        processed_predictions=processed_predictions.copy(),
         output_type="qupath",
         save_path=track_tmp_path
         / "patch_output_qupath"
@@ -255,15 +254,27 @@ def test_single_task_mtsegmentor(
     )
     assert_predictions_and_boxes(output_dict, expected_counts_nuclei, is_zarr=False)
 
+    assert next(iter(mtsegmentor.tasks)) == "nuclei_segmentation"
+    assert len(mtsegmentor.tasks) == 1
+
     # Zarr output comparison
-    output_zarr = mtsegmentor.run(
-        images=inputs,
-        patch_mode=True,
-        device=device,
-        output_type="zarr",
-        save_dir=track_tmp_path / "patch_output_zarr",
+    processed_predictions = convert_to_dask_single_task(
+        output_dict=output_dict,
+        task_name="nuclei_segmentation",
     )
-    output_zarr = zarr.open(output_zarr, mode="r")
+
+    _ = zarr.open(str(track_tmp_path / "patch_output_zarr" / "output.zarr"), mode="w")
+
+    output_zarr = zarr.open(
+        mtsegmentor.save_predictions(
+            processed_predictions=processed_predictions.copy(),
+            output_type="zarr",
+            save_path=track_tmp_path / "patch_output_zarr" / "output.zarr",
+            return_probabilities=False,
+            return_predictions=(True, True),
+        ),
+        mode="r",
+    )
 
     assert_output_lengths(
         output_zarr,
@@ -280,16 +291,13 @@ def test_single_task_mtsegmentor(
     )
 
     # AnnotationStore output comparison
-
-    # Reinitialize to check for probabilities in output.
     mtsegmentor.drop_keys = []
-    output_ann = mtsegmentor.run(
-        images=inputs,
-        patch_mode=True,
-        device=device,
+    output_ann = mtsegmentor.save_predictions(
+        processed_predictions=processed_predictions.copy(),
         output_type="annotationstore",
-        save_dir=track_tmp_path / "patch_output_annotationstore",
+        save_path=(track_tmp_path / "patch_output_annotationstore" / "output_ann.db"),
         return_probabilities=True,
+        return_predictions=(True,),
     )
 
     assert len(output_ann) == 3
@@ -306,12 +314,12 @@ def test_single_task_mtsegmentor(
         class_dict=class_dict_["nuclei_segmentation"],
     )
 
-    zarr_file = track_tmp_path / "patch_output_annotationstore" / "output.zarr"
-
-    assert zarr_file.exists()
+    assert (
+        track_tmp_path / "patch_output_annotationstore" / "output_ann.zarr"
+    ).exists()
 
     zarr_group = zarr.open(
-        str(zarr_file),
+        str(track_tmp_path / "patch_output_annotationstore" / "output_ann.zarr"),
         mode="r",
     )
 
@@ -324,16 +332,13 @@ def test_single_task_mtsegmentor(
     assert "Probability maps cannot be saved as AnnotationStore or JSON" in caplog.text
 
     # QuPath output comparison
-
-    # Reinitialize to check for probabilities in output.
     mtsegmentor.drop_keys = []
-    output_json = mtsegmentor.run(
-        images=inputs,
-        patch_mode=True,
-        device=device,
-        output_type="QuPath",
-        save_dir=track_tmp_path / "patch_output_qupath",
+    output_json = mtsegmentor.save_predictions(
+        processed_predictions=processed_predictions.copy(),
+        output_type="qupath",
+        save_path=track_tmp_path / "patch_output_qupath" / "output_qupath.db",
         return_probabilities=True,
+        return_predictions=(True,),
     )
 
     assert len(output_json) == 3
@@ -348,12 +353,10 @@ def test_single_task_mtsegmentor(
         task_name=None,
     )
 
-    zarr_file = track_tmp_path / "patch_output_qupath" / "output.zarr"
-
-    assert zarr_file.exists()
+    assert (track_tmp_path / "patch_output_qupath" / "output_qupath.zarr").exists()
 
     zarr_group = zarr.open(
-        str(zarr_file),
+        str(track_tmp_path / "patch_output_qupath" / "output_qupath.zarr"),
         mode="r",
     )
 
@@ -1162,6 +1165,28 @@ def convert_to_dask(output_dict: dict | list[dict]) -> dict | list[dict]:
             return da.from_array(output_dict, chunks=(1,) * output_dict.ndim)
         return da.from_array(output_dict)
     return output_dict
+
+
+def convert_to_dask_single_task(
+    output_dict: dict | list[dict], task_name: str
+) -> dict | list[dict]:
+    """Helper to convert a dict into a dict with dask arrays for single task."""
+    processed_predictions = {task_name: {}}
+    for k, v in output_dict.items():
+        if k == "probabilities":
+            processed_predictions[k] = [da.from_array(v_) for v_ in v]
+            continue
+        if isinstance(v, np.ndarray):
+            processed_predictions[task_name][k] = da.from_array(v)
+        if isinstance(v, list):
+            processed_predictions[task_name][k] = []
+            for v_ in v:
+                chunks = (len(v_),) if v_.dtype == object else "auto"
+                processed_predictions[task_name][k].append(
+                    da.from_array(v_, chunks=chunks)
+                )
+
+    return processed_predictions
 
 
 # -------------------------------------------------------------------------------------

--- a/tests/engines/test_multi_task_segmentor.py
+++ b/tests/engines/test_multi_task_segmentor.py
@@ -224,12 +224,15 @@ def test_mtsegmentor_tiles_no_metadata(track_tmp_path: Path) -> None:
         device=device,
         auto_get_mask=False,
         wsireader_kwargs={"mpp": 0.25},  # use this mpp to run test faster
+        return_predictions=(True, True),
     )
 
     assert tile_output[img_file_name].exists()
     output_zarr = zarr.open(tile_output[img_file_name], mode="r")
     assert "nuclei_segmentation" in output_zarr
     assert "layer_segmentation" in output_zarr
+    assert "predictions" in output_zarr["layer_segmentation"]
+    assert "predictions" in output_zarr["nuclei_segmentation"]
     fields_layer = ["contours", "type"]
     assert (field in output_zarr["layer_segmentation"] for field in fields_layer)
     fields_nuclei = ["box", "centroid", "contours", "prob", "type"]

--- a/tests/engines/test_multi_task_segmentor.py
+++ b/tests/engines/test_multi_task_segmentor.py
@@ -6,6 +6,7 @@ import json
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
+from unittest.mock import MagicMock
 
 import dask.array as da
 import numpy as np
@@ -18,6 +19,7 @@ from tqdm.auto import tqdm
 
 from tiatoolbox import cli
 from tiatoolbox.annotation import SQLiteStore
+from tiatoolbox.models import IOSegmentorConfig
 from tiatoolbox.models.architecture import fetch_pretrained_weights
 from tiatoolbox.models.engine.multi_task_segmentor import (
     DaskDelayedJSONStore,
@@ -32,6 +34,8 @@ from tiatoolbox.wsicore import WSIReader
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
+
+    from _pytest.monkeypatch import MonkeyPatch
 
 OutputType = dict[str, Any] | Any
 device = "cuda" if toolbox_env.has_gpu() else "cpu"
@@ -965,6 +969,114 @@ def test_compute_qupath_json_string_class_names(track_tmp_path: Path) -> None:
     #    contains the key, but we don't enforce that here — just
     #    ensure no nulls
     assert "null" not in json.dumps(data)
+
+
+def test_get_tile_info_small_image_triggers_early_return(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Tests _get_tile_info.
+
+    Ensures that when image_shape <= tile_shape, the function returns
+    [[boxes, flag]] with flag = zeros.
+
+    """
+    # --- Arrange ---
+    # Make image smaller than tile_shape
+    image_shape = [100, 100]
+
+    # Configure tile_shape so that tile_shape >= image_shape
+    ioconfig = IOSegmentorConfig(
+        tile_shape=[200, 200],
+        patch_output_shape=[200, 200],
+        margin=None,
+        input_resolutions=[{"units": "mpp", "resolution": 0.25}],
+        patch_input_shape=(200, 200),
+    )
+
+    # Patch PatchExtractor.get_coordinates to return predictable boxes
+    fake_boxes = np.array([[0, 0, 100, 100]])
+    monkeypatch.setattr(
+        "tiatoolbox.tools.patchextraction.PatchExtractor.get_coordinates",
+        lambda **kwargs: (None, fake_boxes),  # noqa: ARG005
+    )
+
+    # --- Act ---
+    result = MultiTaskSegmentor._get_tile_info(image_shape, ioconfig)
+
+    # --- Assert ---
+    assert isinstance(result, list)
+    assert len(result) == 1  # early return path
+    boxes, flag = result[0]
+
+    # boxes should be exactly what we patched
+    assert np.array_equal(boxes, fake_boxes)
+
+    # flag should be zeros with shape (N, 4)
+    assert flag.shape == (1, 4)
+    assert np.all(flag == 0)
+
+
+class FakeSeg(MultiTaskSegmentor):
+    """Minimal subclass that allows us to override internals cleanly."""
+
+    def __init__(self: FakeSeg) -> None:
+        """Initialize the FakeSeg."""
+        # Pretend we have one task
+        self.tasks = {"instance"}
+        self.return_predictions_dict = {"instance": True}
+
+    def _get_model_attr(self: FakeSeg, name: str = "a") -> dict:
+        # Pretend the model has a class_dict
+        return {"instance": {name: 1}}
+
+    # These will be patched in the test
+    _save_predictions_as_dict_zarr = MagicMock()
+    _save_predictions_as_json_store = MagicMock()
+
+
+def test_save_predictions_includes_coordinates(track_tmp_path: Path) -> None:
+    """Test save predictions includes coordinates.
+
+    Ensures that when 'coordinates' is present in processed_predictions,
+    the method merges it into dict_for_store before calling
+    _save_predictions_as_json_store.
+
+    """
+    seg = FakeSeg()
+
+    # processed_predictions returned by _save_predictions_as_dict_zarr
+    processed_predictions = {
+        "instance": {"predictions": [1, 2, 3]},
+        "coordinates": [10, 20, 30],
+    }
+
+    # Make the dict-zarr saver return our processed_predictions
+    seg._save_predictions_as_dict_zarr.return_value = processed_predictions
+
+    # Make the json-store saver return a fake path list
+    seg._save_predictions_as_json_store.return_value = [track_tmp_path / "out.db"]
+
+    save_path = track_tmp_path / "result"
+
+    # --- Act ---
+    seg.save_predictions(
+        processed_predictions=processed_predictions,
+        output_type="annotationstore",
+        save_path=save_path,
+        return_probabilities=False,
+        return_predictions=(False,),  # ensures output_type_ becomes "dict"
+    )
+
+    # --- Assert ---
+    assert seg._save_predictions_as_json_store.called
+
+    # Extract the dict passed to the JSON store saver
+    call_args = seg._save_predictions_as_json_store.call_args.kwargs
+    dict_for_store = call_args["processed_predictions"]
+
+    # Must contain both the task predictions and the coordinates
+    assert dict_for_store["predictions"] == [1, 2, 3]
+    assert dict_for_store["coordinates"] == [10, 20, 30]
 
 
 # HELPER functions

--- a/tests/engines/test_multi_task_segmentor.py
+++ b/tests/engines/test_multi_task_segmentor.py
@@ -261,15 +261,15 @@ def test_single_task_mtsegmentor(
     )
     patch3 = np.zeros_like(patch1)
 
-    patch1_path = track_tmp_path / "patch1.png"
-    patch2_path = track_tmp_path / "patch2.png"
-    patch3_path = track_tmp_path / "patch3.png"
+    imwrite(track_tmp_path / "patch1.png", patch1)
+    imwrite(track_tmp_path / "patch2.png", patch2)
+    imwrite(track_tmp_path / "patch3.png", patch3)
 
-    imwrite(patch1_path, patch1)
-    imwrite(patch2_path, patch2)
-    imwrite(patch3_path, patch3)
-
-    inputs = [Path(patch1_path), Path(patch2_path), Path(patch3_path)]
+    inputs = [
+        track_tmp_path / "patch1.png",
+        track_tmp_path / "patch2.png",
+        track_tmp_path / "patch3.png",
+    ]
 
     assert not mtsegmentor.patch_mode
 
@@ -327,12 +327,17 @@ def test_single_task_mtsegmentor(
 
     # AnnotationStore output comparison
     mtsegmentor.drop_keys = []
-    output_ann = mtsegmentor.save_predictions(
-        processed_predictions=processed_predictions.copy(),
-        output_type="annotationstore",
-        save_path=(track_tmp_path / "patch_output_annotationstore" / "output_ann.db"),
+
+    # Triggers Return Coordinates for patch inference
+    output_ann = mtsegmentor.run(
+        images=inputs,
         return_probabilities=True,
+        return_labels=False,
+        device=device,
+        patch_mode=True,
+        save_dir=track_tmp_path / "patch_output_annotationstore",
         return_predictions=(True,),
+        output_type="annotationstore",
     )
 
     assert len(output_ann) == 3
@@ -349,18 +354,17 @@ def test_single_task_mtsegmentor(
         class_dict=class_dict_["nuclei_segmentation"],
     )
 
-    assert (
-        track_tmp_path / "patch_output_annotationstore" / "output_ann.zarr"
-    ).exists()
+    assert (track_tmp_path / "patch_output_annotationstore" / "output.zarr").exists()
 
     zarr_group = zarr.open(
-        str(track_tmp_path / "patch_output_annotationstore" / "output_ann.zarr"),
+        str(track_tmp_path / "patch_output_annotationstore" / "output.zarr"),
         mode="r",
     )
 
     assert "probabilities" in zarr_group
+    assert "predictions" in zarr_group
 
-    fields = ["box", "centroid", "contours", "prob", "type", "predictions"]
+    fields = ["box", "centroid", "contours", "prob", "type"]
     for field in fields:
         assert field not in zarr_group
 
@@ -397,7 +401,7 @@ def test_single_task_mtsegmentor(
 
     assert "probabilities" in zarr_group
 
-    fields = ["box", "centroid", "contours", "prob", "type", "predictions"]
+    fields = ["box", "centroid", "contours", "prob", "type"]
     for field in fields:
         assert field not in zarr_group
 

--- a/tests/engines/test_multi_task_segmentor.py
+++ b/tests/engines/test_multi_task_segmentor.py
@@ -1022,11 +1022,12 @@ class FakeSeg(MultiTaskSegmentor):
     def __init__(self: FakeSeg) -> None:
         """Initialize the FakeSeg."""
         # Pretend we have one task
+        super().__init__(model="hovernetplus-oed")
         self.tasks = {"instance"}
         self.return_predictions_dict = {"instance": True}
 
     def _get_model_attr(self: FakeSeg, name: str = "a") -> dict:
-        # Pretend the model has a class_dict
+        """Pretend the model has a class_dict."""
         return {"instance": {name: 1}}
 
     # These will be patched in the test

--- a/tests/engines/test_multi_task_segmentor.py
+++ b/tests/engines/test_multi_task_segmentor.py
@@ -223,7 +223,7 @@ def test_mtsegmentor_tiles_no_metadata(track_tmp_path: Path) -> None:
         patch_mode=False,
         device=device,
         auto_get_mask=False,
-        wsireader_kwargs={"mpp": 0.25},
+        wsireader_kwargs={"mpp": 0.25},  # use this mpp to run test faster
     )
 
     assert tile_output[img_file_name].exists()
@@ -372,12 +372,15 @@ def test_single_task_mtsegmentor(
 
     # QuPath output comparison
     mtsegmentor.drop_keys = []
-    output_json = mtsegmentor.save_predictions(
-        processed_predictions=processed_predictions.copy(),
-        output_type="qupath",
-        save_path=track_tmp_path / "patch_output_qupath" / "output_qupath.db",
+    output_json = mtsegmentor.run(
+        images=inputs,
         return_probabilities=True,
-        return_predictions=(True,),
+        return_labels=False,
+        device=device,
+        patch_mode=True,
+        save_dir=track_tmp_path / "patch_output_qupath",
+        return_predictions=(False,),
+        output_type="qupath",
     )
 
     assert len(output_json) == 3
@@ -392,16 +395,16 @@ def test_single_task_mtsegmentor(
         task_name=None,
     )
 
-    assert (track_tmp_path / "patch_output_qupath" / "output_qupath.zarr").exists()
+    assert (track_tmp_path / "patch_output_qupath" / "output.zarr").exists()
 
     zarr_group = zarr.open(
-        str(track_tmp_path / "patch_output_qupath" / "output_qupath.zarr"),
+        str(track_tmp_path / "patch_output_qupath" / "output.zarr"),
         mode="r",
     )
 
     assert "probabilities" in zarr_group
 
-    fields = ["box", "centroid", "contours", "prob", "type"]
+    fields = ["box", "centroid", "contours", "prob", "type", "predictions"]
     for field in fields:
         assert field not in zarr_group
 

--- a/tiatoolbox/models/dataset/dataset_abc.py
+++ b/tiatoolbox/models/dataset/dataset_abc.py
@@ -304,6 +304,7 @@ class WSIPatchDataset(PatchDatasetABC):
             input_img if not isinstance(input_img, WSIReader) else input_img.input_path
         )
         self.img_path = Path(img_path)
+        wsireader_kwargs = {} if wsireader_kwargs is None else wsireader_kwargs
         reader = (
             input_img
             if isinstance(input_img, WSIReader)

--- a/tiatoolbox/models/dataset/dataset_abc.py
+++ b/tiatoolbox/models/dataset/dataset_abc.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import TypeGuard
 
     from tiatoolbox.type_hints import IntPair, Resolution, Units
+    from tiatoolbox.wsicore import WSIReaderParams
 
 input_type = list[str | Path | np.ndarray] | np.ndarray
 
@@ -212,7 +213,7 @@ class WSIPatchDataset(PatchDatasetABC):
 
     """
 
-    def __init__(  # skipcq: PY-R1000
+    def __init__(  # skipcq: PY-R1000  # noqa: PLR0913
         self: WSIPatchDataset,
         input_img: str | Path | WSIReader,
         mask_path: str | Path | None = None,
@@ -223,6 +224,7 @@ class WSIPatchDataset(PatchDatasetABC):
         units: Units = None,
         min_mask_ratio: float = 0,
         preproc_func: Callable | None = None,
+        wsireader_kwargs: WSIReaderParams | None = None,
         *,
         auto_get_mask: bool = True,
     ) -> None:
@@ -265,6 +267,8 @@ class WSIPatchDataset(PatchDatasetABC):
                 Preprocessing function used to transform the input data. If
                 supplied, the function will be called on each patch before
                 returning it.
+            wsireader_kwargs (WSIReaderParams):
+                Specify processing images with no mpp or power in the metadata.
 
         Examples:
             >>> # A user defined preproc func and expected behavior
@@ -303,7 +307,7 @@ class WSIPatchDataset(PatchDatasetABC):
         reader = (
             input_img
             if isinstance(input_img, WSIReader)
-            else WSIReader.open(self.img_path)
+            else WSIReader.open(self.img_path, **wsireader_kwargs)
         )
         # To support multi-threading on Windows
         # Helps pickle using Path

--- a/tiatoolbox/models/engine/__init__.py
+++ b/tiatoolbox/models/engine/__init__.py
@@ -12,6 +12,7 @@ from . import (
 __all__ = [
     "deep_feature_extractor",
     "engine_abc",
+    "multi_task_segmentor",
     "nucleus_detector",
     "nucleus_instance_segmentor",
     "patch_predictor",

--- a/tiatoolbox/models/engine/deep_feature_extractor.py
+++ b/tiatoolbox/models/engine/deep_feature_extractor.py
@@ -192,6 +192,8 @@ class DeepFeatureExtractor(PatchPredictor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -340,6 +342,8 @@ class DeepFeatureExtractor(PatchPredictor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -405,6 +409,8 @@ class DeepFeatureExtractor(PatchPredictor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -501,6 +507,8 @@ class DeepFeatureExtractor(PatchPredictor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -617,6 +625,8 @@ class DeepFeatureExtractor(PatchPredictor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 

--- a/tiatoolbox/models/engine/engine_abc.py
+++ b/tiatoolbox/models/engine/engine_abc.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from tiatoolbox.annotation import AnnotationStore
     from tiatoolbox.models.models_abc import ModelABC
     from tiatoolbox.type_hints import IntPair, Resolution, Units
+    from tiatoolbox.wsicore import WSIReaderParams
 
 
 class EngineABCRunParams(TypedDict, total=False):
@@ -109,6 +110,8 @@ class EngineABCRunParams(TypedDict, total=False):
             Stride used during WSI processing, at requested read resolution.
             Must be positive. Defaults to `patch_input_shape` if not
             provided.
+        wsireader_kwargs (WSIReaderParams):
+            Specify processing images with no mpp or power in the metadata.
         verbose (bool):
             Whether to enable verbose logging.
 
@@ -125,6 +128,7 @@ class EngineABCRunParams(TypedDict, total=False):
     return_labels: bool
     scale_factor: tuple[float, float]
     stride_shape: IntPair
+    wsireader_kwargs: dict
     verbose: bool
 
 
@@ -394,6 +398,7 @@ class EngineABC(ABC):  # noqa: B024
         *,
         patch_mode: bool = True,
         auto_get_mask: bool = True,
+        wsireader_kwargs: WSIReaderParams | None = None,
     ) -> torch.utils.data.DataLoader:
         """Pre-process images and masks and return a DataLoader for inference.
 
@@ -412,6 +417,8 @@ class EngineABC(ABC):  # noqa: B024
                 IO configuration object specifying patch size, stride, and resolution.
             patch_mode (bool):
                 Whether to treat input as patches (`True`) or WSIs (`False`).
+            wsireader_kwargs (WSIReaderParams):
+                Specify processing images with no mpp or power in the metadata.
             auto_get_mask (bool):
                 Whether to automatically generate a tissue mask using
                 `wsireader.tissue_mask()` when `patch_mode` is False.
@@ -436,6 +443,7 @@ class EngineABC(ABC):  # noqa: B024
                 resolution=ioconfig.input_resolutions[0]["resolution"],
                 units=ioconfig.input_resolutions[0]["units"],
                 auto_get_mask=auto_get_mask,
+                wsireader_kwargs=wsireader_kwargs,
             )
 
             dataset.preproc_func = self._get_model_attr("preproc_func")
@@ -623,6 +631,8 @@ class EngineABC(ABC):  # noqa: B024
                         Stride used during WSI processing, at requested read resolution.
                         Must be positive. Defaults to `patch_input_shape` if not
                         provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -688,6 +698,8 @@ class EngineABC(ABC):  # noqa: B024
                         Stride used during WSI processing, at requested read resolution.
                         Must be positive. Defaults to `patch_input_shape` if not
                         provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -908,6 +920,8 @@ class EngineABC(ABC):  # noqa: B024
                         Stride used during WSI processing, at requested read resolution.
                         Must be positive. Defaults to `patch_input_shape` if not
                         provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -976,6 +990,8 @@ class EngineABC(ABC):  # noqa: B024
                         Stride used during WSI processing, at requested read resolution.
                         Must be positive. Defaults to `patch_input_shape` if not
                         provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -1265,6 +1281,8 @@ class EngineABC(ABC):  # noqa: B024
                         Stride used during WSI processing, at requested read resolution.
                         Must be positive. Defaults to `patch_input_shape` if not
                         provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -1401,6 +1419,8 @@ class EngineABC(ABC):  # noqa: B024
                         Stride used during WSI processing, at requested read resolution.
                         Must be positive. Defaults to `patch_input_shape` if not
                         provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -1428,6 +1448,7 @@ class EngineABC(ABC):  # noqa: B024
             labels=self.labels,
             patch_mode=True,
             ioconfig=self._ioconfig,
+            wsireader_kwargs=kwargs.get("wsireader_kwargs"),
         )
         raw_predictions = self.infer_patches(
             dataloader=self.dataloader,
@@ -1556,6 +1577,8 @@ class EngineABC(ABC):  # noqa: B024
                         Stride used during WSI processing, at requested read resolution.
                         Must be positive. Defaults to `patch_input_shape` if not
                         provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -1602,6 +1625,7 @@ class EngineABC(ABC):  # noqa: B024
                 patch_mode=False,
                 ioconfig=self._ioconfig,
                 auto_get_mask=kwargs.get("auto_get_mask", True),
+                wsireader_kwargs=kwargs.get("wsireader_kwargs"),
             )
 
             scale_factor = self._calculate_scale_factor(dataloader=self.dataloader)
@@ -1714,6 +1738,8 @@ class EngineABC(ABC):  # noqa: B024
                         Stride used during WSI processing, at requested read resolution.
                         Must be positive. Defaults to `patch_input_shape` if not
                         provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 

--- a/tiatoolbox/models/engine/multi_task_segmentor.py
+++ b/tiatoolbox/models/engine/multi_task_segmentor.py
@@ -540,6 +540,8 @@ class MultiTaskSegmentor(SemanticSegmentor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -767,6 +769,8 @@ class MultiTaskSegmentor(SemanticSegmentor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -875,6 +879,8 @@ class MultiTaskSegmentor(SemanticSegmentor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -1791,6 +1797,8 @@ class MultiTaskSegmentor(SemanticSegmentor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -1980,6 +1988,8 @@ class MultiTaskSegmentor(SemanticSegmentor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 

--- a/tiatoolbox/models/engine/multi_task_segmentor.py
+++ b/tiatoolbox/models/engine/multi_task_segmentor.py
@@ -2678,7 +2678,7 @@ def _save_annotation_json_store(
     output_path = (save_path.parent / store_file_name).with_suffix(suffix)
     # Patch mode indexes the "coordinates" while calculating "values" variable.
     origin = (0.0, 0.0)
-    _ = predictions.pop("coordinates")
+    _ = predictions.pop("coordinates") if "coordinates" in predictions else None
     return dict_to_json_store(
         processed_predictions=predictions,
         class_dict=class_dict,

--- a/tiatoolbox/models/engine/nucleus_detector.py
+++ b/tiatoolbox/models/engine/nucleus_detector.py
@@ -954,6 +954,8 @@ class NucleusDetector(SemanticSegmentor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to patch_input_shape.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to output logging information.
 

--- a/tiatoolbox/models/engine/patch_predictor.py
+++ b/tiatoolbox/models/engine/patch_predictor.py
@@ -365,6 +365,8 @@ class PatchPredictor(EngineABC):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -429,6 +431,8 @@ class PatchPredictor(EngineABC):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -518,6 +522,8 @@ class PatchPredictor(EngineABC):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -625,6 +631,8 @@ class PatchPredictor(EngineABC):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 

--- a/tiatoolbox/models/engine/semantic_segmentor.py
+++ b/tiatoolbox/models/engine/semantic_segmentor.py
@@ -83,6 +83,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from tiatoolbox.models.engine.io_config import IOSegmentorConfig
     from tiatoolbox.models.models_abc import ModelABC
     from tiatoolbox.type_hints import IntPair, Resolution, Units
+    from tiatoolbox.wsicore import WSIReaderParams
 
 
 class SemanticSegmentorRunParams(PredictorRunParams, total=False):
@@ -317,6 +318,7 @@ class SemanticSegmentor(PatchPredictor):
         *,
         patch_mode: bool = True,
         auto_get_mask: bool = True,
+        wsireader_kwargs: WSIReaderParams | None = None,
     ) -> torch.utils.data.DataLoader:
         """Pre-process images and masks and return a DataLoader for inference.
 
@@ -343,6 +345,8 @@ class SemanticSegmentor(PatchPredictor):
                 `wsireader.tissue_mask()` when `patch_mode` is False.
                 If `True`, only tissue regions are processed. If `False`,
                 all patches are processed. Default is `True`.
+            wsireader_kwargs (WSIReaderParams):
+                Specify processing images with no mpp or power in the metadata.
 
         Returns:
             torch.utils.data.DataLoader:
@@ -360,6 +364,7 @@ class SemanticSegmentor(PatchPredictor):
                 resolution=ioconfig.input_resolutions[0]["resolution"],
                 units=ioconfig.input_resolutions[0]["units"],
                 auto_get_mask=auto_get_mask,
+                wsireader_kwargs=wsireader_kwargs,
             )
 
             dataset.preproc_func = self._get_model_attr("preproc_func")
@@ -380,6 +385,7 @@ class SemanticSegmentor(PatchPredictor):
             labels=labels,
             ioconfig=ioconfig,
             patch_mode=patch_mode,
+            wsireader_kwargs=wsireader_kwargs,
         )
 
     def infer_wsi(

--- a/tiatoolbox/models/engine/semantic_segmentor.py
+++ b/tiatoolbox/models/engine/semantic_segmentor.py
@@ -443,6 +443,8 @@ class SemanticSegmentor(PatchPredictor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -666,6 +668,8 @@ class SemanticSegmentor(PatchPredictor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -834,6 +838,8 @@ class SemanticSegmentor(PatchPredictor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 
@@ -947,6 +953,8 @@ class SemanticSegmentor(PatchPredictor):
                     stride_shape (tuple[int, int]):
                         Stride used during WSI processing.
                         Defaults to `patch_input_shape` if not provided.
+                    wsireader_kwargs (WSIReaderParams):
+                        Specify processing images with no mpp or power in the metadata.
                     verbose (bool):
                         Whether to enable verbose logging.
 

--- a/tiatoolbox/wsicore/__init__.py
+++ b/tiatoolbox/wsicore/__init__.py
@@ -1,12 +1,22 @@
 """Package to read whole slide images."""
 
+from typing import TypedDict
+
 from tiatoolbox.wsicore import metadata, wsimeta, wsireader
 
 from .wsimeta import WSIMeta
-from .wsireader import WSIReader
+from .wsireader import Number, WSIReader
 
 # Top level imports
 __all__ = [
     "WSIMeta",
     "WSIReader",
 ]
+
+
+class WSIReaderParams(TypedDict, total=False):
+    """Parameters for reading whole slide images."""
+
+    meta: WSIMeta | None
+    mpp: tuple[Number, Number] | Number
+    power: Number


### PR DESCRIPTION
## Summary
This PR updates the multi‑task segmentation example notebook to align with the latest TIAToolbox API and data sources. It cleans up metadata, modernizes API usage, and switches all sample downloads to stable HuggingFace hosting. 

## Key Changes
- Removed deprecated metadata (`remove-cell` tags, old IDs). 
- Updated documentation links and installation notes. 
- Updated dependencies: removed `joblib`, added `zarr`, adjusted apt packages. 
- Switched sample image/WSI downloads to HuggingFace. 
- Migrated to new TIAToolbox API:
  - `predict()` → `run()`
  - `pretrained_model` → `model`
  - `num_loader_workers` → `num_workers`
  - `mode` → `patch_mode`
  - Added new args (`wsireader_kwargs`, `return_predictions`, `overwrite`)  
  
- Output now saved as Zarr with keys: `layer_segmentation`, `nuclei_segmentation`. 
