### PR TITLE
:bug: Fix issue with MPS device

### DIFF
--- a/tiatoolbox/models/architecture/efficientunet_tissue_mask_model.py
+++ b/tiatoolbox/models/architecture/efficientunet_tissue_mask_model.py
@@ -927,7 +927,7 @@ class EfficientUNetTissueMaskModel(ModelABC):
         model.eval()
 
         imgs = batch_data
-        imgs = imgs.to(device).type(torch.float32)
+        imgs = imgs.to(device=device, dtype=torch.float32)
         imgs = imgs.permute(0, 3, 1, 2)  # to NCHW
 
         with torch.inference_mode():

--- a/tiatoolbox/models/architecture/grandqc.py
+++ b/tiatoolbox/models/architecture/grandqc.py
@@ -627,7 +627,7 @@ class GrandQCModel(ModelABC):
         model.eval()
 
         imgs = batch_data
-        imgs = imgs.to(device).type(torch.float32)
+        imgs = imgs.to(device=device, dtype=torch.float32)
         imgs = imgs.permute(0, 3, 1, 2)  # to NCHW
 
         with torch.inference_mode():

--- a/tiatoolbox/models/architecture/hovernet.py
+++ b/tiatoolbox/models/architecture/hovernet.py
@@ -890,7 +890,7 @@ class HoVerNet(ModelABC):
         """
         patch_imgs = batch_data
 
-        patch_imgs_gpu = patch_imgs.to(device).type(torch.float32)  # to NCHW
+        patch_imgs_gpu = patch_imgs.to(device=device, dtype=torch.float32)  # to NCHW
         patch_imgs_gpu = patch_imgs_gpu.permute(0, 3, 1, 2).contiguous()
 
         model.eval()  # infer mode

--- a/tiatoolbox/models/architecture/hovernetplus.py
+++ b/tiatoolbox/models/architecture/hovernetplus.py
@@ -440,7 +440,7 @@ class HoVerNetPlus(HoVerNet):
         """
         patch_imgs = batch_data
 
-        patch_imgs_gpu = patch_imgs.to(device).type(torch.float32)  # to NCHW
+        patch_imgs_gpu = patch_imgs.to(device=device, dtype=torch.float32)  # to NCHW
         patch_imgs_gpu = patch_imgs_gpu.permute(0, 3, 1, 2).contiguous()
 
         model.eval()  # infer mode

--- a/tiatoolbox/models/architecture/kongnet.py
+++ b/tiatoolbox/models/architecture/kongnet.py
@@ -789,9 +789,10 @@ class KongNet(ModelABC):
             ... (256, 256, 3)
 
         """
-        mean = np.array([0.485, 0.456, 0.406])
-        std = np.array([0.229, 0.224, 0.225])
-        return (image / 255.0 - mean) / std
+        mean = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+        std = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+        image = image.astype(np.float32, copy=False) / np.float32(255.0)
+        return (image - mean) / std
 
     def forward(  # skipcq: PYL-W0613
         self: KongNet,
@@ -858,7 +859,7 @@ class KongNet(ModelABC):
         model.eval()
 
         imgs = batch_data
-        imgs = imgs.to(device).type(torch.float32)
+        imgs = imgs.to(device=device, dtype=torch.float32)
         imgs = imgs.permute(0, 3, 1, 2)  # to NCHW
 
         with torch.inference_mode():

--- a/tiatoolbox/models/architecture/mapde.py
+++ b/tiatoolbox/models/architecture/mapde.py
@@ -320,7 +320,7 @@ class MapDe(MicroNet):
         """
         patch_imgs = batch_data
 
-        patch_imgs_gpu = patch_imgs.to(device).type(torch.float32)  # to NCHW
+        patch_imgs_gpu = patch_imgs.to(device=device, dtype=torch.float32)  # to NCHW
         patch_imgs_gpu = patch_imgs_gpu.permute(0, 3, 1, 2).contiguous()
 
         model.eval()  # infer mode

--- a/tiatoolbox/models/architecture/micronet.py
+++ b/tiatoolbox/models/architecture/micronet.py
@@ -720,7 +720,7 @@ class MicroNet(ModelABC):
         """
         patch_imgs = batch_data
 
-        patch_imgs_gpu = patch_imgs.to(device).type(torch.float32)  # to NCHW
+        patch_imgs_gpu = patch_imgs.to(device=device, dtype=torch.float32)  # to NCHW
         patch_imgs_gpu = patch_imgs_gpu.permute(0, 3, 1, 2).contiguous()
 
         model.eval()  # infer mode

--- a/tiatoolbox/models/architecture/nuclick.py
+++ b/tiatoolbox/models/architecture/nuclick.py
@@ -679,7 +679,7 @@ class NuClick(ModelABC):
         model.eval()
 
         # Assume batch_data is NCHW
-        batch_data = batch_data.to(device).type(torch.float32)
+        batch_data = batch_data.to(device=device, dtype=torch.float32)
 
         with torch.inference_mode():
             output = model(batch_data)

--- a/tiatoolbox/models/architecture/sccnn.py
+++ b/tiatoolbox/models/architecture/sccnn.py
@@ -415,7 +415,7 @@ class SCCNN(ModelABC):
         """
         patch_imgs = batch_data
 
-        patch_imgs_gpu = patch_imgs.to(device).type(torch.float32)
+        patch_imgs_gpu = patch_imgs.to(device=device, dtype=torch.float32)
         # to NCHW
         patch_imgs_gpu = patch_imgs_gpu.permute(0, 3, 1, 2).contiguous()
 

--- a/tiatoolbox/models/architecture/unet.py
+++ b/tiatoolbox/models/architecture/unet.py
@@ -453,7 +453,7 @@ class UNetModel(ModelABC):
         ####
         imgs = batch_data
 
-        imgs = imgs.to(device).type(torch.float32)
+        imgs = imgs.to(device=device, dtype=torch.float32)
         imgs = imgs.permute(0, 3, 1, 2)  # to NCHW
 
         _, _, h, w = imgs.shape

--- a/tiatoolbox/models/architecture/vanilla.py
+++ b/tiatoolbox/models/architecture/vanilla.py
@@ -239,8 +239,9 @@ def _infer_batch(
         >>> print(output)
 
     """
-    img_patches_device = batch_data.to(device=device).type(
-        torch.float32,
+    img_patches_device = batch_data.to(
+        device=device,
+        dtype=torch.float32,
     )  # to NCHW
     img_patches_device = img_patches_device.permute(0, 3, 1, 2).contiguous()
 


### PR DESCRIPTION
This PR fixes #1070. 
It standardizes the way tensors are moved to a device and cast to `float32` across multiple model architectures in the codebase. The updates ensure that both the device and data type are explicitly specified in a single call to `.to()`, improving code clarity and consistency. Additionally, the image preprocessing in `kongnet.py` is updated to enforce float32 precision throughout.

* Updated all instances of `.to(device).type(torch.float32)` to `.to(device=device, dtype=torch.float32)` in various `infer_batch` functions, ensuring that tensors are moved to the correct device and cast to `float32` in a single step. This change affects the following files: `efficientunet_tissue_mask_model.py` [[1]](diffhunk://#diff-a8291e12107b0b9ca0f341fe353d0ac55ccb44ec721c5c6699c384a906e7755aL930-R930) `grandqc.py` [[2]](diffhunk://#diff-d729ed5d7a23c56dfb32667bd7e1419e045cc20fb136ec2a8db41785178f5f6aL630-R630) `hovernet.py` [[3]](diffhunk://#diff-0fb5e006f0559cba393f7e9f4b2eac85e9f9ff0927d26a5259400370ca0da50eL893-R893) `hovernetplus.py` [[4]](diffhunk://#diff-7c263e43928fb3549f990b4b2b63f1377da03a0396feda30da2bbc70a3b7859eL443-R443) `kongnet.py` [[5]](diffhunk://#diff-4a72853e6e2ebccee27d15fd6c0599d3b113bed534df85a17e2250575f8aa9e5L861-R862) `mapde.py` [[6]](diffhunk://#diff-5baef788a6c73d46453555207a71569b38f137d8b8e3113bc908e4b3807c2fa0L323-R323) `micronet.py` [[7]](diffhunk://#diff-fe9060463fd23bee3f1869571d3222afc5a997c2c7a0588d73d8b289a3111254L723-R723) `nuclick.py` [[8]](diffhunk://#diff-51e6d16bc1e04e7ef0f2b6ecbdfbd6ba8d15e67e7551a9a3f0219cd66f2c8044L682-R682) `sccnn.py` [[9]](diffhunk://#diff-9661859042b5ab55880371b6a64a833fd4d49e0e426cbd1a60bdf50d53b97371L418-R418) `unet.py` [[10]](diffhunk://#diff-ee0e538ba47dc8c73367638c4fbcdef48c130aaba1f1e093a0a28f9f8bcd0970L456-R456) and `vanilla.py` [[11]](diffhunk://#diff-a84858f695910c0026d8a467831bf4f1e12fe67d6f15365d6143b257f7445692L242-R244).