### PR TITLE
:passport_control: Fix Workflow Does Not Contain Permissions

### DIFF
--- a/.github/workflows/pip-install.yml
+++ b/.github/workflows/pip-install.yml
@@ -22,6 +22,9 @@ on:
       - "MANIFEST*in"
       - ".github/workflows/pip-install.yml"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/TissueImageAnalytics/tiatoolbox/security/code-scanning/1](https://github.com/TissueImageAnalytics/tiatoolbox/security/code-scanning/1)

In general, to fix this type of issue you add an explicit `permissions` block to the workflow—either at the top level (applies to all jobs) or inside a specific job—to declare the minimal scopes the `GITHUB_TOKEN` needs. For a workflow that just checks out code and runs builds/tests without modifying repository state or GitHub resources, `contents: read` is typically sufficient.

For this specific `pip-install.yml` workflow, the job only checks out the repository and then creates Conda environments, installs PyTorch and `tiatoolbox`, and runs import tests. It does not perform any write operations to the repository or GitHub, so we can safely restrict the `GITHUB_TOKEN` to read‑only repository contents. The simplest, least invasive fix is to add a root‑level `permissions` block after the `on:` section, before `jobs:`, with `contents: read`. This documents the intended least privilege and ensures that even if repository defaults are broader (or are changed later), this workflow’s token is constrained.

Concretely, in `.github/workflows/pip-install.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `on:` block (ending at line 23) and the `jobs:` key (line 25). No additional imports, steps, or configuration changes are needed, and this does not alter the functional behavior of the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
