### PR TITLE
:bug: Fix Model Name Mismatch 

### DIFF
--- a/docs/pretrained.rst
+++ b/docs/pretrained.rst
@@ -298,7 +298,7 @@ The input output configuration is as follows:
 
 .. collapse:: Model names
 
-    - micronet_hovernet-consep
+    - micronet-consep
 
 
 Kumar Dataset

--- a/docs/pretrained.rst
+++ b/docs/pretrained.rst
@@ -333,7 +333,7 @@ The input output configuration is as follows:
 
 .. collapse:: Model names
 
-    - hovernet_original_kumar
+    - hovernet_original-kumar
 
 Nucleus Detection
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Naming inconsistency with two model names in documentation:
1. micronet_hovernet-consep does not exist, but docs/pretrained.rst on pretrained models defines it -> change to micronet-consep as defined in tiatoolbox/data/pretrained_model.yaml
2. hovernet_original_kumar does not exist, but docs/pretrained.rst on pretrained model defines it -> change to hovernet_original-kumar as defined in tiatoolbox/data/pretrained_model.yaml