### PR TITLE
:pencil2: Fix `docs/pretrained.rst file`

### DIFF
--- a/docs/pretrained.rst
+++ b/docs/pretrained.rst
@@ -313,8 +313,8 @@ The input output configuration is as follows:
 
    .. code-block:: python
 
-        from tiatoolbox.models import IOSegmentorConfig
-        ioconfig = IOSegmentorConfig(
+        from tiatoolbox.models import IOInstanceSegmentorConfig
+        ioconfig = IOInstanceSegmentorConfig(
             input_resolutions=[
                 {'units': 'mpp', 'resolution': 0.25}
             ],

--- a/docs/pretrained.rst
+++ b/docs/pretrained.rst
@@ -163,8 +163,8 @@ The input output configuration is as follows:
 
    .. code-block:: python
 
-        from tiatoolbox.models import IOSegmentorConfig
-        ioconfig = IOSegmentorConfig(
+        from tiatoolbox.models import IOInstanceSegmentorConfig
+        ioconfig = IOInstanceSegmentorConfig(
             input_resolutions=[
                 {'units': 'mpp', 'resolution': 0.25}
             ],
@@ -205,8 +205,8 @@ The input output configuration is as follows:
 
    .. code-block:: python
 
-        from tiatoolbox.models import IOSegmentorConfig
-        ioconfig = IOSegmentorConfig(
+        from tiatoolbox.models import IOInstanceSegmentorConfig
+        ioconfig = IOInstanceSegmentorConfig(
             input_resolutions=[
                 {'units': 'mpp', 'resolution': 0.25}
             ],
@@ -246,8 +246,8 @@ The input output configuration is as follows:
 
    .. code-block:: python
 
-        from tiatoolbox.models import IOSegmentorConfig
-        ioconfig = IOSegmentorConfig(
+        from tiatoolbox.models import IOInstanceSegmentorConfig
+        ioconfig = IOInstanceSegmentorConfig(
             input_resolutions=[
                 {'units': 'mpp', 'resolution': 0.25}
             ],
@@ -281,8 +281,8 @@ The input output configuration is as follows:
 
    .. code-block:: python
 
-        from tiatoolbox.models import IOSegmentorConfig
-        ioconfig = IOSegmentorConfig(
+        from tiatoolbox.models import IOInstanceSegmentorConfig
+        ioconfig = IOInstanceSegmentorConfig(
             input_resolutions=[
                 {'units': 'mpp', 'resolution': 0.25}
             ],


### PR DESCRIPTION
Modifies pertrained models documentation to reflect correct use of `IOInstanceSegmentorConfig` for hovernet models, replacing the previous erroneous use of `IOSegmentorConfig`.