### PR TITLE
:bug: Potential Security Risk: Deserialization of user-controlled data

### DIFF
--- a/tiatoolbox/visualization/tileserver.py
+++ b/tiatoolbox/visualization/tileserver.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
-from flask import Flask, Response, jsonify, make_response, request, send_file
+from flask import Flask, Response, abort, jsonify, make_response, request, send_file
 from flask.templating import render_template
 from matplotlib import colormaps
 from PIL import Image
@@ -340,6 +340,17 @@ class TileServer(Flask):
         """Decode a URL-safe name."""
         return Path(urllib.parse.unquote(name).replace("\\", os.sep))
 
+    @staticmethod
+    def _get_annotation_base_dir() -> Path:
+        """Return the base directory from which annotation overlays may be loaded.
+
+        This is used to restrict user-supplied overlay paths to a trusted subtree
+        on the filesystem.
+        """
+        # For now, restrict to the current working directory. This can be updated
+        # to use a configurable annotations directory if desired.
+        return Path.cwd()
+
     def get_ann_layer(
         self: TileServer,
         session_id: str,
@@ -525,6 +536,16 @@ class TileServer(Flask):
         overlay_path = request.form["overlay_path"]
         overlay_path = self.decode_safe_name(overlay_path)
 
+        # Restrict overlay paths to a trusted base directory.
+        base_dir = self._get_annotation_base_dir().resolve()
+        try:
+            resolved_overlay = (base_dir / overlay_path).resolve()
+        except OSError:
+            abort(400, description="Invalid overlay path.")
+        if not str(resolved_overlay).startswith(str(base_dir) + os.sep):
+            abort(400, description="Overlay path is not allowed.")
+        overlay_path = resolved_overlay
+
         # Get other session id
         session_ids = list(self.layers.keys())
         session_ids.remove(session_id)
@@ -619,6 +640,8 @@ class TileServer(Flask):
         return json.dumps(layer)
 
     def _add_annotation_overlay(self, session_id: str, overlay_path: Path) -> str:
+        # `overlay_path` is expected to have been validated in `change_overlay`
+        # to ensure it lies within a trusted base directory.
         if overlay_path.suffix == ".geojson":
 
             def unpack_qupath(ann: Annotation) -> Annotation:


### PR DESCRIPTION
Potential fix for [https://github.com/TissueImageAnalytics/tiatoolbox/security/code-scanning/17](https://github.com/TissueImageAnalytics/tiatoolbox/security/code-scanning/17)

In general, to fix this kind of issue you must not use unsafe deserialization (pickle/joblib/marshal/yaml full loader) on data that can be influenced by users. Either (a) switch to a safe data format and safe loader (e.g. JSON with `json.load`/`json.loads`), or (b) ensure that only trusted files can ever be passed to the unsafe loader, typically by enforcing strict path validation or whitelisting. The safest approach is to avoid pickle-based formats for anything that can be selected or uploaded by remote clients.

Here, the minimal change that preserves existing functionality is to ensure that, when `store_from_dat` is used via the tile server (i.e. from a request), the `.dat` file is only loaded if it lives under a configured trusted directory. We cannot redesign the file format without breaking users, and we shouldn’t alter all callers of `add_from_dat`/`store_from_dat`. Instead, we can harden `TileServer._add_annotation_overlay` so that it rejects untrusted or arbitrary paths and only accepts `.dat` files from a designated safe directory (for example, the current working directory or a subdirectory such as `data/annotations`). This breaks the taint flow: even though the client chooses `overlay_path`, it must resolve under that trusted base; if not, the server returns an error instead of calling `store_from_dat`.

Concretely:
- In `tileserver.py`, add a helper method (or inline logic) that gets a base annotations directory (e.g. `Path.cwd()` or an environment-configurable directory) and checks that `overlay_path` is within it using `resolve()` and `is_relative_to` (or an equivalent pattern for older Python). Reject paths that are outside that directory or that are not readable.
- Use this validation in `_add_annotation_overlay` before calling `store_from_dat` or opening any annotation file. If validation fails, return a 400-style JSON error instead of proceeding.
- This change does not modify `store_from_dat` or `add_from_dat` themselves, preserving their behavior for internal, trusted callers, but ensures that the tainted `request.form["overlay_path"]` cannot control arbitrary file paths to `joblib.load`.

Because we’re limited to editing the shown snippets, the changes will be confined to `tiatoolbox/visualization/tileserver.py`. We’ll:
- Import `abort` from `flask` to signal invalid paths cleanly.
- Add a static helper `_get_annotation_base_dir` to pick a safe base path.
- In `_add_annotation_overlay`, before using `overlay_path`, resolve it relative to that base dir and ensure it doesn’t escape the base. If it does, call `abort(400, ...)`.
- Use the validated path for the rest of the method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
