### PR TITLE
:bug: Fix for An assert statement has a side-effect

### DIFF
--- a/tests/test_pyramid.py
+++ b/tests/test_pyramid.py
@@ -154,7 +154,8 @@ def test_zoomify_dump(track_tmp_path: Path) -> None:
     dz.dump(out_path)
     assert out_path.exists()
     assert len(list((out_path / "TileGroup0").glob("0-*"))) == 1
-    assert Image.open(out_path / "TileGroup0" / "0-0-0.jpg").size == (64, 64)
+    thumb_image = Image.open(out_path / "TileGroup0" / "0-0-0.jpg")
+    assert thumb_image.size == (64, 64)
 
 
 def test_get_thumb_tile() -> None:


### PR DESCRIPTION
To fix this, move the side-effectful call `Image.open(...)` out of the `assert`, assign its result to a variable, and then assert on that variable’s `.size`. This ensures that the file-open operation always runs when the test runs, independent of how Python handles assertions, and that the `assert` only checks a pure expression.

Concretely, in `tests/test_pyramid.py` around line 157 inside `test_zoomify_dump`, replace:

```py
assert Image.open(out_path / "TileGroup0" / "0-0-0.jpg").size == (64, 64)
```

with:

```py
thumb_image = Image.open(out_path / "TileGroup0" / "0-0-0.jpg")
assert thumb_image.size == (64, 64)
```

This change stays within the shown snippet, uses the already-imported `Image`, does not alter test semantics, and removes the side effect from the `assert`. No additional imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._