### PR TITLE
⚡ Filter `tile_bounds` with Mask

### DIFF
--- a/tests/engines/test_multi_task_segmentor.py
+++ b/tests/engines/test_multi_task_segmentor.py
@@ -1049,7 +1049,8 @@ def test_get_tile_info_small_image_triggers_early_return(
     )
 
     # --- Act ---
-    result = MultiTaskSegmentor._get_tile_info(image_shape, ioconfig)
+    MultiTaskSegmentor._ioconfig = ioconfig
+    result = MultiTaskSegmentor._get_tile_info(wsi_proc_shape=image_shape)
 
     # --- Assert ---
     assert isinstance(result, list)

--- a/tests/engines/test_multi_task_segmentor.py
+++ b/tests/engines/test_multi_task_segmentor.py
@@ -1045,7 +1045,7 @@ def test_get_tile_info_small_image_triggers_early_return(
     fake_boxes = np.array([[0, 0, 100, 100]])
     monkeypatch.setattr(
         "tiatoolbox.tools.patchextraction.PatchExtractor.get_coordinates",
-        lambda: (None, fake_boxes),
+        lambda **_: (None, fake_boxes),
     )
 
     # Create a dummy dataset with required attributes

--- a/tests/engines/test_multi_task_segmentor.py
+++ b/tests/engines/test_multi_task_segmentor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import shutil
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Final
 from unittest.mock import MagicMock
 
@@ -1029,7 +1030,6 @@ def test_get_tile_info_small_image_triggers_early_return(
 
     """
     # --- Arrange ---
-    # Make image smaller than tile_shape
     image_shape = [100, 100]
 
     # Configure tile_shape so that tile_shape >= image_shape
@@ -1041,26 +1041,35 @@ def test_get_tile_info_small_image_triggers_early_return(
         patch_input_shape=(200, 200),
     )
 
-    # Patch PatchExtractor.get_coordinates to return predictable boxes
+    # Fake return from PatchExtractor.get_coordinates
     fake_boxes = np.array([[0, 0, 100, 100]])
     monkeypatch.setattr(
         "tiatoolbox.tools.patchextraction.PatchExtractor.get_coordinates",
-        lambda **kwargs: (None, fake_boxes),  # noqa: ARG005
+        lambda: (None, fake_boxes),
     )
 
+    # Create a dummy dataset with required attributes
+    dummy_dataset = SimpleNamespace(mask_reader=None)
+
+    # Dummy dataloader-like container
+    dummy_dataloader = SimpleNamespace(dataset=dummy_dataset)
+
+    # Create a real instance and inject required fields
+    m = MultiTaskSegmentor(model="hovernet_fast-pannuke")
+    m._ioconfig = ioconfig
+    m.mask_padding = (0, 0, 0, 0)
+    m.dataloader = dummy_dataloader
+
     # --- Act ---
-    MultiTaskSegmentor._ioconfig = ioconfig
-    result = MultiTaskSegmentor._get_tile_info(wsi_proc_shape=image_shape)
+    result = m._get_tile_info(image_shape=image_shape, wsi_proc_shape=image_shape)
 
     # --- Assert ---
     assert isinstance(result, list)
-    assert len(result) == 1  # early return path
+    assert len(result) == 1
+
     boxes, flag = result[0]
 
-    # boxes should be exactly what we patched
     assert np.array_equal(boxes, fake_boxes)
-
-    # flag should be zeros with shape (N, 4)
     assert flag.shape == (1, 4)
     assert np.all(flag == 0)
 

--- a/tests/models/test_arch_micronet.py
+++ b/tests/models/test_arch_micronet.py
@@ -72,7 +72,7 @@ def test_micronet_output(remote_sample: Callable, track_tmp_path: Path) -> None:
     svs_1_small = Path(remote_sample("svs-1-small"))
     micronet_output = Path(remote_sample("micronet-output"))
     model = "micronet-consep"
-    batch_size = 64
+    batch_size = 16
     num_workers = 0
 
     ninst_seg = NucleusInstanceSegmentor(

--- a/tiatoolbox/models/dataset/dataset_abc.py
+++ b/tiatoolbox/models/dataset/dataset_abc.py
@@ -334,15 +334,15 @@ class WSIPatchDataset(PatchDatasetABC):
                 stride_shape=stride_shape[::-1],
             )
 
-        mask_reader = self._setup_mask_reader(
+        self.mask_reader = self._setup_mask_reader(
             input_mask=input_mask,
             reader=reader,
             auto_get_mask=auto_get_mask,
         )
 
-        if mask_reader is not None:
+        if self.mask_reader is not None:
             selected = PatchExtractor.filter_coordinates(
-                mask_reader,  # must be at the same resolution
+                self.mask_reader,  # must be at the same resolution
                 self.inputs,  # must already be at requested resolution
                 wsi_shape=wsi_shape,
                 min_mask_ratio=min_mask_ratio,

--- a/tiatoolbox/models/engine/multi_task_segmentor.py
+++ b/tiatoolbox/models/engine/multi_task_segmentor.py
@@ -149,7 +149,7 @@ from tiatoolbox.utils.misc import (
     tqdm_dask_progress_bar,
     update_tqdm_desc,
 )
-from tiatoolbox.wsicore.wsireader import VirtualWSIReader, is_zarr
+from tiatoolbox.wsicore.wsireader import is_zarr
 
 from .semantic_segmentor import (
     SemanticSegmentor,
@@ -1159,9 +1159,14 @@ class MultiTaskSegmentor(SemanticSegmentor):
         # assume ioconfig has already been converted to `baseline` for `tile` mode
         wsi_proc_shape = wsi_reader.slide_dimensions(**highest_input_resolution)
 
+        masked_output_shape = (
+            self.mask_bounds[2] - self.mask_bounds[0],  # X/row
+            self.mask_bounds[3] - self.mask_bounds[1],  # Y/col
+        )
+
         # * retrieve tile placement and tile info flag
         # tile shape will always be corrected to be multiple of output
-        tile_info_sets = self._get_tile_info(wsi_proc_shape=wsi_proc_shape)
+        tile_info_sets = self._get_tile_info(masked_output_shape, self._ioconfig)
         ioconfig = self._ioconfig.to_baseline()
 
         tile_metadata = _build_tile_tasks(
@@ -1353,9 +1358,10 @@ class MultiTaskSegmentor(SemanticSegmentor):
         postproc_func = self._get_model_attr("postproc_func")
         return postproc_func(head_raws)  # offset is (0, 0) by default.
 
+    @staticmethod
     def _get_tile_info(
-        self: MultiTaskSegmentor,
-        wsi_proc_shape: tuple[int, int],
+        image_shape: list[int, int] | tuple[int, int] | np.ndarray,
+        ioconfig: IOSegmentorConfig,
     ) -> list[list, ...]:
         """Generating tile information.
 
@@ -1370,9 +1376,11 @@ class MultiTaskSegmentor(SemanticSegmentor):
         should be done to achieve the above goal.
 
         Args:
-            wsi_proc_shape (tuple(int, int)):
+            image_shape (:class:`numpy.ndarray`, list(int, int), tuple(int, int)):
                 The shape of WSI to extract the tile from, assumed to be
                 in `[width, height]` / `[x, y]`.
+            ioconfig (:obj:IOSegmentorConfig):
+                The input and output configuration objects.
 
         Returns:
             list:
@@ -1390,28 +1398,26 @@ class MultiTaskSegmentor(SemanticSegmentor):
                     - :class:`numpy.ndarray` - Removal flags
 
         """
-        ioconfig = self._ioconfig
         margin = 0 if ioconfig.margin is None else np.array(ioconfig.margin)
         tile_shape = np.array(ioconfig.tile_shape)
         tile_shape = (
             np.floor(tile_shape / ioconfig.patch_output_shape)
             * ioconfig.patch_output_shape
         ).astype(np.int32)
-
-        boxes = _get_boxes_for_post_processing(
-            tile_shape=tile_shape,
-            mask_reader=self.dataloader.dataset.mask_reader,
-            wsi_proc_shape=wsi_proc_shape,
-            mask_padding=self.mask_padding,
+        image_shape = np.array(image_shape)
+        tile_outputs = PatchExtractor.get_coordinates(
+            image_shape=image_shape,
+            patch_input_shape=tile_shape,
+            patch_output_shape=tile_shape,
+            stride_shape=tile_shape,
         )
 
-        masked_output_shape = (
-            self.mask_bounds[2] - self.mask_bounds[0],  # X/row
-            self.mask_bounds[3] - self.mask_bounds[1],  # Y/col
-        )
+        # * === Now generating the flags to indicate which side should
+        # * === be removed in postproc callback
+        boxes = tile_outputs[1]
 
         # This saves computation time if the image is smaller than the expected tile
-        if np.all(masked_output_shape <= tile_shape):
+        if np.all(image_shape <= tile_shape):
             flag = np.zeros([boxes.shape[0], 4], dtype=np.int32)
             return [[boxes, flag]]
 
@@ -1433,7 +1439,8 @@ class MultiTaskSegmentor(SemanticSegmentor):
                 removal_flag[sel_indices, idx] = 0
             return removal_flag
 
-        w, h = masked_output_shape
+        w, h = image_shape
+        boxes = tile_outputs[1]
         #  expand to full four corners
         boxes_br = boxes[:, 2:]
         boxes_tr = np.dstack([boxes[:, 2], boxes[:, 1]])[0]
@@ -3796,48 +3803,3 @@ def apply_coordinate_offset(
         result[i] = (item + shift_vector).astype(item.dtype)
 
     return result
-
-
-def _get_boxes_for_post_processing(
-    tile_shape: np.ndarray | tuple[int, int],
-    mask_reader: VirtualWSIReader,
-    wsi_proc_shape: np.ndarray | tuple[int, int],
-    mask_padding: tuple[int, int, int, int] | np.ndarray,
-) -> np.ndarray:
-    """Helps filter boxes for post-processing."""
-    tile_outputs = PatchExtractor.get_coordinates(
-        image_shape=wsi_proc_shape,
-        patch_input_shape=tile_shape,
-        patch_output_shape=tile_shape,
-        stride_shape=tile_shape,
-    )
-
-    # * === Now generating the flags to indicate which side should
-    # * === be removed in postproc callback
-    boxes = tile_outputs[1]
-
-    # Filter masked regions
-    if mask_reader is not None:
-        selected = PatchExtractor.filter_coordinates(
-            mask_reader,  # must be at the same resolution
-            boxes,  # must already be at requested resolution
-            wsi_shape=wsi_proc_shape,
-            min_mask_ratio=0,
-        )
-        boxes = boxes[selected]
-
-    # remove offset
-    offset = np.array(mask_padding[:2])
-    boxes = boxes - np.array((*offset, *offset))
-    # remove negative values
-    boxes[:, 0:2] = np.clip(boxes[:, 0:2], 0, None)
-
-    # max x index
-    max_x = wsi_proc_shape[0] - mask_padding[2] - offset[0]
-    boxes[:, 2] = np.clip(boxes[:, 2], None, max_x)
-    # max y index
-    max_y = wsi_proc_shape[1] - mask_padding[3] - offset[1]
-    boxes[:, 3] = np.clip(boxes[:, 3], None, max_y)
-
-    # remove empty boxes
-    return boxes[~((boxes[:, 3] == boxes[:, 1]) | (boxes[:, 2] == boxes[:, 0]))]

--- a/tiatoolbox/models/engine/multi_task_segmentor.py
+++ b/tiatoolbox/models/engine/multi_task_segmentor.py
@@ -1166,7 +1166,9 @@ class MultiTaskSegmentor(SemanticSegmentor):
 
         # * retrieve tile placement and tile info flag
         # tile shape will always be corrected to be multiple of output
-        tile_info_sets = self._get_tile_info(masked_output_shape, self._ioconfig)
+        tile_info_sets = self._get_tile_info(
+            image_shape=masked_output_shape, wsi_proc_shape=wsi_proc_shape
+        )
         ioconfig = self._ioconfig.to_baseline()
 
         tile_metadata = _build_tile_tasks(
@@ -1358,10 +1360,10 @@ class MultiTaskSegmentor(SemanticSegmentor):
         postproc_func = self._get_model_attr("postproc_func")
         return postproc_func(head_raws)  # offset is (0, 0) by default.
 
-    @staticmethod
     def _get_tile_info(
+        self: MultiTaskSegmentor,
         image_shape: list[int, int] | tuple[int, int] | np.ndarray,
-        ioconfig: IOSegmentorConfig,
+        wsi_proc_shape: tuple[int, int] | np.ndarray,
     ) -> list[list, ...]:
         """Generating tile information.
 
@@ -1379,8 +1381,8 @@ class MultiTaskSegmentor(SemanticSegmentor):
             image_shape (:class:`numpy.ndarray`, list(int, int), tuple(int, int)):
                 The shape of WSI to extract the tile from, assumed to be
                 in `[width, height]` / `[x, y]`.
-            ioconfig (:obj:IOSegmentorConfig):
-                The input and output configuration objects.
+            wsi_proc_shape (:class:`numpy.ndarray`, list(int, int), tuple(int, int)):
+                Full wsi processing shape.
 
         Returns:
             list:
@@ -1398,6 +1400,7 @@ class MultiTaskSegmentor(SemanticSegmentor):
                     - :class:`numpy.ndarray` - Removal flags
 
         """
+        ioconfig = self._ioconfig
         margin = 0 if ioconfig.margin is None else np.array(ioconfig.margin)
         tile_shape = np.array(ioconfig.tile_shape)
         tile_shape = (
@@ -1415,6 +1418,21 @@ class MultiTaskSegmentor(SemanticSegmentor):
         # * === Now generating the flags to indicate which side should
         # * === be removed in postproc callback
         boxes = tile_outputs[1]
+        offset = self.mask_padding[:2]
+        boxes = boxes + np.array((*offset, *offset))
+        mask_reader = self.dataloader.dataset.mask_reader
+
+        # Filter masked regions
+        if mask_reader is not None:
+            selected = PatchExtractor.filter_coordinates(
+                mask_reader,  # must be at the same resolution
+                boxes,  # must already be at requested resolution
+                wsi_shape=wsi_proc_shape,
+                min_mask_ratio=0,
+            )
+            boxes = boxes[selected]
+
+        boxes = boxes - np.array((*offset, *offset))
 
         # This saves computation time if the image is smaller than the expected tile
         if np.all(image_shape <= tile_shape):

--- a/tiatoolbox/models/engine/multi_task_segmentor.py
+++ b/tiatoolbox/models/engine/multi_task_segmentor.py
@@ -1458,7 +1458,6 @@ class MultiTaskSegmentor(SemanticSegmentor):
             return removal_flag
 
         w, h = image_shape
-        boxes = tile_outputs[1]
         #  expand to full four corners
         boxes_br = boxes[:, 2:]
         boxes_tr = np.dstack([boxes[:, 2], boxes[:, 1]])[0]

--- a/tiatoolbox/models/engine/multi_task_segmentor.py
+++ b/tiatoolbox/models/engine/multi_task_segmentor.py
@@ -149,7 +149,7 @@ from tiatoolbox.utils.misc import (
     tqdm_dask_progress_bar,
     update_tqdm_desc,
 )
-from tiatoolbox.wsicore.wsireader import is_zarr
+from tiatoolbox.wsicore.wsireader import VirtualWSIReader, is_zarr
 
 from .semantic_segmentor import (
     SemanticSegmentor,
@@ -1159,14 +1159,9 @@ class MultiTaskSegmentor(SemanticSegmentor):
         # assume ioconfig has already been converted to `baseline` for `tile` mode
         wsi_proc_shape = wsi_reader.slide_dimensions(**highest_input_resolution)
 
-        masked_output_shape = (
-            self.mask_bounds[2] - self.mask_bounds[0],  # X/row
-            self.mask_bounds[3] - self.mask_bounds[1],  # Y/col
-        )
-
         # * retrieve tile placement and tile info flag
         # tile shape will always be corrected to be multiple of output
-        tile_info_sets = self._get_tile_info(masked_output_shape, self._ioconfig)
+        tile_info_sets = self._get_tile_info(wsi_proc_shape=wsi_proc_shape)
         ioconfig = self._ioconfig.to_baseline()
 
         tile_metadata = _build_tile_tasks(
@@ -1358,10 +1353,9 @@ class MultiTaskSegmentor(SemanticSegmentor):
         postproc_func = self._get_model_attr("postproc_func")
         return postproc_func(head_raws)  # offset is (0, 0) by default.
 
-    @staticmethod
     def _get_tile_info(
-        image_shape: list[int, int] | tuple[int, int] | np.ndarray,
-        ioconfig: IOSegmentorConfig,
+        self: MultiTaskSegmentor,
+        wsi_proc_shape: tuple[int, int],
     ) -> list[list, ...]:
         """Generating tile information.
 
@@ -1376,11 +1370,9 @@ class MultiTaskSegmentor(SemanticSegmentor):
         should be done to achieve the above goal.
 
         Args:
-            image_shape (:class:`numpy.ndarray`, list(int, int), tuple(int, int)):
+            wsi_proc_shape (tuple(int, int)):
                 The shape of WSI to extract the tile from, assumed to be
                 in `[width, height]` / `[x, y]`.
-            ioconfig (:obj:IOSegmentorConfig):
-                The input and output configuration objects.
 
         Returns:
             list:
@@ -1398,26 +1390,35 @@ class MultiTaskSegmentor(SemanticSegmentor):
                     - :class:`numpy.ndarray` - Removal flags
 
         """
+        ioconfig = self._ioconfig
         margin = 0 if ioconfig.margin is None else np.array(ioconfig.margin)
         tile_shape = np.array(ioconfig.tile_shape)
         tile_shape = (
             np.floor(tile_shape / ioconfig.patch_output_shape)
             * ioconfig.patch_output_shape
         ).astype(np.int32)
-        image_shape = np.array(image_shape)
+
         tile_outputs = PatchExtractor.get_coordinates(
-            image_shape=image_shape,
+            image_shape=wsi_proc_shape,
             patch_input_shape=tile_shape,
             patch_output_shape=tile_shape,
             stride_shape=tile_shape,
         )
 
-        # * === Now generating the flags to indicate which side should
-        # * === be removed in postproc callback
-        boxes = tile_outputs[1]
+        boxes = _get_boxes_for_post_processing(
+            tile_outputs=tile_outputs,
+            mask_reader=self.dataloader.dataset.mask_reader,
+            wsi_proc_shape=wsi_proc_shape,
+            mask_padding=self.mask_padding,
+        )
+
+        masked_output_shape = (
+            self.mask_bounds[2] - self.mask_bounds[0],  # X/row
+            self.mask_bounds[3] - self.mask_bounds[1],  # Y/col
+        )
 
         # This saves computation time if the image is smaller than the expected tile
-        if np.all(image_shape <= tile_shape):
+        if np.all(masked_output_shape <= tile_shape):
             flag = np.zeros([boxes.shape[0], 4], dtype=np.int32)
             return [[boxes, flag]]
 
@@ -1439,8 +1440,7 @@ class MultiTaskSegmentor(SemanticSegmentor):
                 removal_flag[sel_indices, idx] = 0
             return removal_flag
 
-        w, h = image_shape
-        boxes = tile_outputs[1]
+        w, h = masked_output_shape
         #  expand to full four corners
         boxes_br = boxes[:, 2:]
         boxes_tr = np.dstack([boxes[:, 2], boxes[:, 1]])[0]
@@ -3803,3 +3803,41 @@ def apply_coordinate_offset(
         result[i] = (item + shift_vector).astype(item.dtype)
 
     return result
+
+
+def _get_boxes_for_post_processing(
+    tile_outputs: np.ndarray,
+    mask_reader: VirtualWSIReader,
+    wsi_proc_shape: np.ndarray | tuple[int, int],
+    mask_padding: tuple[int, int, int, int] | np.ndarray,
+) -> np.ndarray:
+    """Helps filter boxes for post-processing."""
+    # * === Now generating the flags to indicate which side should
+    # * === be removed in postproc callback
+    boxes = tile_outputs[1]
+
+    # Filter masked regions
+    if mask_reader is not None:
+        selected = PatchExtractor.filter_coordinates(
+            mask_reader,  # must be at the same resolution
+            boxes,  # must already be at requested resolution
+            wsi_shape=wsi_proc_shape,
+            min_mask_ratio=0,
+        )
+        boxes = boxes[selected]
+
+    # remove offset
+    offset = np.array(mask_padding[:2])
+    boxes = boxes - np.array((*offset, *offset))
+    # remove negative values
+    boxes[:, 0:2] = np.clip(boxes[:, 0:2], 0, None)
+
+    # max x index
+    max_x = wsi_proc_shape[0] - mask_padding[2] - offset[0]
+    boxes[:, 2] = np.clip(boxes[:, 2], None, max_x)
+    # max y index
+    max_y = wsi_proc_shape[1] - mask_padding[3] - offset[1]
+    boxes[:, 3] = np.clip(boxes[:, 3], None, max_y)
+
+    # remove empty boxes
+    boxes = boxes[~((boxes[:, 3] == boxes[:, 1]) | (boxes[:, 2] == boxes[:, 0]))]

--- a/tiatoolbox/models/engine/multi_task_segmentor.py
+++ b/tiatoolbox/models/engine/multi_task_segmentor.py
@@ -1398,15 +1398,8 @@ class MultiTaskSegmentor(SemanticSegmentor):
             * ioconfig.patch_output_shape
         ).astype(np.int32)
 
-        tile_outputs = PatchExtractor.get_coordinates(
-            image_shape=wsi_proc_shape,
-            patch_input_shape=tile_shape,
-            patch_output_shape=tile_shape,
-            stride_shape=tile_shape,
-        )
-
         boxes = _get_boxes_for_post_processing(
-            tile_outputs=tile_outputs,
+            tile_shape=tile_shape,
             mask_reader=self.dataloader.dataset.mask_reader,
             wsi_proc_shape=wsi_proc_shape,
             mask_padding=self.mask_padding,
@@ -3806,12 +3799,19 @@ def apply_coordinate_offset(
 
 
 def _get_boxes_for_post_processing(
-    tile_outputs: np.ndarray,
+    tile_shape: np.ndarray | tuple[int, int],
     mask_reader: VirtualWSIReader,
     wsi_proc_shape: np.ndarray | tuple[int, int],
     mask_padding: tuple[int, int, int, int] | np.ndarray,
 ) -> np.ndarray:
     """Helps filter boxes for post-processing."""
+    tile_outputs = PatchExtractor.get_coordinates(
+        image_shape=wsi_proc_shape,
+        patch_input_shape=tile_shape,
+        patch_output_shape=tile_shape,
+        stride_shape=tile_shape,
+    )
+
     # * === Now generating the flags to indicate which side should
     # * === be removed in postproc callback
     boxes = tile_outputs[1]
@@ -3840,4 +3840,4 @@ def _get_boxes_for_post_processing(
     boxes[:, 3] = np.clip(boxes[:, 3], None, max_y)
 
     # remove empty boxes
-    boxes = boxes[~((boxes[:, 3] == boxes[:, 1]) | (boxes[:, 2] == boxes[:, 0]))]
+    return boxes[~((boxes[:, 3] == boxes[:, 1]) | (boxes[:, 2] == boxes[:, 0]))]


### PR DESCRIPTION
- Filter `tile_bounds` with Mask
- This PR filters `tile_bounds` within the mask bounds; this avoids postprocessing of tiles with no tissue region.