### PR TITLE
:bug: Fix padded contours for Visualization

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,6 +46,7 @@ from tiatoolbox.utils.misc import (
     dict_to_store_patch_predictions,
     imread,
     pad_contours,
+    remove_padded_values_in_contours,
 )
 from tiatoolbox.utils.transforms import locsize2bounds
 
@@ -2546,3 +2547,120 @@ def test_create_smart_array_chunks_auto(track_tmp_path: Path) -> None:
 
     # The key assertion: chunks must equal shape_tuple
     assert arr.chunks == shape
+
+
+def test_removes_padded_rows() -> None:
+    """Test removes_padded_rows."""
+    contour = np.array(
+        [
+            [1, 2],
+            [np.iinfo(np.int32).min, np.iinfo(np.int32).min],
+            [3, 4],
+        ],
+        dtype=np.int32,
+    )
+
+    inst_dict = {
+        "inst1": {
+            "contour": contour,
+            "score": 0.9,
+        }
+    }
+
+    result = remove_padded_values_in_contours(inst_dict)
+
+    expected = np.array([[1, 2], [3, 4]], dtype=np.int32)
+
+    np.testing.assert_array_equal(result["inst1"]["contour"], expected)
+    assert result["inst1"]["score"] == 0.9
+
+
+def test_keeps_rows_with_at_least_one_non_padding_value() -> None:
+    """Test with mixed rows to retain padding value."""
+    pad = np.iinfo(np.int16).min
+
+    contour = np.array(
+        [
+            [pad, 5],
+            [pad, pad],
+        ],
+        dtype=np.int16,
+    )
+
+    result = remove_padded_values_in_contours({"inst1": {"contour": contour}})
+
+    expected = np.array([[pad, 5]], dtype=np.int16)
+
+    np.testing.assert_array_equal(
+        result["inst1"]["contour"],
+        expected,
+    )
+
+
+def test_unsigned_integer_contour_is_not_modified() -> None:
+    """Test unsigned integer contour."""
+    contour = np.array([[1, 2], [3, 4]], dtype=np.uint8)
+
+    result = remove_padded_values_in_contours({"inst1": {"contour": contour}})
+
+    np.testing.assert_array_equal(
+        result["inst1"]["contour"],
+        contour,
+    )
+
+
+def test_non_2d_contour_is_not_modified() -> None:
+    """Test non-2d contour."""
+    contour = np.array([1, 2, 3], dtype=np.int32)
+
+    result = remove_padded_values_in_contours({"inst1": {"contour": contour}})
+
+    np.testing.assert_array_equal(
+        result["inst1"]["contour"],
+        contour,
+    )
+
+
+def test_all_padding_rows_removed() -> None:
+    """Tests all padding rows are removed."""
+    pad = np.iinfo(np.int32).min
+
+    contour = np.array(
+        [
+            [pad, pad],
+            [pad, pad],
+        ],
+        dtype=np.int32,
+    )
+
+    result = remove_padded_values_in_contours({"inst1": {"contour": contour}})
+
+    assert result["inst1"]["contour"].shape == (0, 2)
+
+
+def test_returns_new_dict_without_modifying_input() -> None:
+    """Tests the output without modifying input."""
+    pad = np.iinfo(np.int32).min
+
+    contour = np.array(
+        [
+            [1, 2],
+            [pad, pad],
+        ],
+        dtype=np.int32,
+    )
+
+    inst_dict = {"inst1": {"contour": contour}}
+
+    result = remove_padded_values_in_contours(inst_dict)
+
+    assert result is not inst_dict
+
+    # original remains unchanged
+    np.testing.assert_array_equal(
+        inst_dict["inst1"]["contour"],
+        contour,
+    )
+
+    # cleaned result differs
+    assert result["inst1"]["contour"].shape == (1, 2)

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -2131,8 +2131,8 @@ def remove_padded_values_in_contours(inst_dict: dict) -> dict:
             Returns inst_dict with padded values in contours removed.
 
     """
-    for _k, tile_pred in inst_dict.items():
-        contour = tile_pred["contour"]
+    for _k, inst_pred in inst_dict.items():
+        contour = np.asarray(inst_pred["contour"])
         pad_value = np.iinfo(contour.dtype).min
         row_mask = np.any(contour != pad_value, axis=1)
         contour = contour[row_mask]

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -2112,3 +2112,30 @@ def pad_contours(
             for c in contours
         ]
     )
+
+
+def remove_padded_values_in_contours(inst_dict: dict) -> dict:
+    """Removes padded contour values.
+
+    This function removes padded contour values introduced for compatibility
+    with Zarr v3. Zarr v3 does not support "object" dtype which was used as to wrap
+    inhomogenous arrays while saving using Zarr v2. To process contours, the contours
+    are saved as rectangular arrays with padded dtype min values.
+
+    Args:
+        inst_dict (dict):
+            Output of MultiTaskSegmentor Engine.
+
+    Returns:
+        dict:
+            Returns inst_dict with padded values in contours removed.
+
+    """
+    for _k, tile_pred in inst_dict.items():
+        contour = tile_pred["contour"]
+        pad_value = np.iinfo(contour.dtype).min
+        row_mask = np.any(contour != pad_value, axis=1)
+        contour = contour[row_mask]
+        inst_dict[_k]["contour"] = contour
+
+    return inst_dict

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -2118,9 +2118,9 @@ def remove_padded_values_in_contours(inst_dict: dict) -> dict:
     """Removes padded contour values.
 
     This function removes padded contour values introduced for compatibility
-    with Zarr v3. Zarr v3 does not support "object" dtype which was used as to wrap
-    inhomogenous arrays while saving using Zarr v2. To process contours, the contours
-    are saved as rectangular arrays with padded dtype min values.
+    with Zarr v3. Zarr v3 does not support "object" dtype which was used to wrap
+    inhomogeneous arrays while saving using Zarr v2. To process contours, the
+    contours are saved as rectangular arrays with padded dtype min values.
 
     Args:
         inst_dict (dict):
@@ -2128,14 +2128,20 @@ def remove_padded_values_in_contours(inst_dict: dict) -> dict:
 
     Returns:
         dict:
-            Returns inst_dict with padded values in contours removed.
+            Returns a copy of inst_dict with padded values in contours removed.
 
     """
-    for _k, inst_pred in inst_dict.items():
+    cleaned: dict = {}
+    for k, inst_pred in inst_dict.items():
         contour = np.asarray(inst_pred["contour"])
+        # Only attempt padding removal for signed integer contours (the padding
+        # value is expected to be np.iinfo(dtype).min).
+        if contour.ndim != 2 or not np.issubdtype(contour.dtype, np.signedinteger):  # noqa: PLR2004
+            cleaned[k] = {**inst_pred, "contour": contour}
+            continue
         pad_value = np.iinfo(contour.dtype).min
         row_mask = np.any(contour != pad_value, axis=1)
         contour = contour[row_mask]
-        inst_dict[_k]["contour"] = contour
+        cleaned[k] = {**inst_pred, "contour": contour}
 
-    return inst_dict
+    return cleaned

--- a/tiatoolbox/utils/visualization.py
+++ b/tiatoolbox/utils/visualization.py
@@ -16,6 +16,7 @@ from shapely.geometry import Polygon
 
 from tiatoolbox import DuplicateFilter, logger
 from tiatoolbox.enums import GeometryType
+from tiatoolbox.utils.misc import remove_padded_values_in_contours
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable
@@ -567,6 +568,7 @@ def overlay_prediction_contours(
 
     inst_colours_array = inst_colours_array.astype(np.uint8)
 
+    inst_dict = remove_padded_values_in_contours(inst_dict)
     for idx, [_, inst_info] in enumerate(inst_dict.items()):
         inst_contour: np.ndarray = inst_info["contour"]
         if "type" in inst_info and type_colours is not None:


### PR DESCRIPTION
- This commit fixes visualization of contour overlays with padded values.
- padded values were introduced to make the contours rectangular in an effort to make np arrays compatible with zarr v3

<img width="2905" height="1174" alt="image" src="https://github.com/user-attachments/assets/00f06feb-0203-4c34-a8ee-4c8d6b4a880f" />

fixed

<img width="1547" height="736" alt="image" src="https://github.com/user-attachments/assets/a1e351a5-7b50-4543-aeb6-52885d9fb161" />
