### PR TITLE
🔥 Remove `albumentations` Dependencies

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,4 @@
 aiohttp>=3.8.1
-albucore<=0.0.28
-albumentations>=1.3.0
 bokeh>=3.8.2
 Click>=8.2.0
 dask>=2026.1.2
@@ -31,7 +29,6 @@ scikit-learn>=1.2.0
 scipy>=1.8
 shapely>=2.0.0
 SimpleITK>=2.2.1
-simsimd>=6.5.16 # required by conda-package
 sphinx>=9.0.0
 tifffile>=2025.5.21
 timm>=1.0.3

--- a/tests/test_stainaugment.py
+++ b/tests/test_stainaugment.py
@@ -68,7 +68,7 @@ def test_call_returns_original_image_when_probability_check_fails(
     class FakeRNG:
         """Fake random number generator."""
 
-        def random(self: FakeRNG) -> float:
+        def random(self: FakeRNG) -> float:  # skipcq: PYL-R0201
             """Fake random mimics np.random.default_rng().random()."""
             return 0.9
 

--- a/tests/test_stainaugment.py
+++ b/tests/test_stainaugment.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-import albumentations as alb
 import numpy as np
 import pytest
 
@@ -34,7 +33,7 @@ def test_stainaugment(source_image: Path, norm_vahadane: Path) -> None:
     source_img_aug = augmentor.augment()
     assert source_img_aug.dtype == source_img.dtype
     assert np.shape(source_img_aug) == np.shape(source_img)
-    assert np.mean(np.absolute(source_img_aug / 255.0 - source_img / 255.0)) > 1e-2
+    assert np.mean(np.abs(source_img_aug / 255.0 - source_img / 255.0)) > 1e-2
 
     # 2. Testing with predefined stain matrix
     # We first extract the stain matrix of the target image and try to augment the
@@ -54,33 +53,6 @@ def test_stainaugment(source_image: Path, norm_vahadane: Path) -> None:
     )
     augmentor.fit(source_img, threshold=0.8)
     source_img_aug = augmentor.augment()
-    assert np.mean(np.absolute(vahadane_img / 255.0 - source_img_aug / 255.0)) < 1e-1
 
-    # 3. Test in albumentation framework
-    # Using the same trick as before, augment the image with pre-defined stain matrix
-    # and sigma1,2 equal to 0. The output should be equal to stain normalized image.
-    aug_pipeline = alb.Compose(
-        [
-            StainAugmentor(
-                method="vahadane",
-                stain_matrix=target_stain_matrix,
-                sigma1=0.0,
-                sigma2=0.0,
-                always_apply=True,
-            ),
-        ],
-        p=1,
-    )
-    source_img_aug = aug_pipeline(image=source_img)["image"]
-    assert np.mean(np.absolute(vahadane_img / 255.0 - source_img_aug / 255.0)) < 1e-1
-
-    # Test for albumentation helper functions
-    params = augmentor.get_transform_init_args_names()
-    augmentor.get_params_dependent_on_targets(params)
-    assert params == (
-        "method",
-        "stain_matrix",
-        "sigma1",
-        "sigma2",
-        "augment_background",
-    )
+    # Should match vahadane normalized image
+    assert np.mean(np.abs(vahadane_img / 255.0 - source_img_aug / 255.0)) < 1e-1

--- a/tests/test_stainaugment.py
+++ b/tests/test_stainaugment.py
@@ -81,6 +81,7 @@ def test_call_returns_original_image_when_probability_check_fails(
     fit_called = False
 
     def mock_fit(x: np.ndarray) -> None:
+        """Mock fit function."""
         nonlocal fit_called
         fit_called = True
         augmentor._original_img = x

--- a/tests/test_stainaugment.py
+++ b/tests/test_stainaugment.py
@@ -1,5 +1,7 @@
 """Test for stain augmentation code."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import numpy as np
@@ -56,3 +58,36 @@ def test_stainaugment(source_image: Path, norm_vahadane: Path) -> None:
 
     # Should match vahadane normalized image
     assert np.mean(np.abs(vahadane_img / 255.0 - source_img_aug / 255.0)) < 1e-1
+
+
+def test_call_returns_original_image_when_probability_check_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test StainAugmentor class when probability > 0.5."""
+
+    class FakeRNG:
+        """Fake random number generator."""
+
+        def random(self: FakeRNG) -> float:
+            """Fake random mimics np.random.default_rng().random()."""
+            return 0.9
+
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    augmentor = StainAugmentor(p=0.5)
+
+    monkeypatch.setattr(augmentor, "rng", FakeRNG())
+
+    fit_called = False
+
+    def mock_fit(x: np.ndarray) -> None:
+        nonlocal fit_called
+        fit_called = True
+        augmentor._original_img = x
+
+    monkeypatch.setattr(augmentor, "fit", mock_fit)
+
+    result = augmentor(img)
+
+    assert fit_called
+    assert result is img

--- a/tiatoolbox/tools/stainaugment.py
+++ b/tiatoolbox/tools/stainaugment.py
@@ -3,247 +3,176 @@
 from __future__ import annotations
 
 import copy
-from typing import cast
 
 import numpy as np
-from albumentations.core.transforms_interface import ImageOnlyTransform
 
 from tiatoolbox.tools.stainnorm import get_normalizer
 from tiatoolbox.utils.misc import get_luminosity_tissue_mask
 
 
-class StainAugmentor(ImageOnlyTransform):
-    """Stain augmentation using predefined stain matrix or stain extraction methods.
+class StainAugmentor:
+    """Stain augmentation using predefined stain matrices or stain extraction methods.
 
-    This stain augmentation class can be used in 'albumentations'
-    augmentation pipelines as well as stand alone. There is an option to
-    use predefined `stain_matrix` in the input which enables the
-    `StainAugmentor` to generate augmented images faster or do stain
-    normalization to a specific target `stain_matrix`. Having stain
-    matrix beforehand, we don't need to do dictionary learning for stain
-    matrix extraction, hence,speed up the stain
-    augmentation/normalization process which makes it more appropriate
-    for one-the-fly stain augmentation/normalization.
+    This class performs stain augmentation on RGB histology images by modifying
+    their stain concentration values. It supports two stain extraction methods:
+    *Vahadane* and *Macenko*. The augmentation can operate either by extracting a
+    stain matrix from the input image or by using a user-provided stain matrix.
+
+    Providing a pre-extracted `stain_matrix` allows faster augmentation and enables
+    the augmentor to behave like a stain normalizer when the augmentation parameters
+    (`sigma1`, `sigma2`) are set to zero. This avoids the need for dictionary
+    learning during stain matrix extraction and is suitable for efficient
+    on-the-fly stain augmentation or normalization.
 
     Args:
         method (str):
-            The method to use for stain matrix and stain concentration
-            extraction. Can be either "vahadane" (default) or "macenko".
-        stain_matrix (:class:`numpy.ndarray`):
-            Pre-extracted stain matrix of a target image. This can be
-            used for both on-the-fly stain normalization and faster
-            stain augmentation. User can use tools in
-            `tiatoolbox.tools.stainextract` to extract this information.
-            If None (default), the stain matrix will be automatically
-            extracted using the method specified by user.
+            Stain extraction method to use. Supported values are `"vahadane"`
+            (default) and `"macenko"`.
+        stain_matrix (numpy.ndarray):
+            Optional pre-extracted stain matrix for a target image. When supplied,
+            the augmentor uses this matrix directly for stain normalization or
+            faster augmentation. If `None`, the stain matrix is extracted from the
+            input image using the selected method.
         sigma1 (float):
-            Controls the extent of the stain concentrations scale
-            parameter (`alpha` belonging to [1-sigma1, 1+sigma1] range).
-            Default is 0.5.
+            Controls the scaling of stain concentrations. The scale factor `alpha`
+            is sampled from the range `[1 - sigma1, 1 + sigma1]`. Default is `0.4`.
         sigma2 (float):
-            Controls the extent of the stain concentrations shift
-            parameter (`beta` belonging to [-sigma2, sigma2] range).
-            Default is 0.25.
+            Controls the additive shift of stain concentrations. The shift `beta`
+            is sampled from the range `[-sigma2, sigma2]`. Default is `0.2`.
         augment_background (bool):
-            Specifies whether to apply stain augmentation on the
-            background or not. Default is False, which indicates that
-            only tissue region will be stain augmented.
-        always_apply (bool):
-            For use with 'albumentations' pipeline. Please refer to
-            albumentations documentations for more information.
+            Whether to apply stain augmentation to background pixels. If `False`
+            (default), augmentation is applied only to tissue regions determined
+            using a luminosity-based tissue mask.
         p (float):
-            For use with 'albumentations' pipeline which specifies the
-            probability of using the augmentation in a 'albumentations'
-            pipeline. . Please refer to albumentations documentations
-            for more information.
+            Probability of applying stain augmentation. If a random draw exceeds
+            `p`, the input image is returned unchanged. This provides a simple way
+            to control how often augmentation occurs during training.
 
     Attributes:
         stain_normalizer:
-            Fitted stain normalization class.
-        stain_matrix (:class:`numpy.ndarray`):
-            extracted stain matrix from the image
-        source_concentrations (:class:`numpy.ndarray`):
-            Extracted stain concentrations from the input image.
+            Internal stain normalization object used for matrix and concentration
+            extraction.
+        stain_matrix (numpy.ndarray):
+            Extracted or user-provided stain matrix.
+        source_concentrations (numpy.ndarray):
+            Stain concentration values extracted from the input image.
         n_stains (int):
-            Number of stain channels in the stain concentrations.
-            Expected to be 2 for H&E stained images.
-        tissue_mask (:class:`numpy.ndarray`):
-            Tissue region mask in the image.
+            Number of stain channels in the concentration matrix. Typically `2`
+            for H&E images.
+        tissue_mask (numpy.ndarray):
+            Boolean mask indicating tissue regions when background augmentation
+            is disabled.
 
     Examples:
-        >>> '''Using the stain augmentor in the 'albumentations' pipeline'''
         >>> from tiatoolbox.tools.stainaugment import StainAugmentor
-        >>> import albumentations as A
-        >>> # Defining an exemplar stain matrix as reference
-        >>> stain_matrix = np.array([[0.91633014, -0.20408072, -0.34451435],
-        ...                [0.17669817, 0.92528011, 0.33561059]])
-        >>> # Define albumentations pipeline
-        >>> aug_pipline = A.Compose([
-        ...                         A.RandomRotate90(),
-        ...                         A.Flip(),
-        ...                         StainAugmentor(stain_matrix=stain_matrix)
-        ...                         ])
-        >>> # apply the albumentations pipeline on an image (RGB numpy unit8 type)
-        >>> img_aug = aug(image=img)['image']
-
-        >>> '''Using the stain augmentor stand alone'''
-        >>> from tiatoolbox.tools.stainaugment import StainAugmentor
-        >>> # Defining an exemplar stain matrix as reference
-        >>> stain_matrix = np.array([[0.91633014, -0.20408072, -0.34451435],
-        ...                [0.17669817, 0.92528011, 0.33561059]])
-        >>> # Instantiate the stain augmentor and fit it on an image
-        >>> stain_augmentor = StainAugmentor(stain_matrix=stain_matrix)
-        >>> stain_augmentor.fit(img)
-        >>> # Now using the fitted `stain_augmentor` in a loop to generate
-        >>> # several augmented instances from the same image.
-        >>> for i in range(10):
-        ...     img_aug = stain_augmentor.augment()
+        >>> import numpy as np
+        >>>
+        >>> stain_matrix = np.array([
+        ...     [0.91633014, -0.20408072, -0.34451435],
+        ...     [0.17669817,  0.92528011,  0.33561059],
+        ... ])
+        >>>
+        >>> augmentor = StainAugmentor(stain_matrix=stain_matrix, p=0.5)
+        >>> augmentor.fit(img)
+        >>> img_aug = augmentor.augment()
 
     """
 
     def __init__(
-        self: StainAugmentor,
+        self,
         method: str = "vahadane",
         stain_matrix: np.ndarray | None = None,
         sigma1: float = 0.4,
         sigma2: float = 0.2,
-        p: float = 0.5,
+        p: float = 1.0,
         *,
         augment_background: bool = False,
-        always_apply: bool = False,
     ) -> None:
-        """Initialize :class:`StainAugmentor`."""
-        super().__init__(always_apply=always_apply, p=p)
-
-        self.augment_background = augment_background
-        self.sigma1 = sigma1
-        self.sigma2 = sigma2
-        self.method = method
-        self.stain_matrix = stain_matrix
-
-        if self.method.lower() not in {"macenko", "vahadane"}:
+        """Initialize StainAugmentor object."""
+        self.method = method.lower()
+        if self.method not in {"macenko", "vahadane"}:
             msg = (
-                f"Unsupported stain extractor method {self.method!r} "
-                f"for StainAugmentor. Choose either 'vahadane' or 'macenko'."
+                f"Unsupported stain extractor method {self.method!r}. "
+                f"Choose either 'vahadane' or 'macenko'."
             )
             raise ValueError(
                 msg,
             )
-        self.stain_normalizer = get_normalizer(self.method.lower())
 
+        self.stain_matrix = stain_matrix
+        self.sigma1 = sigma1
+        self.sigma2 = sigma2
+        self.augment_background = augment_background
+        self.p = p
+
+        self.stain_normalizer = get_normalizer(self.method)
+        self.rng = np.random.default_rng()
+
+        # Populated during fit()
         self.alpha: float
         self.beta: float
         self.img_shape: tuple[int, ...]
         self.tissue_mask: np.ndarray
         self.n_stains: int
         self.source_concentrations: np.ndarray
+        self._original_img: np.ndarray
 
-    def fit(self: StainAugmentor, img: np.ndarray, threshold: float = 0.85) -> None:
-        """Fit function to extract information needed for stain augmentation.
+    def fit(self, img: np.ndarray, threshold: float = 0.85) -> None:
+        """Extract stain matrix and concentrations from the input image."""
+        self._original_img = img  # store original image for probability logic
 
-        The `fit` function uses either 'Macenko' or 'Vahadane' stain
-        extraction methods to extract stain matrix and stain
-        concentrations of the input image to be used in the `augment`
-        function.
-
-        Args:
-            img (:class:`numpy.ndarray`):
-                RGB image in the form of uint8 numpy array.
-            threshold (float):
-                The threshold value used to find tissue mask from the
-                luminosity component of the image. The found
-                `tissue_mask` will be used to filter out background area
-                in stain augmentation process upon user setting
-                `augment_background=False`.
-
-        """
         if self.stain_matrix is None:
             self.stain_normalizer.fit(img)
             self.stain_matrix = self.stain_normalizer.stain_matrix_target
             self.source_concentrations = self.stain_normalizer.target_concentrations
         else:
             self.source_concentrations = self.stain_normalizer.get_concentrations(
-                img,
-                self.stain_matrix,
+                img, self.stain_matrix
             )
+
         self.n_stains = self.source_concentrations.shape[1]
+
         if not self.augment_background:
             self.tissue_mask = get_luminosity_tissue_mask(
-                img,
-                threshold=threshold,
+                img, threshold=threshold
             ).ravel()
+
         self.img_shape = img.shape
 
-    def augment(self: StainAugmentor) -> np.ndarray:
-        """Return an augmented instance based on source stain concentrations.
+    def augment(self) -> np.ndarray:
+        """Generate a stain-augmented image, applied with probability p."""
+        if self.rng.random() > self.p:
+            return self._original_img
 
-        Stain concentrations of the source image are altered (scaled and
-        shifted) based on the random alpha and beta parameters, and then
-        an augmented image is reconstructed from the altered
-        concentrations. All parameters needed for this part are
-        calculated when calling `fit()` function.
-
-        Returns:
-            :class:`numpy.ndarray`:
-                Stain augmented image.
-
-        """
         augmented_concentrations = copy.deepcopy(self.source_concentrations)
+
         for i in range(self.n_stains):
-            self.get_params()
+            self._sample_params()
+
             if self.augment_background:
                 augmented_concentrations[:, i] *= self.alpha
                 augmented_concentrations[:, i] += self.beta
             else:
                 augmented_concentrations[self.tissue_mask, i] *= self.alpha
                 augmented_concentrations[self.tissue_mask, i] += self.beta
-        self.stain_matrix = cast("np.ndarray", self.stain_matrix)
+
+        self.stain_matrix = np.asarray(self.stain_matrix)
+
         img_augmented = 255 * np.exp(
-            -1 * np.dot(augmented_concentrations, self.stain_matrix),
+            -np.dot(augmented_concentrations, self.stain_matrix)
         )
         img_augmented = img_augmented.reshape(self.img_shape)
         img_augmented = np.clip(img_augmented, 0, 255)
+
         return img_augmented.astype(np.uint8)
 
-    def apply(
-        self: StainAugmentor,  # skipcq: PYL-W0613
-        img: np.ndarray,
-        **params: dict,  # noqa: ARG002
-    ) -> np.ndarray:  # alpha=None, beta=None,
-        """Call the `fit` and `augment` functions to generate a stain augmented image.
-
-        Args:
-            img (:class:`numpy.ndarray`):
-                Input RGB image in the form of unit8 numpy array.
-            params (dict):
-                Additional parameters.
-
-        Returns:
-            :class:`numpy.ndarray`:
-                Stain augmented image with the same size and format as
-                the input img.
-
-        """
-        self.fit(img, threshold=0.85)
+    def __call__(self, img: np.ndarray) -> np.ndarray:
+        """Convenience wrapper: fit + augment."""
+        self.fit(img)
         return self.augment()
 
-    def get_params(self: StainAugmentor) -> dict:
-        """Return randomly generated parameters based on input arguments."""
+    def _sample_params(self) -> None:
+        """Generate random alpha/beta parameters."""
         rng = np.random.default_rng()
         self.alpha = rng.uniform(1 - self.sigma1, 1 + self.sigma1)
         self.beta = rng.uniform(-self.sigma2, self.sigma2)
-        return {}
-
-    def get_params_dependent_on_targets(  # skipcq: PYL-R0201
-        self: StainAugmentor,
-        params: dict,  # skipcq: PYL-W0613  # noqa: ARG002
-    ) -> dict:
-        """Does nothing, added to resolve flake 8 error."""
-        return {}
-
-    @staticmethod
-    def get_transform_init_args_names(
-        **kwargs: dict,  # noqa: ARG004
-    ) -> tuple[str, ...]:
-        """Return the argument names for albumentations use."""
-        return "method", "stain_matrix", "sigma1", "sigma2", "augment_background"


### PR DESCRIPTION
- This PR removes `albumentations` Dependencies. 
- `albumentations` is no longer maintained. The alternative `albumentationsx` is under an incompatible license.