### PR TITLE
🐛 Fix multi-gpu error (AttributeError) for `kongnet` and `nucleus_detector`

### DIFF
--- a/tiatoolbox/models/architecture/kongnet.py
+++ b/tiatoolbox/models/architecture/kongnet.py
@@ -862,10 +862,8 @@ class KongNet(ModelABC):
         imgs = imgs.to(device=device, dtype=torch.float32)
         imgs = imgs.permute(0, 3, 1, 2)  # to NCHW
 
-        try:
-            target_channels = model.target_channels
-        except AttributeError:
-            target_channels = model.module.target_channels
+        # unwrap DataParallel/DDP if present (happens in multi-gpu settings)
+        target_channels = getattr(model, "module", model).target_channels
 
         with torch.inference_mode():
             logits = model(imgs)

--- a/tiatoolbox/models/architecture/kongnet.py
+++ b/tiatoolbox/models/architecture/kongnet.py
@@ -862,9 +862,14 @@ class KongNet(ModelABC):
         imgs = imgs.to(device=device, dtype=torch.float32)
         imgs = imgs.permute(0, 3, 1, 2)  # to NCHW
 
+        try:
+            target_channels = model.target_channels
+        except AttributeError:
+            target_channels = model.module.target_channels
+
         with torch.inference_mode():
             logits = model(imgs)
-            target_logits = logits[:, model.target_channels, :, :]
+            target_logits = logits[:, target_channels, :, :]
             probs = torch.nn.functional.sigmoid(target_logits)
             probs = probs.permute(0, 2, 3, 1)  # to NHWC
 

--- a/tiatoolbox/models/engine/engine_abc.py
+++ b/tiatoolbox/models/engine/engine_abc.py
@@ -386,8 +386,11 @@ class EngineABC(ABC):  # noqa: B024
         return model, None
 
     def _get_model_attr(self: EngineABC, attr_name: str) -> Callable:
-        """Return a model attribute, unwrapping DataParallel/DDP if required (happens in multi-gpu settings).
-        Reads the attribute from ``self.model.module`` if the model is wrapped, otherwise directly from ``self.model``.
+        """Return a model attribute, unwrapping DataParallel/DDP if required.
+
+        Reads the attribute from ``self.model.module`` if the model is wrapped
+        (in multi-gpu settings), otherwise directly from ``self.model``.
+
         """
         return getattr(getattr(self.model, "module", self.model), attr_name)
 

--- a/tiatoolbox/models/engine/engine_abc.py
+++ b/tiatoolbox/models/engine/engine_abc.py
@@ -386,12 +386,10 @@ class EngineABC(ABC):  # noqa: B024
         return model, None
 
     def _get_model_attr(self: EngineABC, attr_name: str) -> Callable:
-        """Return a model attribute, unwrapping DataParallel if required."""
-        try:
-            return getattr(self.model, attr_name)
-        except AttributeError:
-            module = getattr(self.model, "module", None)
-            return getattr(module, attr_name)
+        """Return a model attribute, unwrapping DataParallel/DDP if required (happens in multi-gpu settings).
+        Reads the attribute from ``self.model.module`` if the model is wrapped, otherwise directly from ``self.model``.
+        """
+        return getattr(getattr(self.model, "module", self.model), attr_name)
 
     def get_dataloader(
         self: EngineABC,

--- a/tiatoolbox/models/engine/nucleus_detector.py
+++ b/tiatoolbox/models/engine/nucleus_detector.py
@@ -431,10 +431,10 @@ class NucleusDetector(SemanticSegmentor):
         # min_distance and postproc_tile_shape cannot be None here
         min_distance = kwargs.get("min_distance")
         if min_distance is None:
-            min_distance = self.model.min_distance
+            min_distance = self._get_model_attr("min_distance")
         tile_shape = kwargs.get("tile_shape")
         if tile_shape is None:
-            tile_shape = self.model.tile_shape
+            tile_shape = self._get_model_attr("tile_shape")
 
         # Add halo (overlap) around each block for post-processing
         depth_h = min_distance


### PR DESCRIPTION
Follow-up to the earlier multi-GPU fix. kongnet and nucleus_detector were missed and still crash on multi-GPU machines with:

AttributeError: 'DataParallel' object has no attribute 'target_channels'

When multi-gpu, the model is wrapped in `nn.DataParallel` / `DistributedDataParallel`, so these need to go through **the `_get_model_attr()` wrapper helper function** (or a similar approach) which unwraps the module before reading the attribute.

### Changes
- `nucleus_detector.py`: read `min_distance` / `tile_shape` via the `_get_model_attr` helper instead of directly off `self.model`.
- `kongnet.py`: unwrap the module before reading `target_channels` in `infer_batch`. This can't reach the helper function, so it applies the same unwrap inline.
- `engine_abc.py`: simplify _get_model_attr to a single getattr-based unwrap and clarify its docstring.
